### PR TITLE
some ui changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Heavily inspired by [slate](https://randomlabs.ai/blog/slate). Also takes inspir
 Install the latest `edge` build:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sapiosaturn/nac/main/scripts/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/arcee-ai/nac/main/scripts/install.sh | sh
 ```
 
 Pinned version installs are not supported yet.
@@ -57,7 +57,7 @@ Open `http://127.0.0.1:3210/` for the dense session dashboard. `nac-web` exposes
 Uninstall:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/sapiosaturn/nac/main/scripts/uninstall.sh | sh
+curl -fsSL https://raw.githubusercontent.com/arcee-ai/nac/main/scripts/uninstall.sh | sh
 ```
 
 `nac` can run tools inside a Podman sandbox (requires Podman to be installed):

--- a/crates/nac-core/src/skills/discovery.rs
+++ b/crates/nac-core/src/skills/discovery.rs
@@ -44,6 +44,7 @@ pub(super) fn discover_skill_sources(
     }
 
     sources.sort_by_key(|source| source.precedence);
+    sources.dedup_by(|a, b| a.host_root == b.host_root);
     Ok(sources)
 }
 

--- a/crates/nac-core/src/upgrade.rs
+++ b/crates/nac-core/src/upgrade.rs
@@ -4,7 +4,7 @@ use std::process::{Command, Stdio};
 
 use anyhow::{anyhow, Context, Result};
 
-const DEFAULT_REPO: &str = "sapiosaturn/nac";
+const DEFAULT_REPO: &str = "arcee-ai/nac";
 const DEFAULT_BRANCH: &str = "main";
 const RAW_GITHUB_BASE: &str = "https://raw.githubusercontent.com";
 
@@ -173,7 +173,7 @@ mod tests {
 
         assert_eq!(
             script_url("install.sh"),
-            "https://raw.githubusercontent.com/sapiosaturn/nac/main/scripts/install.sh"
+            "https://raw.githubusercontent.com/arcee-ai/nac/main/scripts/install.sh"
         );
 
         unsafe {

--- a/crates/nac-core/src/view.rs
+++ b/crates/nac-core/src/view.rs
@@ -598,8 +598,8 @@ mod tests {
     #[test]
     fn parse_remote_label_handles_ssh() {
         assert_eq!(
-            parse_remote_label("git@github.com:sapiosaturn/nac.git").as_deref(),
-            Some("sapiosaturn/nac")
+            parse_remote_label("git@github.com:arcee-ai/nac.git").as_deref(),
+            Some("arcee-ai/nac")
         );
     }
 

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -1675,3 +1675,26 @@ button.session-card {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
+
+/* --- Tool call event styling --- */
+
+.event-item.event-tool-start {
+  border-left: 3px solid var(--blue);
+}
+
+.event-item.event-tool-finish {
+  border-left: 3px solid #4fd2a8;
+}
+
+.event-item.event-tool-error {
+  border-left: 3px solid #dc767e;
+}
+
+.event-item.event-tool-error .event-body {
+  color: #dc767e;
+}
+
+.event-item.event-tool-start .event-body,
+.event-item.event-tool-finish .event-body {
+  font-family: var(--mono);
+}

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -1678,18 +1678,6 @@ button.session-card {
 
 /* --- Tool call event styling --- */
 
-.event-item.event-tool-start {
-  border-left: 3px solid var(--blue);
-}
-
-.event-item.event-tool-finish {
-  border-left: 3px solid #4fd2a8;
-}
-
-.event-item.event-tool-error {
-  border-left: 3px solid #dc767e;
-}
-
 .event-item.event-tool-error .event-body {
   color: #dc767e;
 }

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -548,10 +548,12 @@ button.session-card {
 
 .sandbox-icon {
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  vertical-align: middle;
+  width: 12px;
+  height: 12px;
+  vertical-align: -0.1em;
   color: var(--amber);
+  stroke-width: 1.5;
+  opacity: 0.7;
 }
 
 .telemetry-grid {

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -12,7 +12,7 @@
   --faint: #76767e;
   --highlight: rgba(255, 255, 255, 0.84);
   --teal: #4fd2a8;
-  --amber: #bdbdc2;
+  --amber: #e8a838;
   --rose: #d0d0d4;
   --blue: #6ea8ff;
   --green: #8a8a90;
@@ -551,9 +551,21 @@ button.session-card {
   width: 12px;
   height: 12px;
   vertical-align: -0.1em;
-  color: var(--amber);
+  color: var(--text);
   stroke-width: 1.5;
-  opacity: 0.7;
+  opacity: 0.8;
+  filter: drop-shadow(0 0 3px var(--text));
+}
+
+.ssh-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  vertical-align: -0.1em;
+  color: var(--text);
+  stroke-width: 1.5;
+  opacity: 0.8;
+  filter: drop-shadow(0 0 3px var(--text));
 }
 
 .telemetry-grid {
@@ -897,7 +909,7 @@ button.session-card {
   border: 1px solid rgba(255, 255, 255, 0.075);
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.055);
-  color: var(--amber);
+  color: var(--code-amber);
   padding: 0 3px;
   white-space: break-spaces;
   word-break: break-word;

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -548,12 +548,10 @@ button.session-card {
 
 .sandbox-icon {
   display: inline-block;
-  width: 10px;
-  height: 10px;
-  background: var(--amber);
-  border-radius: 2px;
-  margin-right: var(--space-xs);
+  width: 14px;
+  height: 14px;
   vertical-align: middle;
+  color: var(--amber);
 }
 
 .telemetry-grid {

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -513,26 +513,47 @@ button.session-card {
   white-space: nowrap;
 }
 
-.badge-row {
-  display: flex;
-  flex-wrap: wrap;
+.meta-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--space-sm);
   margin-top: var(--space-sm);
 }
 
-.badge {
-  border-radius: var(--radius-pill);
-  color: #c6c6ca;
-  font-family: var(--mono);
-  font-size: var(--type-meta);
-  padding: var(--space-2xs) var(--space-sm);
+.meta-grid div {
+  min-width: 0;
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
   background: var(--bg-sunken);
   box-shadow: var(--neu-sunken-soft);
 }
 
-.badge.sandbox {
-  border-color: rgba(255, 255, 255, 0.34);
-  color: var(--amber);
+.meta-grid span {
+  display: block;
+  color: var(--faint);
+  font-family: var(--mono);
+  font-size: var(--type-label);
+  text-transform: uppercase;
+}
+
+.meta-grid strong {
+  display: block;
+  overflow: hidden;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sandbox-icon {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  background: var(--amber);
+  border-radius: 2px;
+  margin-right: var(--space-xs);
+  vertical-align: middle;
 }
 
 .telemetry-grid {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -892,7 +892,7 @@ function renderSessionCard(card) {
     <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""}" data-session-id="${escapeAttr(card.sessionId)}">
       <div class="session-card-head">
         <div>
-          <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect></svg>` : ""}</h2>
+          <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}</h2>
           <div class="cwd">${escapeHtml(card.cwd)}</div>
         </div>
         <span class="status-dot ${card.statusClass}"></span>

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -892,7 +892,7 @@ function renderSessionCard(card) {
     <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""}" data-session-id="${escapeAttr(card.sessionId)}">
       <div class="session-card-head">
         <div>
-          <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}</h2>
+          <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}${card.sshHost ? ` <svg class="icon ssh-icon" viewBox="0 0 24 24" aria-hidden="true" title="ssh: ${escapeAttr(card.sshHost)}"><rect x="4" y="5" width="16" height="14" rx="2"></rect><path d="M7 10l3 2-3 2"></path><path d="M13 14h4"></path></svg>` : ""}</h2>
           <div class="cwd">${escapeHtml(card.cwd)}</div>
         </div>
         <span class="status-dot ${card.statusClass}"></span>

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -1655,15 +1655,26 @@ function renderEvents() {
     return;
   }
 
-  el.eventLog.innerHTML = events.slice(0, 160).map((envelope) => `
-    <div class="event-item">
+  el.eventLog.innerHTML = events.slice(0, 160).map((envelope) => {
+    const kind = eventKind(envelope);
+    const detail = eventDetail(envelope);
+    const classes = ["event-item"];
+    if (kind === "tool_call_started") classes.push("event-tool-start");
+    if (kind === "tool_call_finished") {
+      classes.push("event-tool-finish");
+      const inner = envelope.event?.event || {};
+      if (inner.is_error) classes.push("event-tool-error");
+    }
+    return `
+    <div class="${classes.join(" ")}">
       <div class="event-meta">
-        <span class="event-kind">${escapeHtml(eventKind(envelope))}</span>
+        <span class="event-kind">${escapeHtml(kind)}</span>
         <span>${envelope.sequence_id ? `#${envelope.sequence_id}` : "local"}</span>
       </div>
-      <div class="event-body">${escapeHtml(eventDetail(envelope))}</div>
+      <div class="event-body">${escapeHtml(detail)}</div>
     </div>
-  `).join("");
+  `;
+  }).join("");
 }
 
 function renderThreads(snapshot) {
@@ -2377,6 +2388,14 @@ function eventDetail(envelope) {
   if (envelope.local) return event.detail || "";
   if (event.type === "agent") {
     const inner = event.event || {};
+    if (inner.type === "tool_call_started") {
+      const args = inner.args_preview || (inner.args_detail ? inner.args_detail.slice(0, 200) : "");
+      return `${inner.name || "tool"}(${args})`;
+    }
+    if (inner.type === "tool_call_finished") {
+      const prefix = inner.is_error ? "ERROR " : "";
+      return `${prefix}${inner.name || "tool"}: ${inner.content_preview || ""}`;
+    }
     return inner.message || inner.line || inner.content || inner.name || inner.prompt_preview || JSON.stringify(inner);
   }
   return event.response || event.message || event.prompt_preview || event.session_id || JSON.stringify(event);
@@ -2465,7 +2484,12 @@ function formatWorkspaceDiffTotals(totals) {
 
 function formatToolCalls(toolCalls) {
   if (!toolCalls || toolCalls.length === 0) return "";
-  return toolCalls.map((call) => `${call.function?.name || "tool"} ${call.id}`).join("\n");
+  return toolCalls.map((call) => {
+    const name = call.function?.name || "tool";
+    const args = call.function?.arguments || "";
+    const preview = args.length > 100 ? args.slice(0, 97) + "..." : args;
+    return `${name}(${preview}) [${call.id}]`;
+  }).join("\n");
 }
 
 function messageText(message) {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -365,6 +365,7 @@ function sessionCardRenderDigest(card) {
     card.shortId,
     card.cwd,
     card.backend,
+    card.model,
     card.sshHost,
     card.sandboxed ? "1" : "0",
     card.selected ? "1" : "0",
@@ -891,15 +892,14 @@ function renderSessionCard(card) {
     <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""}" data-session-id="${escapeAttr(card.sessionId)}">
       <div class="session-card-head">
         <div>
-          <h2>${escapeHtml(card.shortId)}</h2>
+          <h2>${card.sandboxed ? `<span class="sandbox-icon" title="sandbox active"></span>` : ""}${escapeHtml(card.shortId)}</h2>
           <div class="cwd">${escapeHtml(card.cwd)}</div>
         </div>
         <span class="status-dot ${card.statusClass}"></span>
       </div>
-      <div class="badge-row">
-        <span class="badge">${escapeHtml(card.backend)}</span>
-        ${card.sshHost ? `<span class="badge host">${escapeHtml(card.sshHost)}</span>` : ""}
-        ${card.sandboxed ? `<span class="badge sandbox">sandbox</span>` : ""}
+      <div class="meta-grid">
+        <div><span>model</span><strong>${escapeHtml(card.model)}</strong></div>
+        <div><span>backend</span><strong>${escapeHtml(card.backend)}</strong></div>
       </div>
       <div class="telemetry-grid">
         <div><span>msgs</span><strong>${card.messageCount}</strong></div>

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -892,7 +892,7 @@ function renderSessionCard(card) {
     <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""}" data-session-id="${escapeAttr(card.sessionId)}">
       <div class="session-card-head">
         <div>
-          <h2>${card.sandboxed ? `<span class="sandbox-icon" title="sandbox active"></span>` : ""}${escapeHtml(card.shortId)}</h2>
+          <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect></svg>` : ""}</h2>
           <div class="cwd">${escapeHtml(card.cwd)}</div>
         </div>
         <span class="status-dot ${card.statusClass}"></span>

--- a/crates/nac-tui/src/tui/mod.rs
+++ b/crates/nac-tui/src/tui/mod.rs
@@ -1716,8 +1716,8 @@ mod tests {
     #[test]
     fn parse_remote_label_handles_ssh() {
         assert_eq!(
-            core_view::parse_remote_label("git@github.com:sapiosaturn/nac.git").as_deref(),
-            Some("sapiosaturn/nac")
+            core_view::parse_remote_label("git@github.com:arcee-ai/nac.git").as_deref(),
+            Some("arcee-ai/nac")
         );
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-REPO="${NAC_REPO:-sapiosaturn/nac}"
+REPO="${NAC_REPO:-arcee-ai/nac}"
 CHANNEL="${NAC_CHANNEL:-edge}"
 BASE_URL="${NAC_BASE_URL:-https://github.com/${REPO}/releases/download}"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly documentation, install defaults, and frontend presentation; the skill-source dedup is a small behavioral fix with low blast radius.
> 
> **Overview**
> Repoints the default GitHub org/repo from **sapiosaturn/nac** to **arcee-ai/nac** in install/uninstall URLs, `nac upgrade` script fetching, and related tests/docs.
> 
> On the web dashboard, **session cards** swap backend/SSH/sandbox badges for a **model + backend** meta grid, move sandbox/SSH to inline title icons, and include **model** in the card render digest. **Event log** and chat tool-call text now show richer tool start/finish lines (args preview, error styling). **CSS** restores amber accent, adds tool-event classes, and a two-column session grid on small viewports.
> 
> **Skills discovery** deduplicates skill sources that share the same `host_root` after precedence sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fad56022e957421549436e9e35d4c7906c42399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->