### PR TITLE
bunch of features to increase usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ podman machine init
 podman machine start
 ```
 
+`nac` also supports a smolvm sandbox backend — a lightweight microVM that provides hardware-level VM isolation instead of container namespace isolation. It requires `smolvm` to be installed.
+
+Select it with `--sandbox-backend smolvm`, or set `backend = "smolvm"` under `[sandbox]` in config:
+
+```sh
+nac --sandbox --sandbox-backend smolvm
+```
+
+smolvm uses the same default OCI image (`python:3.13-bookworm`) and the same mount flags as Podman. Network is always enabled for smolvm VMs. On macOS, smolvm runs natively via the Hypervisor.framework — no separate machine init step is needed.
+
 ## Recommended config
 
 Optional config lives at `~/.config/nac/config.toml`, or at `$NAC_HOME/config.toml` when `NAC_HOME` is set. Explicit CLI args and environment variables override TOML defaults. Resumed sessions continue using the model and sandbox settings stored in their session snapshot.

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinSet;
 
 use crate::events::{AgentEvent, EventSink};
 use crate::mcp::McpRegistry;
-use crate::model::ModelClient;
+use crate::model::{ModelClient, TokenUsage};
 use crate::sandbox::SandboxSession;
 use crate::skills::SkillRegistry;
 use crate::tools::{self, ToolResult, ToolRuntime};
@@ -60,6 +60,9 @@ pub struct Agent {
     tool_runtime: ToolRuntime,
     event_sink: EventSink,
     thread_name: Option<String>,
+    /// Token usage from the most recent `send()` call; `None` until the
+    /// final `AssistantMessage` is emitted or if the provider omitted usage.
+    pub last_usage: Option<crate::model::TokenUsage>,
 }
 
 fn append_to_initial_system_message(messages: &mut [Message], extra: &str) {
@@ -249,9 +252,11 @@ impl Agent {
                 skills: config.skills,
                 terminal_manager: crate::terminal::TerminalManager::new(),
                 thread_timeout_secs: config.thread_timeout_secs,
+                worker_usage: Arc::new(Mutex::new(TokenUsage::default())),
             },
             event_sink: config.event_sink,
             thread_name: config.thread_name,
+            last_usage: None,
         })
     }
 
@@ -309,6 +314,7 @@ impl Agent {
         }
 
         let mut iteration = 0usize;
+        let mut accumulated_usage = TokenUsage::default();
         loop {
             iteration = iteration.saturating_add(1);
             self.emit(AgentEvent::ModelCallStarted {
@@ -331,6 +337,13 @@ impl Agent {
                     return Err(error);
                 }
             };
+            if let Some(usage) = &response.usage {
+                accumulated_usage += usage.clone();
+                // total_tokens is the current context length, not a sum.
+                // Overwrite with the last call's total so it reflects the
+                // live context window size after the most recent model call.
+                accumulated_usage.total_tokens = usage.total_tokens;
+            }
             if response.finish_reason.as_deref() == Some("length") {
                 let error = anyhow!(
                     "Context window full (finish_reason=length). nac does not auto-compact thread history right now; retry with a narrower prompt, a fresh thread, or less carried context."
@@ -365,7 +378,9 @@ impl Agent {
                 self.emit(AgentEvent::AssistantMessage {
                     thread_name: self.thread_name.clone(),
                     content: content.clone(),
+                    usage: Some(accumulated_usage.clone()),
                 });
+                self.last_usage = Some(accumulated_usage.clone());
                 self.emit(AgentEvent::RunFinished {
                     thread_name: self.thread_name.clone(),
                 });
@@ -382,6 +397,19 @@ impl Agent {
                 self.thread_name.clone(),
             )
             .await;
+
+            // Fold worker token usage (from thread dispatches) into the
+            // orchestrator's accumulated usage.  Only cost fields are summed;
+            // total_tokens (context length) stays orchestrator-only.
+            {
+                let mut wu = self.tool_runtime.worker_usage.lock().await;
+                accumulated_usage.input_tokens += wu.input_tokens;
+                accumulated_usage.output_tokens += wu.output_tokens;
+                accumulated_usage.cache_read_tokens += wu.cache_read_tokens;
+                accumulated_usage.cache_write_tokens += wu.cache_write_tokens;
+                *wu = TokenUsage::default();
+            }
+
             for (tool_call_id, _tool_name, result) in results {
                 self.messages.push(Message::Tool {
                     tool_call_id,

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -295,6 +295,16 @@ impl Agent {
         self.tool_runtime.backend.ensure_ready().await
     }
 
+    /// Returns a clone of the sandbox session if the execution backend is
+    /// a sandbox, or `None` for local/SSH backends.  The clone is cheap
+    /// (inner data is behind `Arc`).
+    pub fn sandbox_session(&self) -> Option<SandboxSession> {
+        match self.tool_runtime.backend.as_ref() {
+            crate::sandbox::ExecutionBackend::Sandbox(session) => Some(session.clone()),
+            _ => None,
+        }
+    }
+
     pub async fn send(&mut self, prompt: &str) -> Result<String> {
         self.emit(AgentEvent::RunStarted {
             thread_name: self.thread_name.clone(),

--- a/crates/nac-core/src/events.rs
+++ b/crates/nac-core/src/events.rs
@@ -131,10 +131,14 @@ pub enum AgentEvent {
         timed_out: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout_reason: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<crate::model::TokenUsage>,
     },
     AssistantMessage {
         thread_name: Option<String>,
         content: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<crate::model::TokenUsage>,
     },
     Error {
         thread_name: Option<String>,

--- a/crates/nac-core/src/lib.rs
+++ b/crates/nac-core/src/lib.rs
@@ -12,7 +12,7 @@ mod process;
 pub mod runtime;
 mod sandbox;
 pub mod session_service;
-mod sessions;
+pub mod sessions;
 mod skills;
 mod store;
 mod terminal;

--- a/crates/nac-core/src/model/anthropic.rs
+++ b/crates/nac-core/src/model/anthropic.rs
@@ -252,6 +252,26 @@ pub(super) fn parse_anthropic_messages_response(
             }
         });
 
+    let usage = value.get("usage").map(|u| {
+        let input_tokens = u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cache_read = u
+            .get("cache_read_input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let cache_write = u
+            .get("cache_creation_input_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let output_tokens = u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        TokenUsage {
+            input_tokens,
+            output_tokens,
+            cache_read_tokens: cache_read,
+            cache_write_tokens: cache_write,
+            total_tokens: input_tokens + output_tokens + cache_read + cache_write,
+        }
+    });
+
     Ok(ModelTurnResponse {
         assistant: AssistantTurn {
             content,
@@ -264,5 +284,6 @@ pub(super) fn parse_anthropic_messages_response(
             },
         },
         finish_reason,
+        usage,
     })
 }

--- a/crates/nac-core/src/model/anthropic.rs
+++ b/crates/nac-core/src/model/anthropic.rs
@@ -7,12 +7,13 @@ pub(super) fn anthropic_messages_request(
     model: &str,
     messages: &[Message],
     tools: &[ToolDefinition],
+    cache_ttl: Option<&str>,
 ) -> Result<Value> {
-    let (system, messages) = anthropic_messages_from_internal(messages)?;
+    let (system, mut messages) = anthropic_messages_from_internal(messages)?;
     let mut request = json!({
         "model": model,
         "max_tokens": ANTHROPIC_MAX_TOKENS,
-        "messages": messages,
+        "messages": &messages,
         "thinking": {
             "type": "adaptive",
             "display": "omitted",
@@ -22,15 +23,59 @@ pub(super) fn anthropic_messages_request(
         },
     });
 
+    // Breakpoint 1: system prompt (also caches tools, which render before system).
     if let Some(system) = system {
-        request["system"] = Value::String(system);
+        let mut system_block = json!({"type": "text", "text": system});
+        system_block["cache_control"] = cache_control_value(cache_ttl);
+        request["system"] = json!([system_block]);
     }
 
+    // Breakpoint 2: last tool definition.
     if !tools.is_empty() {
-        request["tools"] = Value::Array(tools.iter().map(anthropic_tool_to_value).collect());
+        let mut tools_arr: Vec<Value> = tools.iter().map(anthropic_tool_to_value).collect();
+        if let Some(last_tool) = tools_arr.last_mut() {
+            last_tool["cache_control"] = cache_control_value(cache_ttl);
+        }
+        request["tools"] = Value::Array(tools_arr);
     }
+
+    // Breakpoint 3: last content block of the last message (conversation history).
+    if let Some(last_msg) = messages.last_mut() {
+        add_cache_control_to_last_block(last_msg, cache_ttl);
+    }
+    request["messages"] = Value::Array(messages);
 
     Ok(request)
+}
+
+/// Build the `cache_control` JSON value for the given TTL.
+/// `None` or any non-"1h" value → default 5-minute ephemeral cache.
+fn cache_control_value(ttl: Option<&str>) -> Value {
+    match ttl {
+        Some("1h") => json!({"type": "ephemeral", "ttl": "1h"}),
+        _ => json!({"type": "ephemeral"}),
+    }
+}
+
+/// Add `cache_control` to the last content block of an Anthropic message.
+/// If the message content is a plain string, convert it to a content-block
+/// array first so that `cache_control` can be attached.
+fn add_cache_control_to_last_block(message: &mut Value, ttl: Option<&str>) {
+    let Some(content) = message.get_mut("content") else {
+        return;
+    };
+
+    // If content is a string, convert to a single-element text block array.
+    if let Some(text) = content.as_str().map(|s| s.to_string()) {
+        *content = Value::Array(vec![json!({"type": "text", "text": text})]);
+    }
+
+    let Some(arr) = content.as_array_mut() else {
+        return;
+    };
+    if let Some(last_block) = arr.last_mut() {
+        last_block["cache_control"] = cache_control_value(ttl);
+    }
 }
 
 fn anthropic_messages_from_internal(messages: &[Message]) -> Result<(Option<String>, Vec<Value>)> {

--- a/crates/nac-core/src/model/chat.rs
+++ b/crates/nac-core/src/model/chat.rs
@@ -28,6 +28,25 @@ pub(super) fn parse_chat_completions_response(
         }
     };
 
+    let usage = value.get("usage").map(|u| {
+        let prompt_tokens = u.get("prompt_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cached = u
+            .get("prompt_tokens_details")
+            .and_then(|d| d.get("cached_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        TokenUsage {
+            input_tokens: prompt_tokens.saturating_sub(cached),
+            output_tokens: u
+                .get("completion_tokens")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0),
+            cache_read_tokens: cached,
+            cache_write_tokens: 0,
+            total_tokens: u.get("total_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+        }
+    });
+
     Ok(ModelTurnResponse {
         assistant: AssistantTurn {
             content: message
@@ -45,5 +64,6 @@ pub(super) fn parse_chat_completions_response(
             .get("finish_reason")
             .and_then(Value::as_str)
             .map(ToString::to_string),
+        usage,
     })
 }

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -9,6 +9,7 @@ pub struct ModelClient {
     pub model: String,
     backend: BackendKind,
     reasoning_effort: Option<ReasoningEffort>,
+    api_key_env: Option<String>,
     extra_headers: std::collections::BTreeMap<String, String>,
 }
 
@@ -47,6 +48,7 @@ impl ModelClient {
             model,
             backend,
             reasoning_effort,
+            api_key_env: overrides.api_key_env.clone(),
             extra_headers: overrides.extra_headers,
         })
     }
@@ -86,6 +88,14 @@ impl ModelClient {
 
     pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
         self.reasoning_effort
+    }
+
+    pub fn api_key_env(&self) -> Option<&str> {
+        self.api_key_env.as_deref()
+    }
+
+    pub fn extra_headers(&self) -> &std::collections::BTreeMap<String, String> {
+        &self.extra_headers
     }
 
     async fn send_fireworks_chat(
@@ -291,6 +301,7 @@ impl ModelClient {
             model: "gpt-5.5".to_string(),
             backend: BackendKind::OpenAiResponses,
             reasoning_effort: Some(ReasoningEffort::Xhigh),
+            api_key_env: None,
             extra_headers: std::collections::BTreeMap::new(),
         }
     }

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -11,6 +11,9 @@ pub struct ModelClient {
     reasoning_effort: Option<ReasoningEffort>,
     api_key_env: Option<String>,
     extra_headers: std::collections::BTreeMap<String, String>,
+    /// Anthropic prompt-cache TTL. `None` = default 5-minute TTL (workers);
+    /// `Some("1h")` = 1-hour TTL with beta header (orchestrator).
+    cache_ttl: Option<&'static str>,
 }
 
 impl ModelClient {
@@ -50,7 +53,15 @@ impl ModelClient {
             reasoning_effort,
             api_key_env: overrides.api_key_env.clone(),
             extra_headers: overrides.extra_headers,
+            cache_ttl: None,
         })
+    }
+
+    /// Set the Anthropic prompt-cache TTL. `Some("1h")` enables 1-hour cache
+    /// TTL (requires beta header); `None` uses the default 5-minute TTL.
+    pub fn with_cache_ttl(mut self, ttl: Option<&'static str>) -> Self {
+        self.cache_ttl = ttl;
+        self
     }
 
     pub async fn send_turn(
@@ -180,7 +191,7 @@ impl ModelClient {
         tools: Vec<ToolDefinition>,
     ) -> Result<ModelTurnResponse> {
         let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
-        let request = anthropic_messages_request(&self.model, &messages, &tools)?;
+        let request = anthropic_messages_request(&self.model, &messages, &tools, self.cache_ttl)?;
 
         let value = self.post_anthropic_json_with_retry(&url, &request).await?;
         parse_anthropic_messages_response(&value, &url)
@@ -196,10 +207,15 @@ impl ModelClient {
 
     async fn post_anthropic_json_with_retry(&self, url: &str, body: &Value) -> Result<Value> {
         let api_key = self.api_key.as_str();
+        let cache_ttl = self.cache_ttl;
         self.post_json_with_retry_headers(url, body, |request| {
-            request
+            let mut request = request
                 .header("x-api-key", api_key)
-                .header("anthropic-version", ANTHROPIC_VERSION)
+                .header("anthropic-version", ANTHROPIC_VERSION);
+            if cache_ttl == Some("1h") {
+                request = request.header("anthropic-beta", "extended-cache-ttl-2025-04-11");
+            }
+            request
         })
         .await
     }
@@ -303,6 +319,7 @@ impl ModelClient {
             reasoning_effort: Some(ReasoningEffort::Xhigh),
             api_key_env: None,
             extra_headers: std::collections::BTreeMap::new(),
+            cache_ttl: None,
         }
     }
 }

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -166,6 +166,7 @@ mod tests {
                     }),
                 },
             }],
+            None,
         )
         .unwrap();
 
@@ -174,11 +175,80 @@ mod tests {
         assert_eq!(request["thinking"]["type"], "adaptive");
         assert_eq!(request["thinking"]["display"], "omitted");
         assert_eq!(request["output_config"]["effort"], "max");
-        assert_eq!(request["system"], "system instructions");
-        assert_eq!(request["messages"][0]["role"], "user");
-        assert_eq!(request["messages"][0]["content"], "read a file");
+        // System prompt is now a content-block array with cache_control.
+        assert_eq!(request["system"][0]["type"], "text");
+        assert_eq!(request["system"][0]["text"], "system instructions");
+        assert_eq!(request["system"][0]["cache_control"]["type"], "ephemeral");
+        assert!(request["system"][0]["cache_control"].get("ttl").is_none());
+        // Last tool has cache_control.
         assert_eq!(request["tools"][0]["name"], "read");
         assert_eq!(request["tools"][0]["input_schema"]["type"], "object");
+        assert_eq!(request["tools"][0]["cache_control"]["type"], "ephemeral");
+        // Last message (user) content is converted to array with cache_control.
+        assert_eq!(request["messages"][0]["role"], "user");
+        assert_eq!(request["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(request["messages"][0]["content"][0]["text"], "read a file");
+        assert_eq!(
+            request["messages"][0]["content"][0]["cache_control"]["type"],
+            "ephemeral"
+        );
+    }
+
+    #[test]
+    fn anthropic_request_with_1h_ttl_sets_ttl_on_all_breakpoints() {
+        let request = anthropic_messages_request(
+            "claude-sonnet-4-6",
+            &[
+                Message::System {
+                    content: "system".to_string(),
+                },
+                Message::User {
+                    content: "hello".to_string(),
+                },
+            ],
+            &[ToolDefinition {
+                def_type: "function".to_string(),
+                function: crate::types::FunctionDef {
+                    name: "read".to_string(),
+                    description: "Read".to_string(),
+                    parameters: json!({"type": "object"}),
+                },
+            }],
+            Some("1h"),
+        )
+        .unwrap();
+
+        // System breakpoint has 1h TTL.
+        assert_eq!(request["system"][0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(request["system"][0]["cache_control"]["ttl"], "1h");
+        // Tool breakpoint has 1h TTL.
+        assert_eq!(request["tools"][0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(request["tools"][0]["cache_control"]["ttl"], "1h");
+        // Last message breakpoint has 1h TTL.
+        assert_eq!(
+            request["messages"][0]["content"][0]["cache_control"]["ttl"],
+            "1h"
+        );
+    }
+
+    #[test]
+    fn anthropic_request_with_no_messages_skips_message_breakpoint() {
+        let request = anthropic_messages_request(
+            "claude-sonnet-4-6",
+            &[Message::System {
+                content: "system only".to_string(),
+            }],
+            &[],
+            None,
+        )
+        .unwrap();
+
+        // System breakpoint still set.
+        assert_eq!(request["system"][0]["cache_control"]["type"], "ephemeral");
+        // No tools → no tools key.
+        assert!(request.get("tools").is_none());
+        // No messages → empty array, no crash.
+        assert_eq!(request["messages"].as_array().unwrap().len(), 0);
     }
 
     #[test]
@@ -260,6 +330,7 @@ mod tests {
                 },
             ],
             &[],
+            None,
         )
         .unwrap();
 

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -20,7 +20,7 @@ mod types;
 pub(crate) use backend::detect_backend;
 use chatgpt_codex::{codex_auth_login, codex_auth_logout, codex_auth_status};
 pub(crate) use client::ModelClient;
-pub(crate) use types::{AssistantTurn, ClientOverrides, ModelTurnResponse};
+pub(crate) use types::{AssistantTurn, ClientOverrides, ModelTurnResponse, TokenUsage};
 pub use types::{BackendKind, ReasoningEffort};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -235,6 +235,12 @@ mod tests {
             serde_json::from_str::<Value>(&tool_call.function.arguments).unwrap(),
             json!({"path": "src/main.rs"})
         );
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 20);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens, 30);
 
         let request = anthropic_messages_request(
             "claude-opus-4-6",
@@ -386,6 +392,12 @@ mod tests {
             Some("worked through it")
         );
         assert!(parsed.assistant.tool_calls.is_none());
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 20);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens, 30);
     }
 
     #[test]
@@ -439,5 +451,108 @@ mod tests {
                 .len(),
             1
         );
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 10);
+        assert_eq!(usage.output_tokens, 20);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens, 30);
+    }
+
+    #[test]
+    fn parses_openai_responses_usage_with_cached_tokens() {
+        let parsed = parse_openai_responses_response(
+            &json!({
+                "status": "completed",
+                "output": [
+                    {"type": "message", "content": [{"type": "output_text", "text": "hi"}]}
+                ],
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "total_tokens": 150,
+                    "input_tokens_details": {"cached_tokens": 80},
+                    "output_tokens_details": {"reasoning_tokens": 10}
+                }
+            }),
+            "https://api.openai.com/v1/responses",
+        )
+        .unwrap();
+
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 20);   // 100 - 80 cached
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 80);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn parses_anthropic_usage_with_cache_fields() {
+        let parsed = parse_anthropic_messages_response(
+            &json!({
+                "content": [{"type": "text", "text": "done"}],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_read_input_tokens": 200,
+                    "cache_creation_input_tokens": 30
+                }
+            }),
+            "https://api.anthropic.com/v1/messages",
+        )
+        .unwrap();
+
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 200);
+        assert_eq!(usage.cache_write_tokens, 30);
+        assert_eq!(usage.total_tokens, 380);  // 100 + 50 + 200 + 30
+    }
+
+    #[test]
+    fn parses_chat_completions_usage_with_cached_tokens() {
+        let parsed = parse_chat_completions_response(
+            &json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "message": {"content": "done", "tool_calls": null}
+                }],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                    "prompt_tokens_details": {"cached_tokens": 60},
+                    "completion_tokens_details": {"reasoning_tokens": 5}
+                }
+            }),
+            "https://api.deepseek.com/chat/completions",
+        )
+        .unwrap();
+
+        let usage = parsed.usage.expect("usage should be parsed");
+        assert_eq!(usage.input_tokens, 40);   // 100 - 60 cached
+        assert_eq!(usage.output_tokens, 50);
+        assert_eq!(usage.cache_read_tokens, 60);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn response_without_usage_yields_none() {
+        let parsed = parse_openai_responses_response(
+            &json!({
+                "status": "completed",
+                "output": [
+                    {"type": "message", "content": [{"type": "output_text", "text": "hi"}]}
+                ]
+            }),
+            "https://api.openai.com/v1/responses",
+        )
+        .unwrap();
+
+        assert!(parsed.usage.is_none());
     }
 }

--- a/crates/nac-core/src/model/responses.rs
+++ b/crates/nac-core/src/model/responses.rs
@@ -91,6 +91,22 @@ pub(super) fn parse_openai_responses_response(
         None
     };
 
+    let usage = value.get("usage").map(|u| {
+        let input_tokens = u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
+        let cached = u
+            .get("input_tokens_details")
+            .and_then(|d| d.get("cached_tokens"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        TokenUsage {
+            input_tokens: input_tokens.saturating_sub(cached),
+            output_tokens: u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+            cache_read_tokens: cached,
+            cache_write_tokens: 0,
+            total_tokens: u.get("total_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+        }
+    });
+
     Ok(ModelTurnResponse {
         assistant: AssistantTurn {
             content,
@@ -103,6 +119,7 @@ pub(super) fn parse_openai_responses_response(
             },
         },
         finish_reason,
+        usage,
     })
 }
 

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -70,8 +70,28 @@ pub struct AssistantTurn {
     pub tool_calls: Option<Vec<ToolCall>>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TokenUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+    pub total_tokens: u64,
+}
+
+impl std::ops::AddAssign for TokenUsage {
+    fn add_assign(&mut self, other: Self) {
+        self.input_tokens += other.input_tokens;
+        self.output_tokens += other.output_tokens;
+        self.cache_read_tokens += other.cache_read_tokens;
+        self.cache_write_tokens += other.cache_write_tokens;
+        self.total_tokens += other.total_tokens;
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ModelTurnResponse {
     pub assistant: AssistantTurn,
     pub finish_reason: Option<String>,
+    pub usage: Option<TokenUsage>,
 }

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -1089,6 +1089,47 @@ mod tests {
     }
 
     #[test]
+    fn parse_extra_headers_json_handles_empty_object() {
+        // Empty string → None (no override)
+        assert_eq!(parse_extra_headers_json(""), None);
+        // "{}" → Some(empty map) so the worker uses empty headers, not config fallback
+        assert_eq!(parse_extra_headers_json("{}"), Some(BTreeMap::new()));
+        // Valid headers → Some(map)
+        let mut headers = BTreeMap::new();
+        headers.insert("X-Custom".to_string(), "val".to_string());
+        assert_eq!(
+            parse_extra_headers_json(r#"{"X-Custom":"val"}"#),
+            Some(headers)
+        );
+        // Invalid JSON → None
+        assert_eq!(parse_extra_headers_json("not json"), None);
+    }
+
+    #[test]
+    fn model_overrides_empty_extra_headers_does_not_leak_config() {
+        // When the CLI passes Some(empty map), config's extra_headers must NOT leak.
+        let mut config = NacConfig::default();
+        config
+            .model
+            .extra_headers
+            .insert("X-Config-Leak".to_string(), "should-not-appear".to_string());
+
+        let overrides = model_overrides(
+            &ModelOptions {
+                backend: None,
+                reasoning_effort: None,
+                api_base_url: None,
+                api_model: None,
+                api_key_env: None,
+                extra_headers: Some(BTreeMap::new()),
+            },
+            &config,
+        )
+        .unwrap();
+        assert!(overrides.extra_headers.is_empty());
+    }
+
+    #[test]
     fn sandbox_image_config_is_default_not_enablement() {
         let mut config = NacConfig::default();
         config.sandbox.image = Some("custom-image".to_string());

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -54,6 +54,8 @@ pub struct ModelConfig {
 pub struct SandboxConfig {
     pub image: Option<String>,
     pub backend: Option<String>,
+    pub cpus: Option<u8>,
+    pub memory_mib: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
@@ -119,6 +121,8 @@ pub struct SandboxOptions {
     pub sandbox_session_key: Option<String>,
     pub sandbox_workdir: Option<String>,
     pub sandbox_backend: Option<String>,
+    pub sandbox_cpus: Option<u8>,
+    pub sandbox_mem: Option<u32>,
 }
 
 impl SandboxOptions {
@@ -132,6 +136,8 @@ impl SandboxOptions {
             || !self.sandbox_gpus.is_empty()
             || self.sandbox_shm_size.is_some()
             || self.sandbox_backend.is_some()
+            || self.sandbox_cpus.is_some()
+            || self.sandbox_mem.is_some()
     }
 }
 
@@ -191,6 +197,8 @@ pub struct EffectiveSandboxOptions {
     pub sandbox_session_key: Option<String>,
     pub sandbox_workdir: Option<String>,
     pub sandbox_backend: crate::sandbox::SandboxBackendType,
+    pub sandbox_cpus: u8,
+    pub sandbox_mem: u32,
     pub explicit_sandbox_config_flags_present: bool,
 }
 
@@ -278,6 +286,14 @@ pub(crate) fn effective_sandbox_options(
         .or(config.sandbox.backend.as_deref())
         .map(|s| SandboxBackendType::from_str(s).unwrap_or_default())
         .unwrap_or_default();
+    let sandbox_cpus = options
+        .sandbox_cpus
+        .or(config.sandbox.cpus)
+        .unwrap_or(2);
+    let sandbox_mem = options
+        .sandbox_mem
+        .or(config.sandbox.memory_mib)
+        .unwrap_or(2048);
     EffectiveSandboxOptions {
         sandbox: options.sandbox,
         no_mount_cwd: options.no_mount_cwd,
@@ -291,6 +307,8 @@ pub(crate) fn effective_sandbox_options(
         sandbox_session_key: options.sandbox_session_key,
         sandbox_workdir: options.sandbox_workdir,
         sandbox_backend,
+        sandbox_cpus,
+        sandbox_mem,
         explicit_sandbox_config_flags_present,
     }
 }
@@ -943,6 +961,8 @@ pub async fn build_sandbox_session(
                 .clone()
                 .unwrap_or_else(|| "0".to_string()),
         ),
+        options.sandbox_cpus,
+        options.sandbox_mem,
     )?;
     let owner = options.sandbox_session_key.is_none();
     let session_key = options
@@ -1675,6 +1695,8 @@ url = "https://mcp.context7.com/mcp"
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: Vec::new(),
                 shm_size: None,
+                cpus: 2,
+                memory_mib: 2048,
             }),
             Some("build-box".to_string()),
             Vec::new(),

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -102,6 +102,8 @@ pub struct ModelOptions {
     pub reasoning_effort: Option<ReasoningEffort>,
     pub api_base_url: Option<String>,
     pub api_model: Option<String>,
+    pub api_key_env: Option<String>,
+    pub extra_headers: Option<BTreeMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -331,9 +333,24 @@ pub(crate) fn model_overrides(model: &ModelOptions, config: &NacConfig) -> Resul
             .or_else(|| config.model.model.clone()),
         backend: model.backend.or(config.model.backend),
         reasoning_effort: model.reasoning_effort.or(config.model.reasoning_effort),
-        api_key_env: configured_api_key_env(config),
-        extra_headers: config.model.extra_headers.clone(),
+        api_key_env: model
+            .api_key_env
+            .clone()
+            .or_else(|| configured_api_key_env(config)),
+        extra_headers: model
+            .extra_headers
+            .clone()
+            .unwrap_or_else(|| config.model.extra_headers.clone()),
     })
+}
+
+/// Parse a JSON object string into a `BTreeMap<String, String>`.
+/// Returns `None` for empty or invalid input.
+pub fn parse_extra_headers_json(json: &str) -> Option<BTreeMap<String, String>> {
+    if json.is_empty() {
+        return None;
+    }
+    serde_json::from_str::<BTreeMap<String, String>>(json).ok()
 }
 
 pub(crate) fn worker_thread_timeout_secs(config: &NacConfig) -> u64 {
@@ -1032,6 +1049,8 @@ mod tests {
                 reasoning_effort: Some(ReasoningEffort::Low),
                 api_base_url: Some("https://cli.example/v1".to_string()),
                 api_model: Some("cli-model".to_string()),
+                api_key_env: None,
+                extra_headers: None,
             },
             &config,
         )
@@ -1043,6 +1062,27 @@ mod tests {
         assert_eq!(cli_overrides.model.as_deref(), Some("cli-model"));
         assert_eq!(cli_overrides.backend, Some(BackendKind::DeepSeekChat));
         assert_eq!(cli_overrides.reasoning_effort, Some(ReasoningEffort::Low));
+
+        // CLI-provided api_key_env and extra_headers should override config values.
+        let mut cli_extra = std::collections::BTreeMap::new();
+        cli_extra.insert("X-Custom".to_string(), "cli-value".to_string());
+        let cli_full_overrides = model_overrides(
+            &ModelOptions {
+                backend: Some(BackendKind::DeepSeekChat),
+                reasoning_effort: Some(ReasoningEffort::Low),
+                api_base_url: Some("https://cli.example/v1".to_string()),
+                api_model: Some("cli-model".to_string()),
+                api_key_env: Some("CLI_KEY_ENV".to_string()),
+                extra_headers: Some(cli_extra.clone()),
+            },
+            &config,
+        )
+        .unwrap();
+        assert_eq!(
+            cli_full_overrides.api_key_env.as_deref(),
+            Some("CLI_KEY_ENV")
+        );
+        assert_eq!(cli_full_overrides.extra_headers, cli_extra);
 
         restore_env("OPENAI_BASE_URL", original_base_url);
         restore_env("OPENAI_MODEL", original_model);

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -13,8 +13,8 @@ use crate::mcp::{McpRegistry, McpRootPolicy, McpTransportPolicy};
 use crate::model::{BackendKind, ClientOverrides, ModelClient, ReasoningEffort};
 use crate::paths::PathContext;
 use crate::sandbox::{
-    build_sandbox_spec, parse_mount_spec, MountSpec, SandboxSession, DEFAULT_SANDBOX_IMAGE,
-    DEFAULT_SANDBOX_WORKDIR,
+    build_sandbox_spec, parse_mount_spec, MountSpec, SandboxBackendType, SandboxSession,
+    DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_WORKDIR,
 };
 use crate::sessions::{self, SessionSnapshot};
 use crate::skills::{self, SkillRegistry};
@@ -53,6 +53,7 @@ pub struct ModelConfig {
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct SandboxConfig {
     pub image: Option<String>,
+    pub backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, serde::Deserialize)]
@@ -117,6 +118,7 @@ pub struct SandboxOptions {
     pub sandbox_shm_size: Option<String>,
     pub sandbox_session_key: Option<String>,
     pub sandbox_workdir: Option<String>,
+    pub sandbox_backend: Option<String>,
 }
 
 impl SandboxOptions {
@@ -129,6 +131,7 @@ impl SandboxOptions {
             || self.sandbox_image.is_some()
             || !self.sandbox_gpus.is_empty()
             || self.sandbox_shm_size.is_some()
+            || self.sandbox_backend.is_some()
     }
 }
 
@@ -187,6 +190,7 @@ pub struct EffectiveSandboxOptions {
     pub sandbox_shm_size: Option<String>,
     pub sandbox_session_key: Option<String>,
     pub sandbox_workdir: Option<String>,
+    pub sandbox_backend: crate::sandbox::SandboxBackendType,
     pub explicit_sandbox_config_flags_present: bool,
 }
 
@@ -268,6 +272,12 @@ pub(crate) fn effective_sandbox_options(
     config: &NacConfig,
 ) -> EffectiveSandboxOptions {
     let explicit_sandbox_config_flags_present = options.explicit_sandbox_config_flags_present();
+    let sandbox_backend = options
+        .sandbox_backend
+        .as_deref()
+        .or(config.sandbox.backend.as_deref())
+        .map(|s| SandboxBackendType::from_str(s).unwrap_or_default())
+        .unwrap_or_default();
     EffectiveSandboxOptions {
         sandbox: options.sandbox,
         no_mount_cwd: options.no_mount_cwd,
@@ -280,6 +290,7 @@ pub(crate) fn effective_sandbox_options(
         sandbox_shm_size: options.sandbox_shm_size,
         sandbox_session_key: options.sandbox_session_key,
         sandbox_workdir: options.sandbox_workdir,
+        sandbox_backend,
         explicit_sandbox_config_flags_present,
     }
 }
@@ -293,7 +304,7 @@ fn validate_target_sandbox_options(
         && (options.sandbox_enabled() || options.explicit_sandbox_config_flags_present())
     {
         anyhow::bail!(
-            "invalid remote {remote_label}: ssh_host and podman sandbox options cannot both be set"
+            "invalid remote {remote_label}: ssh_host and sandbox options cannot both be set"
         );
     }
     validate_sandbox_options(options)
@@ -913,6 +924,7 @@ pub async fn build_sandbox_session(
     )?);
 
     let spec = build_sandbox_spec(
+        options.sandbox_backend,
         options
             .sandbox_image
             .as_deref()
@@ -1657,6 +1669,7 @@ url = "https://mcp.context7.com/mcp"
             BackendKind::OpenAiResponses,
             None,
             Some(SandboxSpec {
+                backend: crate::sandbox::SandboxBackendType::Podman,
                 image: DEFAULT_SANDBOX_IMAGE.to_string(),
                 mounts: Vec::new(),
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -375,7 +375,8 @@ pub async fn build_run_config(
         .config_cwd
         .clone()
         .unwrap_or_else(|| default_config_cwd(&options.workspace_cwd, ssh_host.as_deref()));
-    let client = ModelClient::from_env_with_overrides(model_overrides(&options.model, config)?)?;
+    let overrides = model_overrides(&options.model, config)?;
+    let client = ModelClient::from_env_with_overrides(overrides.clone())?;
     let sandbox_options = effective_sandbox_options(options.sandbox, config);
     validate_target_sandbox_options(ssh_host.as_deref(), &sandbox_options, "session")?;
     let store_base_cwd = if ssh_host.is_some() {
@@ -422,6 +423,8 @@ pub async fn build_run_config(
             None,
             Some(ssh_host),
             agent.messages.clone(),
+            overrides.api_key_env.clone(),
+            overrides.extra_headers.clone(),
         );
         sessions::create_session(&store_path, &session_snapshot)?;
 
@@ -496,6 +499,8 @@ pub async fn build_run_config(
         sandbox.as_ref().map(|session| session.spec().clone()),
         None, // fresh local/sandbox sessions carry no ssh_host
         agent.messages.clone(),
+        overrides.api_key_env.clone(),
+        overrides.extra_headers.clone(),
     );
     sessions::create_session(&store_path, &session_snapshot)?;
 
@@ -736,8 +741,8 @@ async fn build_resume_config_from_snapshot(
         model: Some(snapshot.model.clone()),
         backend: Some(snapshot.backend),
         reasoning_effort: snapshot.reasoning_effort,
-        api_key_env: configured_api_key_env(config),
-        extra_headers: config.model.extra_headers.clone(),
+        api_key_env: snapshot.api_key_env.clone(),
+        extra_headers: snapshot.extra_headers.clone(),
     })?;
     let sandbox = if ssh_host.is_some() {
         None
@@ -1457,6 +1462,8 @@ url = "https://mcp.context7.com/mcp"
                     tool_calls: None,
                 },
             ],
+        None,
+        BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
 
@@ -1528,6 +1535,8 @@ url = "https://mcp.context7.com/mcp"
             None,
             Some("build-box".to_string()),
             Vec::new(),
+        None,
+        BTreeMap::new(),
         );
 
         let normalized =
@@ -1547,6 +1556,8 @@ url = "https://mcp.context7.com/mcp"
             None,
             Some("build-box".to_string()),
             Vec::new(),
+        None,
+        BTreeMap::new(),
         );
         let normalized =
             normalize_snapshot_paths(relative, Path::new("/local/resume/base")).unwrap();
@@ -1571,6 +1582,8 @@ url = "https://mcp.context7.com/mcp"
             }),
             Some("build-box".to_string()),
             Vec::new(),
+        None,
+        BTreeMap::new(),
         );
 
         let error = match build_resume_config_from_snapshot(
@@ -1611,6 +1624,8 @@ url = "https://mcp.context7.com/mcp"
             None,
             None,
             Vec::new(),
+        None,
+        BTreeMap::new(),
         );
 
         let error = normalize_snapshot_paths(snapshot, Path::new("/")).unwrap_err();
@@ -1656,6 +1671,8 @@ url = "https://mcp.context7.com/mcp"
                     content: "hello".to_string(),
                 },
             ],
+        None,
+        BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
 

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -393,7 +393,7 @@ pub async fn build_run_config(
         .clone()
         .unwrap_or_else(|| default_config_cwd(&options.workspace_cwd, ssh_host.as_deref()));
     let overrides = model_overrides(&options.model, config)?;
-    let client = ModelClient::from_env_with_overrides(overrides.clone())?;
+    let client = ModelClient::from_env_with_overrides(overrides.clone())?.with_cache_ttl(Some("1h"));
     let sandbox_options = effective_sandbox_options(options.sandbox, config);
     validate_target_sandbox_options(ssh_host.as_deref(), &sandbox_options, "session")?;
     let store_base_cwd = if ssh_host.is_some() {
@@ -640,7 +640,8 @@ pub async fn build_resume_picker_config(
     config: &NacConfig,
 ) -> Result<OrchestratorRunConfig> {
     let client =
-        ModelClient::from_env_with_overrides(model_overrides(&ModelOptions::default(), config)?)?;
+        ModelClient::from_env_with_overrides(model_overrides(&ModelOptions::default(), config)?)?
+            .with_cache_ttl(Some("1h"));
     let lookup_cwd = options.lookup_cwd;
     let paths = PathContext::new(&lookup_cwd);
     let agents_md = AgentsMdBundle::load(Some(&lookup_cwd), &paths)?;
@@ -760,7 +761,8 @@ async fn build_resume_config_from_snapshot(
         reasoning_effort: snapshot.reasoning_effort,
         api_key_env: snapshot.api_key_env.clone(),
         extra_headers: snapshot.extra_headers.clone(),
-    })?;
+    })?
+    .with_cache_ttl(Some("1h"));
     let sandbox = if ssh_host.is_some() {
         None
     } else {

--- a/crates/nac-core/src/sandbox/backend.rs
+++ b/crates/nac-core/src/sandbox/backend.rs
@@ -61,7 +61,7 @@ impl ExecutionBackend {
     pub async fn ensure_ready(&self) -> Result<()> {
         match self {
             Self::Local { .. } => Ok(()),
-            Self::Sandbox(session) => session.inner.ensure_ready().await,
+            Self::Sandbox(session) => session.ensure_ready().await,
             Self::Ssh(ssh) => ssh.ensure_ready().await,
         }
     }
@@ -231,7 +231,7 @@ pub fn select_execution_backend(
 ) -> Result<Arc<ExecutionBackend>> {
     match (ssh_host, sandbox) {
         (Some(ssh_host), Some(_)) => anyhow::bail!(
-            "invalid session configuration: ssh_host '{}' and podman sandbox cannot both be set",
+            "invalid session configuration: ssh_host '{}' and sandbox cannot both be set",
             ssh_host
         ),
         (Some(ssh_host), None) => Ok(Arc::new(ExecutionBackend::Ssh(
@@ -255,6 +255,7 @@ mod tests {
 
     fn sandbox() -> SandboxSession {
         SandboxSession::new_for_test(SandboxSpec {
+            backend: crate::sandbox::SandboxBackendType::Podman,
             image: DEFAULT_SANDBOX_IMAGE.to_string(),
             mounts: Vec::new(),
             workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),

--- a/crates/nac-core/src/sandbox/backend.rs
+++ b/crates/nac-core/src/sandbox/backend.rs
@@ -261,6 +261,8 @@ mod tests {
             workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
             gpu_devices: Vec::new(),
             shm_size: None,
+            cpus: 2,
+            memory_mib: 2048,
         })
     }
 

--- a/crates/nac-core/src/sandbox/mod.rs
+++ b/crates/nac-core/src/sandbox/mod.rs
@@ -4,9 +4,11 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use portable_pty::CommandBuilder as PtyCommandBuilder;
+use serde::{Deserialize, Serialize};
 
 mod backend;
 mod podman;
+mod smolvm;
 mod ssh;
 
 #[cfg(test)]
@@ -17,6 +19,40 @@ pub use ssh::SshBackend;
 pub const DEFAULT_SANDBOX_IMAGE: &str = "python:3.13-bookworm";
 pub const DEFAULT_SANDBOX_WORKDIR: &str = "/workspace";
 
+/// Identifies which sandbox backend implementation to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxBackendType {
+    Podman,
+    SmolVm,
+}
+
+impl Default for SandboxBackendType {
+    fn default() -> Self {
+        SandboxBackendType::Podman
+    }
+}
+
+impl SandboxBackendType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SandboxBackendType::Podman => "podman",
+            SandboxBackendType::SmolVm => "smolvm",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "podman" => Ok(Self::Podman),
+            "smolvm" => Ok(Self::SmolVm),
+            other => Err(anyhow!(
+                "invalid sandbox backend '{}': expected 'podman' or 'smolvm'",
+                other
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MountSpec {
     pub host: PathBuf,
@@ -26,6 +62,7 @@ pub struct MountSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxSpec {
+    pub backend: SandboxBackendType,
     pub image: String,
     pub mounts: Vec<MountSpec>,
     pub workdir: PathBuf,
@@ -34,44 +71,70 @@ pub struct SandboxSpec {
 }
 
 #[derive(Clone)]
-pub struct SandboxSession {
-    inner: Arc<podman::PodmanSession>,
+#[allow(private_interfaces)]
+pub enum SandboxSession {
+    Podman(Arc<podman::PodmanSession>),
+    SmolVm(Arc<smolvm::SmolVmSession>),
 }
 
 impl SandboxSession {
     pub async fn create(spec: SandboxSpec, session_key: String, owner: bool) -> Result<Self> {
-        let inner = Arc::new(podman::PodmanSession::new(spec, session_key, owner));
-        inner.ensure_ready().await?;
-        Ok(Self { inner })
+        let session = match spec.backend {
+            SandboxBackendType::Podman => {
+                let inner = Arc::new(podman::PodmanSession::new(spec, session_key, owner));
+                inner.ensure_ready().await?;
+                Self::Podman(inner)
+            }
+            SandboxBackendType::SmolVm => {
+                let inner = Arc::new(smolvm::SmolVmSession::new(spec, session_key, owner));
+                inner.ensure_ready().await?;
+                Self::SmolVm(inner)
+            }
+        };
+        Ok(session)
     }
 
     pub fn workdir_display(&self) -> String {
-        self.inner.spec().workdir.display().to_string()
+        self.spec().workdir.display().to_string()
     }
 
     pub fn host_workdir(&self) -> Option<PathBuf> {
-        host_workdir_from_spec(self.inner.spec())
+        host_workdir_from_spec(self.spec())
     }
 
     pub fn image(&self) -> &str {
-        &self.inner.spec().image
+        &self.spec().image
     }
 
     pub fn spec(&self) -> &SandboxSpec {
-        self.inner.spec()
+        match self {
+            Self::Podman(inner) => inner.spec(),
+            Self::SmolVm(inner) => inner.spec(),
+        }
     }
 
     pub fn status_text(&self) -> String {
-        format!("on (podman, image={})", self.image())
+        let backend = self.spec().backend.as_str();
+        format!("on ({backend}, image={})", self.image())
+    }
+
+    pub async fn ensure_ready(&self) -> Result<()> {
+        match self {
+            Self::Podman(inner) => inner.ensure_ready().await,
+            Self::SmolVm(inner) => inner.ensure_ready().await,
+        }
     }
 
     pub fn worker_cli_args(&self) -> Vec<OsString> {
-        self.inner.worker_cli_args()
+        match self {
+            Self::Podman(inner) => inner.worker_cli_args(),
+            Self::SmolVm(inner) => inner.worker_cli_args(),
+        }
     }
 
     pub fn resolve_path(&self, path: &str) -> Result<PathBuf> {
         let requested = PathBuf::from(path);
-        let spec = self.inner.spec();
+        let spec = self.spec();
 
         if requested.is_relative() {
             return Ok(spec.workdir.join(requested));
@@ -112,7 +175,10 @@ impl SandboxSession {
         args: &[String],
         stdin: Option<Vec<u8>>,
     ) -> Result<std::process::Output> {
-        self.inner.exec(program, args, stdin).await
+        match self {
+            Self::Podman(inner) => inner.exec(program, args, stdin).await,
+            Self::SmolVm(inner) => inner.exec(program, args, stdin).await,
+        }
     }
 
     pub fn child_process_command(
@@ -121,7 +187,10 @@ impl SandboxSession {
         args: &[String],
         envs: &[(String, String)],
     ) -> tokio::process::Command {
-        self.inner.child_process_command(program, args, envs)
+        match self {
+            Self::Podman(inner) => inner.child_process_command(program, args, envs),
+            Self::SmolVm(inner) => inner.child_process_command(program, args, envs),
+        }
     }
 
     pub fn terminal_pty_command(
@@ -129,7 +198,10 @@ impl SandboxSession {
         cwd: Option<&Path>,
         envs: &[(String, String)],
     ) -> (PtyCommandBuilder, String) {
-        self.inner.terminal_pty_command(cwd, envs)
+        match self {
+            Self::Podman(inner) => inner.terminal_pty_command(cwd, envs),
+            Self::SmolVm(inner) => inner.terminal_pty_command(cwd, envs),
+        }
     }
 
     pub fn terminal_pipe_command(
@@ -138,21 +210,32 @@ impl SandboxSession {
         cwd: Option<&Path>,
         envs: &[(String, String)],
     ) -> (tokio::process::Command, String) {
-        self.inner.terminal_pipe_command(cmd, cwd, envs)
+        match self {
+            Self::Podman(inner) => inner.terminal_pipe_command(cmd, cwd, envs),
+            Self::SmolVm(inner) => inner.terminal_pipe_command(cmd, cwd, envs),
+        }
     }
 
     pub async fn terminal_pipe_kill(&self, pidfile: &str) -> Result<()> {
-        self.inner.terminal_pipe_kill(pidfile).await
+        match self {
+            Self::Podman(inner) => inner.terminal_pipe_kill(pidfile).await,
+            Self::SmolVm(inner) => inner.terminal_pipe_kill(pidfile).await,
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn new_for_test(spec: SandboxSpec) -> Self {
-        Self {
-            inner: Arc::new(podman::PodmanSession::new(
+        match spec.backend {
+            SandboxBackendType::Podman => Self::Podman(Arc::new(podman::PodmanSession::new(
                 spec,
                 "test-session".to_string(),
                 false,
-            )),
+            ))),
+            SandboxBackendType::SmolVm => Self::SmolVm(Arc::new(smolvm::SmolVmSession::new(
+                spec,
+                "test-session".to_string(),
+                false,
+            ))),
         }
     }
 }
@@ -201,6 +284,7 @@ pub(crate) fn host_workdir_from_spec(spec: &SandboxSpec) -> Option<PathBuf> {
 }
 
 pub fn build_sandbox_spec(
+    backend: SandboxBackendType,
     image: String,
     workdir: String,
     mounts: Vec<MountSpec>,
@@ -216,6 +300,7 @@ pub fn build_sandbox_spec(
     }
 
     Ok(SandboxSpec {
+        backend,
         image,
         mounts,
         workdir,
@@ -278,19 +363,14 @@ mod tests {
             guest: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
             read_only: false,
         };
-        let session = SandboxSession {
-            inner: Arc::new(podman::PodmanSession::new(
-                SandboxSpec {
-                    image: DEFAULT_SANDBOX_IMAGE.to_string(),
-                    mounts: vec![mount],
-                    workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
-                    gpu_devices: Vec::new(),
-                    shm_size: Some("0".to_string()),
-                },
-                "test-session".to_string(),
-                false,
-            )),
-        };
+        let session = SandboxSession::new_for_test(SandboxSpec {
+            backend: SandboxBackendType::Podman,
+            image: DEFAULT_SANDBOX_IMAGE.to_string(),
+            mounts: vec![mount],
+            workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+            gpu_devices: Vec::new(),
+            shm_size: Some("0".to_string()),
+        });
 
         assert_eq!(session.host_workdir().unwrap(), cwd);
 

--- a/crates/nac-core/src/sandbox/mod.rs
+++ b/crates/nac-core/src/sandbox/mod.rs
@@ -68,6 +68,8 @@ pub struct SandboxSpec {
     pub workdir: PathBuf,
     pub gpu_devices: Vec<String>,
     pub shm_size: Option<String>,
+    pub cpus: u8,
+    pub memory_mib: u32,
 }
 
 #[derive(Clone)]
@@ -290,6 +292,8 @@ pub fn build_sandbox_spec(
     mounts: Vec<MountSpec>,
     gpu_devices: Vec<String>,
     shm_size: Option<String>,
+    cpus: u8,
+    memory_mib: u32,
 ) -> Result<SandboxSpec> {
     let workdir = PathBuf::from(workdir);
     if !workdir.is_absolute() {
@@ -306,6 +310,8 @@ pub fn build_sandbox_spec(
         workdir,
         gpu_devices,
         shm_size,
+        cpus,
+        memory_mib,
     })
 }
 
@@ -370,6 +376,8 @@ mod tests {
             workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
             gpu_devices: Vec::new(),
             shm_size: Some("0".to_string()),
+            cpus: 2,
+            memory_mib: 2048,
         });
 
         assert_eq!(session.host_workdir().unwrap(), cwd);

--- a/crates/nac-core/src/sandbox/mod.rs
+++ b/crates/nac-core/src/sandbox/mod.rs
@@ -225,6 +225,16 @@ impl SandboxSession {
         }
     }
 
+    /// Explicitly destroy the sandbox (container or VM), regardless of
+    /// remaining `Arc` references.  Best-effort and idempotent.  Only
+    /// acts if this session is the owner.
+    pub async fn destroy(&self) -> Result<()> {
+        match self {
+            Self::Podman(inner) => inner.destroy().await,
+            Self::SmolVm(inner) => inner.destroy().await,
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn new_for_test(spec: SandboxSpec) -> Self {
         match spec.backend {

--- a/crates/nac-core/src/sandbox/podman.rs
+++ b/crates/nac-core/src/sandbox/podman.rs
@@ -109,6 +109,8 @@ impl PodmanSession {
         let mut args = vec![
             OsString::from("--sandbox"),
             OsString::from("--no-mount-cwd"),
+            OsString::from("--sandbox-backend"),
+            OsString::from("podman"),
             OsString::from("--sandbox-image"),
             OsString::from(self.spec.image.clone()),
             OsString::from("--sandbox-workdir"),
@@ -419,7 +421,7 @@ fn volume_arg(mount: &MountSpec) -> String {
     )
 }
 
-fn sanitize_name(input: &str) -> String {
+pub(crate) fn sanitize_name(input: &str) -> String {
     let mut out = String::new();
     for ch in input.chars() {
         if ch.is_ascii_alphanumeric() {
@@ -431,7 +433,7 @@ fn sanitize_name(input: &str) -> String {
     out.trim_matches('-').to_string()
 }
 
-fn shell_escape_path(path: &Path) -> String {
+pub(crate) fn shell_escape_path(path: &Path) -> String {
     path.display().to_string().replace('\'', "'\"'\"'")
 }
 
@@ -458,12 +460,13 @@ fn should_enable_gpu_access_options() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sandbox::{DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_WORKDIR};
+    use crate::sandbox::{SandboxBackendType, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_WORKDIR};
     use std::path::PathBuf;
 
     fn sample_session() -> PodmanSession {
         PodmanSession::new(
             SandboxSpec {
+                backend: SandboxBackendType::Podman,
                 image: DEFAULT_SANDBOX_IMAGE.to_string(),
                 mounts: vec![MountSpec {
                     host: PathBuf::from("/tmp/project"),
@@ -523,6 +526,7 @@ mod tests {
     fn create_container_args_skip_user_without_rw_mounts() {
         let session = PodmanSession::new(
             SandboxSpec {
+                backend: SandboxBackendType::Podman,
                 image: DEFAULT_SANDBOX_IMAGE.to_string(),
                 mounts: Vec::new(),
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
@@ -544,6 +548,7 @@ mod tests {
     fn create_container_args_include_gpu_devices() {
         let session = PodmanSession::new(
             SandboxSpec {
+                backend: SandboxBackendType::Podman,
                 image: DEFAULT_SANDBOX_IMAGE.to_string(),
                 mounts: Vec::new(),
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),

--- a/crates/nac-core/src/sandbox/podman.rs
+++ b/crates/nac-core/src/sandbox/podman.rs
@@ -395,6 +395,19 @@ impl PodmanSession {
         )));
         args
     }
+
+    /// Explicitly destroy the sandbox container, regardless of remaining
+    /// `Arc` references.  Best-effort and idempotent: `podman rm -f` already
+    /// handles non-existent containers gracefully.
+    pub(crate) async fn destroy(&self) -> Result<()> {
+        if !self.owner {
+            return Ok(());
+        }
+        let mut cmd = Command::new("podman");
+        cmd.args(["rm", "-f", &self.container_name]);
+        let _ = cmd.output().await; // best-effort, ignore errors
+        Ok(())
+    }
 }
 
 impl Drop for PodmanSession {

--- a/crates/nac-core/src/sandbox/podman.rs
+++ b/crates/nac-core/src/sandbox/podman.rs
@@ -117,6 +117,10 @@ impl PodmanSession {
             OsString::from(self.spec.workdir.display().to_string()),
             OsString::from("--sandbox-session-key"),
             OsString::from(self.session_key.clone()),
+            OsString::from("--sandbox-cpus"),
+            OsString::from(self.spec.cpus.to_string()),
+            OsString::from("--sandbox-mem"),
+            OsString::from(self.spec.memory_mib.to_string()),
         ];
 
         for mount in &self.spec.mounts {
@@ -349,6 +353,10 @@ impl PodmanSession {
             OsString::from("--rm"),
             OsString::from("--name"),
             OsString::from(self.container_name.clone()),
+            OsString::from("--cpus"),
+            OsString::from(self.spec.cpus.to_string()),
+            OsString::from("--memory"),
+            OsString::from(format!("{}m", self.spec.memory_mib)),
         ];
 
         if should_keep_id_userns() && self.spec.mounts.iter().any(|mount| !mount.read_only) {
@@ -476,6 +484,8 @@ mod tests {
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: Vec::new(),
                 shm_size: Some("0".to_string()),
+                cpus: 2,
+                memory_mib: 2048,
             },
             "abc123".to_string(),
             false,
@@ -532,6 +542,8 @@ mod tests {
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: Vec::new(),
                 shm_size: Some("0".to_string()),
+                cpus: 2,
+                memory_mib: 2048,
             },
             "empty".to_string(),
             false,
@@ -557,6 +569,8 @@ mod tests {
                     "nvidia.com/gpu=mig1:0".to_string(),
                 ],
                 shm_size: Some("8g".to_string()),
+                cpus: 2,
+                memory_mib: 2048,
             },
             "gpu".to_string(),
             false,

--- a/crates/nac-core/src/sandbox/smolvm.rs
+++ b/crates/nac-core/src/sandbox/smolvm.rs
@@ -1,0 +1,538 @@
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::Stdio as StdStdio;
+use std::process::{Command as StdCommand, Stdio};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use portable_pty::CommandBuilder as PtyCommandBuilder;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use super::podman::{
+    make_sandbox_pidfile, sanitize_name, shell_escape_path, SANDBOX_EXEC_WRAPPER,
+    SANDBOX_KILL_WRAPPER, SANDBOX_PTY_WRAPPER,
+};
+use super::{MountSpec, SandboxSpec};
+
+pub(crate) struct SmolVmSession {
+    spec: SandboxSpec,
+    session_key: String,
+    owner: bool,
+    vm_name: String,
+}
+
+impl SmolVmSession {
+    pub(crate) fn new(spec: SandboxSpec, session_key: String, owner: bool) -> Self {
+        let vm_name = format!("nac-{}", sanitize_name(&session_key));
+        Self {
+            spec,
+            session_key,
+            owner,
+            vm_name,
+        }
+    }
+
+    pub(crate) fn spec(&self) -> &SandboxSpec {
+        &self.spec
+    }
+
+    pub(crate) async fn ensure_ready(&self) -> Result<()> {
+        let exists = self.vm_exists().await?;
+        if !exists {
+            if !self.owner {
+                bail!(
+                    "sandbox session '{}' is not available; start the parent nac process first",
+                    self.session_key
+                );
+            }
+            self.create_vm().await?;
+            return Ok(());
+        }
+
+        // Start the VM if it's stopped.  smolvm machine start is safe to
+        // call on an already-running VM (it reports success), but we
+        // propagate any real errors.
+        self.start_vm().await?;
+
+        Ok(())
+    }
+
+    pub(crate) fn worker_cli_args(&self) -> Vec<OsString> {
+        let mut args = vec![
+            OsString::from("--sandbox"),
+            OsString::from("--no-mount-cwd"),
+            OsString::from("--sandbox-backend"),
+            OsString::from("smolvm"),
+            OsString::from("--sandbox-image"),
+            OsString::from(self.spec.image.clone()),
+            OsString::from("--sandbox-workdir"),
+            OsString::from(self.spec.workdir.display().to_string()),
+            OsString::from("--sandbox-session-key"),
+            OsString::from(self.session_key.clone()),
+        ];
+
+        for mount in &self.spec.mounts {
+            args.push(OsString::from(if mount.read_only {
+                "--mount-ro"
+            } else {
+                "--mount"
+            }));
+            args.push(OsString::from(format!(
+                "{}:{}",
+                mount.host.display(),
+                mount.guest.display()
+            )));
+        }
+        // smolvm does not support --shm-size; skip it.
+        for device in &self.spec.gpu_devices {
+            args.push(OsString::from("--sandbox-gpu"));
+            args.push(OsString::from(device));
+        }
+
+        args
+    }
+
+    pub(crate) async fn exec(
+        &self,
+        program: &str,
+        args: &[String],
+        stdin: Option<Vec<u8>>,
+    ) -> Result<std::process::Output> {
+        let mut command = Command::new("smolvm");
+        command.args(self.exec_args(program, args, stdin.is_some(), false, None, &[]));
+
+        if stdin.is_some() {
+            command.stdin(Stdio::piped());
+        }
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let mut child = command
+            .spawn()
+            .with_context(|| "failed to spawn 'smolvm machine exec'")?;
+
+        if let Some(input) = stdin {
+            if let Some(mut stdin_pipe) = child.stdin.take() {
+                stdin_pipe.write_all(&input).await?;
+            }
+        }
+
+        child
+            .wait_with_output()
+            .await
+            .with_context(|| "failed to wait for 'smolvm machine exec'")
+    }
+
+    pub(crate) fn child_process_command(
+        &self,
+        program: &str,
+        args: &[String],
+        envs: &[(String, String)],
+    ) -> Command {
+        let mut command = Command::new("smolvm");
+        command.args(self.exec_args(program, args, true, false, None, envs));
+        command.stdin(Stdio::piped());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::inherit());
+        command
+    }
+
+    pub(crate) fn terminal_pty_command(
+        &self,
+        cwd: Option<&Path>,
+        envs: &[(String, String)],
+    ) -> (PtyCommandBuilder, String) {
+        let pidfile = make_sandbox_pidfile();
+        let pty_args = vec![
+            "-lc".to_string(),
+            SANDBOX_PTY_WRAPPER.to_string(),
+            "nac-pty".to_string(),
+            pidfile.clone(),
+        ];
+        let mut cmd = PtyCommandBuilder::new("smolvm");
+        cmd.args(self.exec_args("bash", &pty_args, true, true, cwd, envs));
+        (cmd, pidfile)
+    }
+
+    pub(crate) fn terminal_pipe_command(
+        &self,
+        cmd_str: &str,
+        cwd: Option<&Path>,
+        envs: &[(String, String)],
+    ) -> (Command, String) {
+        let pidfile = make_sandbox_pidfile();
+        let pipe_args = vec![
+            "-lc".to_string(),
+            SANDBOX_EXEC_WRAPPER.to_string(),
+            "nac-exec".to_string(),
+            cmd_str.to_string(),
+            pidfile.clone(),
+        ];
+        let mut command = Command::new("smolvm");
+        command.args(self.exec_args("bash", &pipe_args, false, false, cwd, envs));
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+        (command, pidfile)
+    }
+
+    pub(crate) async fn terminal_pipe_kill(&self, pidfile: &str) -> Result<()> {
+        let mut command = Command::new("smolvm");
+        command
+            .arg("machine")
+            .arg("exec")
+            .arg("--name")
+            .arg(&self.vm_name)
+            .arg("--")
+            .arg("sh")
+            .arg("-c")
+            .arg(SANDBOX_KILL_WRAPPER)
+            .arg("nac-kill")
+            .arg(pidfile)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        let _ = timeout(Duration::from_secs(2), command.status()).await;
+        Ok(())
+    }
+
+    fn exec_args(
+        &self,
+        program: &str,
+        args: &[String],
+        interactive: bool,
+        tty: bool,
+        cwd: Option<&Path>,
+        envs: &[(String, String)],
+    ) -> Vec<OsString> {
+        let mut command_args = vec![
+            OsString::from("machine"),
+            OsString::from("exec"),
+            OsString::from("--name"),
+            OsString::from(self.vm_name.clone()),
+        ];
+
+        let wd = cwd
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| self.spec.workdir.display().to_string());
+        command_args.push(OsString::from("--workdir"));
+        command_args.push(OsString::from(wd));
+
+        for (key, value) in envs {
+            command_args.push(OsString::from("--env"));
+            command_args.push(OsString::from(format!("{key}={value}")));
+        }
+
+        if interactive {
+            command_args.push(OsString::from("-i"));
+        }
+        if tty {
+            command_args.push(OsString::from("-t"));
+        }
+
+        // smolvm uses `--` to separate its flags from the guest command.
+        command_args.push(OsString::from("--"));
+        command_args.push(OsString::from(program));
+        for arg in args {
+            command_args.push(OsString::from(arg));
+        }
+        command_args
+    }
+
+    async fn vm_exists(&self) -> Result<bool> {
+        let output = Command::new("smolvm")
+            .arg("machine")
+            .arg("status")
+            .arg("--name")
+            .arg(&self.vm_name)
+            .output()
+            .await
+            .with_context(|| "failed to execute 'smolvm machine status'")?;
+        Ok(output.status.success())
+    }
+
+    async fn start_vm(&self) -> Result<()> {
+        let output = Command::new("smolvm")
+            .arg("machine")
+            .arg("start")
+            .arg("--name")
+            .arg(&self.vm_name)
+            .output()
+            .await
+            .with_context(|| "failed to execute 'smolvm machine start'")?;
+        if !output.status.success() {
+            // VM might already be running — that's OK.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.contains("already running") && !stderr.contains("running") {
+                bail!(
+                    "failed to start sandbox VM '{}': {}",
+                    self.vm_name,
+                    stderr.trim()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn create_vm(&self) -> Result<()> {
+        let mut command = Command::new("smolvm");
+        command.args(self.create_vm_args());
+        let output = command
+            .output()
+            .await
+            .with_context(|| "failed to execute 'smolvm machine run'")?;
+        if !output.status.success() {
+            bail!(
+                "failed to create sandbox VM '{}': {}",
+                self.vm_name,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    fn create_vm_args(&self) -> Vec<OsString> {
+        let mut args = vec![
+            OsString::from("machine"),
+            OsString::from("run"),
+            OsString::from("-d"),
+            OsString::from("--net"),
+            OsString::from("--name"),
+            OsString::from(self.vm_name.clone()),
+            OsString::from("--image"),
+            OsString::from(self.spec.image.clone()),
+        ];
+
+        for mount in &self.spec.mounts {
+            args.push(OsString::from("-v"));
+            args.push(OsString::from(volume_arg(mount)));
+        }
+
+        // smolvm does not support --shm-size; skip it.
+
+        if !self.spec.gpu_devices.is_empty() {
+            args.push(OsString::from("--gpu"));
+        }
+
+        args.push(OsString::from("--workdir"));
+        args.push(OsString::from(self.spec.workdir.display().to_string()));
+
+        args.push(OsString::from("--"));
+        args.push(OsString::from("sh"));
+        args.push(OsString::from("-lc"));
+        args.push(OsString::from(format!(
+            "mkdir -p '{}' && exec sleep infinity",
+            shell_escape_path(&self.spec.workdir)
+        )));
+        args
+    }
+}
+
+impl Drop for SmolVmSession {
+    fn drop(&mut self) {
+        if !self.owner {
+            return;
+        }
+
+        let _ = StdCommand::new("smolvm")
+            .arg("machine")
+            .arg("delete")
+            .arg("--name")
+            .arg(&self.vm_name)
+            .arg("-f")
+            .stdout(StdStdio::null())
+            .stderr(StdStdio::null())
+            .spawn();
+    }
+}
+
+fn volume_arg(mount: &MountSpec) -> String {
+    if mount.read_only {
+        format!(
+            "{}:{}:ro",
+            mount.host.display(),
+            mount.guest.display()
+        )
+    } else {
+        format!("{}:{}", mount.host.display(), mount.guest.display())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::{SandboxBackendType, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_WORKDIR};
+    use std::path::PathBuf;
+
+    fn sample_session() -> SmolVmSession {
+        SmolVmSession::new(
+            SandboxSpec {
+                backend: SandboxBackendType::SmolVm,
+                image: DEFAULT_SANDBOX_IMAGE.to_string(),
+                mounts: vec![MountSpec {
+                    host: PathBuf::from("/tmp/project"),
+                    guest: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+                    read_only: false,
+                }],
+                workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+                gpu_devices: Vec::new(),
+                shm_size: Some("0".to_string()),
+            },
+            "abc123".to_string(),
+            false,
+        )
+    }
+
+    #[test]
+    fn worker_cli_args_include_backend_and_image() {
+        let args = sample_session().worker_cli_args();
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered.contains(&"--sandbox".to_string()));
+        assert!(rendered.contains(&"--no-mount-cwd".to_string()));
+        assert!(rendered.contains(&"--sandbox-backend".to_string()));
+        assert!(rendered.contains(&"smolvm".to_string()));
+        assert!(rendered.contains(&"--sandbox-session-key".to_string()));
+        assert!(rendered.contains(&"/tmp/project:/workspace".to_string()));
+    }
+
+    #[test]
+    fn create_vm_args_include_net_and_image() {
+        let args = sample_session().create_vm_args();
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered.starts_with(&[
+            "machine".to_string(),
+            "run".to_string(),
+            "-d".to_string(),
+            "--net".to_string(),
+        ]));
+        assert!(rendered.contains(&"--name".to_string()));
+        assert!(rendered.contains(&"--image".to_string()));
+        assert!(rendered.contains(&DEFAULT_SANDBOX_IMAGE.to_string()));
+        assert!(rendered.contains(&"-v".to_string()));
+        assert!(rendered.contains(&"/tmp/project:/workspace".to_string()));
+        assert!(rendered.contains(&"--workdir".to_string()));
+        assert!(rendered
+            .iter()
+            .any(|value| value.contains("sleep infinity")));
+        // smolvm should NOT include --shm-size
+        assert!(!rendered.contains(&"--shm-size".to_string()));
+        // smolvm should NOT include --userns
+        assert!(!rendered.contains(&"--userns".to_string()));
+    }
+
+    #[test]
+    fn create_vm_args_include_gpu_flag() {
+        let session = SmolVmSession::new(
+            SandboxSpec {
+                backend: SandboxBackendType::SmolVm,
+                image: DEFAULT_SANDBOX_IMAGE.to_string(),
+                mounts: Vec::new(),
+                workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+                gpu_devices: vec!["all".to_string()],
+                shm_size: None,
+            },
+            "gpu".to_string(),
+            false,
+        );
+        let rendered: Vec<String> = session
+            .create_vm_args()
+            .into_iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered.contains(&"--gpu".to_string()));
+        // smolvm uses --gpu, not --device
+        assert!(!rendered.contains(&"--device".to_string()));
+    }
+
+    #[test]
+    fn exec_args_use_double_dash_separator() {
+        let args = sample_session().exec_args(
+            "python3",
+            &["-c".to_string(), "print('hi')".to_string()],
+            true,
+            false,
+            None,
+            &[],
+        );
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(rendered.first().map(String::as_str), Some("machine"));
+        assert!(rendered.contains(&"exec".to_string()));
+        assert!(rendered.contains(&"--name".to_string()));
+        assert!(rendered.contains(&"-i".to_string()));
+        assert!(!rendered.contains(&"-t".to_string()));
+        // The `--` separator must be present before the program
+        let dash_pos = rendered
+            .iter()
+            .position(|v| v == "--")
+            .expect("expected -- separator");
+        assert_eq!(rendered[dash_pos + 1], "python3");
+    }
+
+    #[test]
+    fn exec_args_include_env_vars() {
+        let args = sample_session().exec_args(
+            "bash",
+            &["-c".to_string(), "echo $TERM".to_string()],
+            false,
+            false,
+            None,
+            &[
+                ("TERM".to_string(), "dumb".to_string()),
+                ("PAGER".to_string(), "cat".to_string()),
+            ],
+        );
+        let rendered: Vec<String> = args
+            .into_iter()
+            .map(|value| value.to_string_lossy().to_string())
+            .collect();
+        assert!(rendered.contains(&"--env".to_string()));
+        assert!(rendered.contains(&"TERM=dumb".to_string()));
+        assert!(rendered.contains(&"PAGER=cat".to_string()));
+    }
+
+    #[test]
+    fn terminal_pipe_command_produces_pidfile() {
+        let session = sample_session();
+        let (command, pidfile) = session.terminal_pipe_command(
+            "echo hello",
+            None,
+            &[
+                ("TERM".to_string(), "dumb".to_string()),
+                ("PAGER".to_string(), "cat".to_string()),
+            ],
+        );
+        assert!(pidfile.starts_with("/tmp/nac-exec-"));
+        assert!(pidfile.ends_with(".pid"));
+        let debug = format!("{command:?}");
+        assert!(debug.contains("smolvm"), "expected smolvm: {debug}");
+        assert!(debug.contains("machine"), "expected machine: {debug}");
+        assert!(debug.contains("exec"), "expected exec: {debug}");
+    }
+
+    #[test]
+    fn vm_name_uses_sanitized_session_key() {
+        let session = SmolVmSession::new(
+            SandboxSpec {
+                backend: SandboxBackendType::SmolVm,
+                image: DEFAULT_SANDBOX_IMAGE.to_string(),
+                mounts: Vec::new(),
+                workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+                gpu_devices: Vec::new(),
+                shm_size: None,
+            },
+            "abc-123_DEF".to_string(),
+            false,
+        );
+        assert_eq!(session.vm_name, "nac-abc-123-def");
+    }
+}

--- a/crates/nac-core/src/sandbox/smolvm.rs
+++ b/crates/nac-core/src/sandbox/smolvm.rs
@@ -335,6 +335,19 @@ impl SmolVmSession {
         )));
         args
     }
+
+    /// Explicitly destroy the sandbox VM, regardless of remaining `Arc`
+    /// references.  Best-effort and idempotent: `smolvm machine delete -f`
+    /// already handles non-existent VMs gracefully.
+    pub(crate) async fn destroy(&self) -> Result<()> {
+        if !self.owner {
+            return Ok(());
+        }
+        let mut cmd = Command::new("smolvm");
+        cmd.args(["machine", "delete", "--name", &self.vm_name, "-f"]);
+        let _ = cmd.output().await; // best-effort, ignore errors
+        Ok(())
+    }
 }
 
 impl Drop for SmolVmSession {

--- a/crates/nac-core/src/sandbox/smolvm.rs
+++ b/crates/nac-core/src/sandbox/smolvm.rs
@@ -71,6 +71,10 @@ impl SmolVmSession {
             OsString::from(self.spec.workdir.display().to_string()),
             OsString::from("--sandbox-session-key"),
             OsString::from(self.session_key.clone()),
+            OsString::from("--sandbox-cpus"),
+            OsString::from(self.spec.cpus.to_string()),
+            OsString::from("--sandbox-mem"),
+            OsString::from(self.spec.memory_mib.to_string()),
         ];
 
         for mount in &self.spec.mounts {
@@ -302,6 +306,10 @@ impl SmolVmSession {
             OsString::from(self.vm_name.clone()),
             OsString::from("--image"),
             OsString::from(self.spec.image.clone()),
+            OsString::from("--cpus"),
+            OsString::from(self.spec.cpus.to_string()),
+            OsString::from("--mem"),
+            OsString::from(self.spec.memory_mib.to_string()),
         ];
 
         for mount in &self.spec.mounts {
@@ -378,6 +386,8 @@ mod tests {
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: Vec::new(),
                 shm_size: Some("0".to_string()),
+                cpus: 2,
+                memory_mib: 2048,
             },
             "abc123".to_string(),
             false,
@@ -437,6 +447,8 @@ mod tests {
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: vec!["all".to_string()],
                 shm_size: None,
+                cpus: 2,
+                memory_mib: 2048,
             },
             "gpu".to_string(),
             false,
@@ -529,6 +541,8 @@ mod tests {
                 workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
                 gpu_devices: Vec::new(),
                 shm_size: None,
+                cpus: 2,
+                memory_mib: 2048,
             },
             "abc-123_DEF".to_string(),
             false,

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -955,6 +955,7 @@ mod tests {
     use super::*;
     use crate::agent::{AgentConfig, AgentMode};
     use crate::model::ModelClient;
+    use std::collections::BTreeMap;
 
     fn test_store_path(label: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
@@ -1045,6 +1046,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         snapshot.last_response_duration_ms = Some(200);
         snapshot.previous_response_duration_ms = Some(100);
@@ -1096,6 +1099,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
         let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
@@ -1201,6 +1206,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
             agent,
@@ -1277,6 +1284,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
             agent,
@@ -1384,6 +1393,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
         let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
@@ -1583,6 +1594,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         snapshot.last_response_duration_ms = Some(123);
         snapshot.response_durations_ms = Some(vec![Some(123)]);
@@ -1658,6 +1671,8 @@ mod tests {
             None,
             None,
             agent.messages.clone(),
+        None,
+        BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
         let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -44,6 +44,10 @@ pub struct ResponseTimingSnapshot {
     pub last_response_duration_ms: Option<u64>,
     pub previous_response_duration_ms: Option<u64>,
     pub response_durations_ms: Option<Vec<Option<u64>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub token_usages: Option<Vec<Option<crate::model::TokenUsage>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_token_usage: Option<crate::model::TokenUsage>,
 }
 
 impl ResponseTimingSnapshot {
@@ -54,10 +58,13 @@ impl ResponseTimingSnapshot {
 
 impl From<&SessionSnapshot> for ResponseTimingSnapshot {
     fn from(snapshot: &SessionSnapshot) -> Self {
+        let last_token_usage = snapshot.token_usages.last().cloned().flatten();
         Self {
             last_response_duration_ms: snapshot.last_response_duration_ms,
             previous_response_duration_ms: snapshot.previous_response_duration_ms,
             response_durations_ms: snapshot.response_durations_ms.clone(),
+            token_usages: Some(snapshot.token_usages.clone()),
+            last_token_usage,
         }
     }
 }
@@ -244,7 +251,7 @@ struct CancellingRun {
 }
 
 enum RunOutcome {
-    Completed(String),
+    Completed(String, Option<crate::model::TokenUsage>),
     Failed(String),
 }
 
@@ -514,7 +521,7 @@ impl SessionService {
         self.append_cancellation_message().await;
         let message = "run cancelled by user".to_string();
         let persistence_error = match self
-            .persist_run_snapshot(&cancelling_run.snapshot, None)
+            .persist_run_snapshot(&cancelling_run.snapshot, None, None)
             .await
         {
             Ok(()) => None,
@@ -556,7 +563,7 @@ impl SessionService {
         let event_bus = self.event_bus.clone();
         let service = self.clone();
         let task = tokio::spawn(async move {
-            let result = {
+            let (result, usage) = {
                 let mut agent = service.agent.lock().await;
                 agent.set_event_sink(EventSink::bus_with_context(
                     event_bus.clone(),
@@ -568,12 +575,13 @@ impl SessionService {
                     .await
                     .map_err(|error| error.to_string());
                 agent.set_event_sink(EventSink::bus(event_bus));
-                result
+                let usage = result.as_ref().ok().and_then(|_| agent.last_usage.clone());
+                (result, usage)
             };
             match result {
                 Ok(response) => {
                     service
-                        .finish_run_once(&task_run_id, RunOutcome::Completed(response))
+                        .finish_run_once(&task_run_id, RunOutcome::Completed(response, usage))
                         .await;
                 }
                 Err(message) => {
@@ -644,12 +652,16 @@ impl SessionService {
         let Some(finishing_run) = self.mark_run_finishing(run_id) else {
             return false;
         };
-        let completed_duration_ms = match outcome {
-            RunOutcome::Completed(_) => Some(finishing_run.duration_ms),
-            RunOutcome::Failed(_) => None,
+        let (completed_duration_ms, completed_usage) = match &outcome {
+            RunOutcome::Completed(_, usage) => (Some(finishing_run.duration_ms), usage.clone()),
+            RunOutcome::Failed(_) => (None, None),
         };
         let persistence_error = match self
-            .persist_run_snapshot(&finishing_run.snapshot, completed_duration_ms)
+            .persist_run_snapshot(
+                &finishing_run.snapshot,
+                completed_duration_ms,
+                completed_usage,
+            )
             .await
         {
             Ok(()) => None,
@@ -665,10 +677,10 @@ impl SessionService {
         let run_id = finishing_run.snapshot.run_id.clone();
         let client_id = finishing_run.snapshot.client_id.clone();
         let terminal_event = match (outcome, persistence_error) {
-            (RunOutcome::Completed(_), Some(error)) => SessionEvent::RunFailed {
+            (RunOutcome::Completed(_, _), Some(error)) => SessionEvent::RunFailed {
                 message: format!("run completed, but failed to persist session snapshot: {error}"),
             },
-            (RunOutcome::Completed(response), None) => SessionEvent::RunCompleted {
+            (RunOutcome::Completed(response, _), None) => SessionEvent::RunCompleted {
                 response,
                 duration_ms: completed_duration_ms,
             },
@@ -761,6 +773,7 @@ impl SessionService {
         &self,
         active_run: &ActiveRunSnapshot,
         completed_duration_ms: Option<u64>,
+        completed_usage: Option<crate::model::TokenUsage>,
     ) -> Result<()> {
         let messages = {
             let agent = self.agent.lock().await;
@@ -774,12 +787,19 @@ impl SessionService {
             };
             let response_timing =
                 response_timing_after_run(snapshot, &messages, completed_duration_ms);
+            let token_usages = token_usages_after_run(
+                &snapshot.token_usages,
+                &snapshot.messages,
+                &messages,
+                completed_usage,
+            );
             sessions::refresh_snapshot(
                 snapshot,
                 messages,
                 response_timing.last_response_duration_ms,
                 response_timing.previous_response_duration_ms,
                 response_timing.response_durations_ms,
+                token_usages,
             )
         };
 
@@ -918,6 +938,8 @@ fn response_timing_after_run(
         last_response_duration_ms,
         previous_response_duration_ms,
         response_durations_ms: Some(durations),
+        token_usages: None,
+        last_token_usage: None,
     }
 }
 
@@ -948,6 +970,36 @@ fn visible_response_count(messages: &[Message]) -> usize {
             )
         })
         .count()
+}
+
+/// Build the per-response token-usage vector after a run, mirroring the
+/// logic in `response_timing_after_run` for durations.  The existing
+/// vector is preserved and padded to match the new response count; the
+/// most recent response's usage is set from `completed_usage` when the
+/// run completed successfully.
+fn token_usages_after_run(
+    existing: &[Option<crate::model::TokenUsage>],
+    old_messages: &[Message],
+    new_messages: &[Message],
+    completed_usage: Option<crate::model::TokenUsage>,
+) -> Vec<Option<crate::model::TokenUsage>> {
+    let mut usages = existing.to_vec();
+    let previous_response_count = visible_response_count(old_messages);
+    if usages.len() < previous_response_count {
+        usages.resize(previous_response_count, None);
+    }
+
+    let current_response_count = visible_response_count(new_messages);
+    if usages.len() < current_response_count {
+        usages.resize(current_response_count, None);
+    }
+    if let (Some(usage), Some(last_index)) =
+        (completed_usage, current_response_count.checked_sub(1))
+    {
+        usages[last_index] = Some(usage);
+    }
+
+    usages
 }
 
 #[cfg(test)]
@@ -1140,7 +1192,7 @@ mod tests {
         assert!(
             parts
                 .service
-                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string()))
+                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string(), None))
                 .await
         );
 
@@ -1184,6 +1236,110 @@ mod tests {
             parts.init.restored_messages.len() + 2
         );
         assert!(parts.service.active_run().is_none());
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn finish_run_persists_token_usage() {
+        let store_path = test_store_path("active_finish_token_usage");
+        let client = ModelClient::new_for_test();
+        let session_id = "session-finish-token-usage".to_string();
+        let agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
+        let snapshot = sessions::new_snapshot(
+            session_id.clone(),
+            PathBuf::from("/repo"),
+            client.model.clone(),
+            client.base_url().to_string(),
+            client.backend(),
+            client.reasoning_effort(),
+            None,
+            None,
+            agent.messages.clone(),
+            None,
+            BTreeMap::new(),
+        );
+        sessions::create_session(&store_path, &snapshot).unwrap();
+        let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+            agent,
+            client,
+            session: OrchestratorSession::Active {
+                session_id: session_id.clone(),
+                store_path: store_path.clone(),
+                snapshot,
+            },
+            sandbox_status: "off".to_string(),
+            agents_md_status: "off".to_string(),
+            workspace_display: "/repo".to_string(),
+            workspace_host_path: Some(PathBuf::from("/repo")),
+            resume_base_cwd: PathBuf::from("/repo"),
+        });
+
+        let active = parts
+            .service
+            .try_begin_run(None, "prompt")
+            .unwrap();
+        {
+            let mut agent = parts.service.agent.lock().await;
+            agent.messages.push(Message::User {
+                content: "prompt".to_string(),
+            });
+            agent.messages.push(Message::Assistant {
+                content: Some("done".to_string()),
+                reasoning_text: None,
+                reasoning_details: None,
+                tool_calls: None,
+            });
+        }
+
+        let test_usage = crate::model::TokenUsage {
+            input_tokens: 500,
+            output_tokens: 120,
+            cache_read_tokens: 80,
+            cache_write_tokens: 15,
+            total_tokens: 715,
+        };
+        assert!(
+            parts
+                .service
+                .finish_run_once(
+                    &active.run_id,
+                    RunOutcome::Completed("done".to_string(), Some(test_usage.clone())),
+                )
+                .await
+        );
+
+        let loaded = sessions::load_session(&store_path, &session_id).unwrap();
+        assert_eq!(loaded.token_usages.len(), 1);
+        let persisted = loaded.token_usages[0]
+            .as_ref()
+            .expect("token usage should be persisted");
+        assert_eq!(persisted.input_tokens, 500);
+        assert_eq!(persisted.output_tokens, 120);
+        assert_eq!(persisted.cache_read_tokens, 80);
+        assert_eq!(persisted.cache_write_tokens, 15);
+        assert_eq!(persisted.total_tokens, 715);
+
+        // Frontend snapshot should expose the usage
+        let frontend = parts.service.frontend_snapshot().await.unwrap();
+        assert_eq!(
+            frontend
+                .response_timing
+                .last_token_usage
+                .as_ref()
+                .unwrap()
+                .total_tokens,
+            715
+        );
+        assert_eq!(
+            frontend
+                .response_timing
+                .token_usages
+                .as_ref()
+                .unwrap()
+                .len(),
+            1
+        );
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
@@ -1242,7 +1398,7 @@ mod tests {
         assert!(
             parts
                 .service
-                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string()))
+                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string(), None))
                 .await
         );
         let started = events.recv().await.unwrap();
@@ -1449,7 +1605,7 @@ mod tests {
 
         parts
             .service
-            .persist_run_snapshot(&finishing.snapshot, Some(42))
+            .persist_run_snapshot(&finishing.snapshot, Some(42), None)
             .await
             .unwrap();
 
@@ -1518,7 +1674,7 @@ mod tests {
         assert!(
             parts
                 .service
-                .finish_run_once(&first.run_id, RunOutcome::Completed("done".to_string()))
+                .finish_run_once(&first.run_id, RunOutcome::Completed("done".to_string(), None))
                 .await
         );
         let completion = events.recv().await.unwrap();
@@ -1539,7 +1695,7 @@ mod tests {
                 .service
                 .finish_run_once(
                     &first.run_id,
-                    RunOutcome::Completed("duplicate".to_string())
+                    RunOutcome::Completed("duplicate".to_string(), None)
                 )
                 .await
         );
@@ -1750,7 +1906,7 @@ mod tests {
         assert!(
             parts
                 .service
-                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string()))
+                .finish_run_once(&active.run_id, RunOutcome::Completed("done".to_string(), None))
                 .await
         );
         let started = events.recv().await.unwrap();

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -395,6 +395,23 @@ impl SessionService {
             .map(|active_run| active_run.snapshot.clone())
     }
 
+    /// Explicitly destroy the sandbox (if any) associated with this session.
+    /// Best-effort: errors are logged but not propagated.  This is used
+    /// during session deletion to ensure the container/VM is torn down
+    /// even if other `Arc` references (e.g. from SSE handlers) keep the
+    /// `SessionService` alive.
+    pub async fn destroy_sandbox(&self) {
+        let sandbox = {
+            let agent = self.agent.lock().await;
+            agent.sandbox_session()
+        };
+        if let Some(sandbox) = sandbox {
+            if let Err(error) = sandbox.destroy().await {
+                eprintln!("nac: failed to destroy sandbox during deletion: {error:#}");
+            }
+        }
+    }
+
     pub async fn active_thread_names(&self) -> Vec<String> {
         let mut names = self
             .active_threads

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -37,6 +37,14 @@ pub struct SessionMetadata {
     pub session_id: Option<String>,
     pub sandbox_status: String,
     pub agents_md_status: String,
+    #[serde(default)]
+    pub base_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key_env: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra_headers: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -283,6 +291,13 @@ impl SessionService {
             session_id,
             sandbox_status: run_config.sandbox_status,
             agents_md_status: run_config.agents_md_status,
+            base_url: run_config.client.base_url().to_string(),
+            reasoning_effort: run_config
+                .client
+                .reasoning_effort()
+                .map(|effort| effort.as_str().to_string()),
+            api_key_env: run_config.client.api_key_env().map(str::to_string),
+            extra_headers: run_config.client.extra_headers().clone(),
         };
         let session_snapshot = run_config.session.into_snapshot();
         let active_threads = run_config.agent.active_threads_handle();

--- a/crates/nac-core/src/sessions/codec.rs
+++ b/crates/nac-core/src/sessions/codec.rs
@@ -11,6 +11,10 @@ struct PersistedSandboxSpec {
     gpu_devices: Vec<String>,
     #[serde(default = "default_sandbox_shm_size")]
     shm_size: Option<String>,
+    #[serde(default = "default_cpus")]
+    cpus: u8,
+    #[serde(default = "default_memory_mib")]
+    memory_mib: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,6 +26,14 @@ struct PersistedMountSpec {
 
 fn default_sandbox_shm_size() -> Option<String> {
     Some("0".to_string())
+}
+
+fn default_cpus() -> u8 {
+    2
+}
+
+fn default_memory_mib() -> u32 {
+    2048
 }
 
 pub(super) fn serialize_sandbox(spec: &SandboxSpec) -> Result<String> {
@@ -40,6 +52,8 @@ pub(super) fn serialize_sandbox(spec: &SandboxSpec) -> Result<String> {
             .collect(),
         gpu_devices: spec.gpu_devices.clone(),
         shm_size: spec.shm_size.clone(),
+        cpus: spec.cpus,
+        memory_mib: spec.memory_mib,
     };
     serde_json::to_string(&persisted).context("failed to serialize sandbox spec")
 }
@@ -65,5 +79,7 @@ pub(super) fn deserialize_sandbox(raw: Option<String>) -> Result<Option<SandboxS
             .collect(),
         gpu_devices: persisted.gpu_devices,
         shm_size: persisted.shm_size,
+        cpus: persisted.cpus,
+        memory_mib: persisted.memory_mib,
     }))
 }

--- a/crates/nac-core/src/sessions/codec.rs
+++ b/crates/nac-core/src/sessions/codec.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[derive(Debug, Serialize, Deserialize)]
 struct PersistedSandboxSpec {
+    #[serde(default)]
+    backend: SandboxBackendType,
     image: String,
     workdir: String,
     mounts: Vec<PersistedMountSpec>,
@@ -24,6 +26,7 @@ fn default_sandbox_shm_size() -> Option<String> {
 
 pub(super) fn serialize_sandbox(spec: &SandboxSpec) -> Result<String> {
     let persisted = PersistedSandboxSpec {
+        backend: spec.backend,
         image: spec.image.clone(),
         workdir: spec.workdir.display().to_string(),
         mounts: spec
@@ -48,6 +51,7 @@ pub(super) fn deserialize_sandbox(raw: Option<String>) -> Result<Option<SandboxS
     let persisted: PersistedSandboxSpec =
         serde_json::from_str(&raw).context("failed to parse sandbox spec")?;
     Ok(Some(SandboxSpec {
+        backend: persisted.backend,
         image: persisted.image,
         workdir: PathBuf::from(persisted.workdir),
         mounts: persisted

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -71,6 +71,35 @@ pub fn load_last_session(path: &Path) -> Result<SessionSnapshot> {
     row.into_snapshot()
 }
 
+pub fn delete_session(path: &Path, session_id: &str) -> Result<bool> {
+    let mut conn = crate::store::open_connection(path)?;
+    let tx = conn.transaction()?;
+    // Delete child tables before parent tables to respect FK constraints:
+    // episodes → threads, workset_items → worksets.
+    tx.execute(
+        "DELETE FROM episodes WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    tx.execute(
+        "DELETE FROM workset_items WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    tx.execute(
+        "DELETE FROM threads WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    tx.execute(
+        "DELETE FROM worksets WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    let deleted = tx.execute(
+        "DELETE FROM sessions WHERE session_id = ?1",
+        params![session_id],
+    )?;
+    tx.commit()?;
+    Ok(deleted > 0)
+}
+
 fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
     Ok(SessionRow {
         session_id: row.get(0)?,

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -36,7 +36,7 @@ pub fn load_session(path: &Path, session_id: &str) -> Result<SessionSnapshot> {
     let conn = crate::store::open_connection(path)?;
     let row = conn
         .query_row(
-            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
+            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json, token_usages_json
              FROM sessions
              WHERE session_id = ?1",
             params![session_id],
@@ -55,7 +55,7 @@ pub fn load_last_session(path: &Path) -> Result<SessionSnapshot> {
     let conn = crate::store::open_connection(path)?;
     let row = conn
         .query_row(
-            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
+            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json, token_usages_json
              FROM sessions
              ORDER BY updated_at DESC, created_at DESC
              LIMIT 1",
@@ -118,6 +118,7 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
         ssh_host: row.get(13)?,
         api_key_env: row.get(14)?,
         extra_headers_json: row.get(15)?,
+        token_usages_json: row.get(16)?,
     })
 }
 
@@ -215,14 +216,20 @@ fn insert_or_replace_session(
         Some(serde_json::to_string(&snapshot.extra_headers)
             .context("failed to serialize session extra_headers")?)
     };
+    let token_usages_json = if snapshot.token_usages.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&snapshot.token_usages)
+            .context("failed to serialize session token usages")?)
+    };
 
     // The legacy `store_path` column is kept physically (NOT NULL in existing
     // stores) but is informational only: it records the store that was
     // actually opened for this write and is never read back.
     tx.execute(
         "INSERT INTO sessions (
-             session_id, cwd, store_path, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+             session_id, cwd, store_path, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json, token_usages_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
          ON CONFLICT(session_id) DO UPDATE SET
              cwd = excluded.cwd,
              store_path = excluded.store_path,
@@ -238,7 +245,8 @@ fn insert_or_replace_session(
              updated_at = excluded.updated_at,
              host_id = excluded.host_id,
              api_key_env = excluded.api_key_env,
-             extra_headers_json = excluded.extra_headers_json",
+             extra_headers_json = excluded.extra_headers_json,
+             token_usages_json = excluded.token_usages_json",
         params![
             snapshot.session_id,
             snapshot.cwd.display().to_string(),
@@ -257,6 +265,7 @@ fn insert_or_replace_session(
             snapshot.ssh_host,
             snapshot.api_key_env,
             extra_headers_json,
+            token_usages_json,
         ],
     )?;
     Ok(())
@@ -279,6 +288,7 @@ struct SessionRow {
     ssh_host: Option<String>,
     api_key_env: Option<String>,
     extra_headers_json: Option<String>,
+    token_usages_json: Option<String>,
 }
 
 impl SessionRow {
@@ -304,6 +314,16 @@ impl SessionRow {
             })
             .transpose()?
             .unwrap_or_default();
+        let token_usages = self
+            .token_usages_json
+            .as_deref()
+            .filter(|json| !json.is_empty())
+            .map(|json| {
+                serde_json::from_str::<Vec<Option<crate::model::TokenUsage>>>(json)
+                    .context("failed to parse stored session token usages")
+            })
+            .transpose()?
+            .unwrap_or_default();
         Ok(SessionSnapshot {
             session_id: self.session_id,
             cwd: PathBuf::from(self.cwd),
@@ -319,6 +339,7 @@ impl SessionRow {
             last_response_duration_ms: self.last_response_duration_ms,
             previous_response_duration_ms: self.previous_response_duration_ms,
             response_durations_ms,
+            token_usages,
             created_at: self.created_at,
             updated_at: self.updated_at,
         })

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -36,7 +36,7 @@ pub fn load_session(path: &Path, session_id: &str) -> Result<SessionSnapshot> {
     let conn = crate::store::open_connection(path)?;
     let row = conn
         .query_row(
-            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id
+            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
              FROM sessions
              WHERE session_id = ?1",
             params![session_id],
@@ -55,7 +55,7 @@ pub fn load_last_session(path: &Path) -> Result<SessionSnapshot> {
     let conn = crate::store::open_connection(path)?;
     let row = conn
         .query_row(
-            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id
+            "SELECT session_id, cwd, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
              FROM sessions
              ORDER BY updated_at DESC, created_at DESC
              LIMIT 1",
@@ -87,6 +87,8 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
         created_at: row.get(11)?,
         updated_at: row.get(12)?,
         ssh_host: row.get(13)?,
+        api_key_env: row.get(14)?,
+        extra_headers_json: row.get(15)?,
     })
 }
 
@@ -178,14 +180,20 @@ fn insert_or_replace_session(
         .map(serde_json::to_string)
         .transpose()
         .context("failed to serialize session response durations")?;
+    let extra_headers_json = if snapshot.extra_headers.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&snapshot.extra_headers)
+            .context("failed to serialize session extra_headers")?)
+    };
 
     // The legacy `store_path` column is kept physically (NOT NULL in existing
     // stores) but is informational only: it records the store that was
     // actually opened for this write and is never read back.
     tx.execute(
         "INSERT INTO sessions (
-             session_id, cwd, store_path, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+             session_id, cwd, store_path, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
          ON CONFLICT(session_id) DO UPDATE SET
              cwd = excluded.cwd,
              store_path = excluded.store_path,
@@ -199,7 +207,9 @@ fn insert_or_replace_session(
              previous_response_duration_ms = excluded.previous_response_duration_ms,
              response_durations_ms_json = excluded.response_durations_ms_json,
              updated_at = excluded.updated_at,
-             host_id = excluded.host_id",
+             host_id = excluded.host_id,
+             api_key_env = excluded.api_key_env,
+             extra_headers_json = excluded.extra_headers_json",
         params![
             snapshot.session_id,
             snapshot.cwd.display().to_string(),
@@ -216,6 +226,8 @@ fn insert_or_replace_session(
             snapshot.created_at,
             snapshot.updated_at,
             snapshot.ssh_host,
+            snapshot.api_key_env,
+            extra_headers_json,
         ],
     )?;
     Ok(())
@@ -236,6 +248,8 @@ struct SessionRow {
     created_at: String,
     updated_at: String,
     ssh_host: Option<String>,
+    api_key_env: Option<String>,
+    extra_headers_json: Option<String>,
 }
 
 impl SessionRow {
@@ -251,6 +265,16 @@ impl SessionRow {
             .transpose()?;
         let base_url = self.base_url;
         let backend = parse_backend(self.backend, &base_url)?;
+        let extra_headers = self
+            .extra_headers_json
+            .as_deref()
+            .filter(|json| !json.is_empty())
+            .map(|json| {
+                serde_json::from_str::<BTreeMap<String, String>>(json)
+                    .context("failed to parse stored session extra_headers")
+            })
+            .transpose()?
+            .unwrap_or_default();
         Ok(SessionSnapshot {
             session_id: self.session_id,
             cwd: PathBuf::from(self.cwd),
@@ -260,6 +284,8 @@ impl SessionRow {
             reasoning_effort: parse_reasoning_effort(self.reasoning_effort)?,
             sandbox_spec: deserialize_sandbox(self.sandbox_json)?,
             ssh_host: self.ssh_host,
+            api_key_env: self.api_key_env,
+            extra_headers,
             messages,
             last_response_duration_ms: self.last_response_duration_ms,
             previous_response_duration_ms: self.previous_response_duration_ms,

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -6,7 +6,7 @@ use rusqlite::{params, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::model::{detect_backend, BackendKind, ReasoningEffort};
-use crate::sandbox::SandboxSpec;
+use crate::sandbox::{SandboxBackendType, SandboxSpec};
 use crate::types::Message;
 
 mod codec;
@@ -410,6 +410,7 @@ mod tests {
             BackendKind::FireworksChat,
             None,
             Some(SandboxSpec {
+                backend: SandboxBackendType::Podman,
                 image: "python:3.13".to_string(),
                 workdir: PathBuf::from("/workspace"),
                 mounts: Vec::new(),

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
@@ -31,6 +32,12 @@ pub struct SessionSnapshot {
     pub sandbox_spec: Option<SandboxSpec>,
     /// OpenSSH target for remote sessions; `None` for local sessions.
     pub ssh_host: Option<String>,
+    /// Env var name used to resolve the API key at session creation time.
+    /// Stored per-session so resume uses the same key source, not current config.
+    pub api_key_env: Option<String>,
+    /// Custom HTTP headers captured at session creation time.
+    /// Stored per-session so resume uses the same headers, not current config.
+    pub extra_headers: BTreeMap<String, String>,
     pub messages: Vec<Message>,
     pub last_response_duration_ms: Option<u64>,
     pub previous_response_duration_ms: Option<u64>,
@@ -88,6 +95,8 @@ mod tests {
             vec![Message::User {
                 content: "hello".to_string(),
             }],
+        None,
+        BTreeMap::new(),
         );
         snapshot.last_response_duration_ms = Some(12_345);
         snapshot.previous_response_duration_ms = Some(6_789);
@@ -264,6 +273,8 @@ mod tests {
             vec![Message::User {
                 content: "hello".to_string(),
             }],
+        None,
+        BTreeMap::new(),
         );
         create_session(&store_path, &snapshot).unwrap();
 
@@ -307,6 +318,8 @@ mod tests {
             None,
             None,
             Vec::new(),
+        None,
+        BTreeMap::new(),
         );
         create_session(&store_path, &first).unwrap();
 
@@ -322,6 +335,8 @@ mod tests {
             vec![Message::User {
                 content: "latest".to_string(),
             }],
+        None,
+        BTreeMap::new(),
         );
         save_session(&store_path, &second).unwrap();
 
@@ -353,6 +368,8 @@ mod tests {
                     content: "first prompt".to_string(),
                 },
             ],
+        None,
+        BTreeMap::new(),
         );
         create_session(&store_path, &first).unwrap();
 
@@ -385,6 +402,8 @@ mod tests {
                     tool_calls: None,
                 },
             ],
+        None,
+        BTreeMap::new(),
         );
         save_session(&store_path, &second).unwrap();
 
@@ -397,6 +416,125 @@ mod tests {
             Some("latest prompt")
         );
         assert!(sessions[0].sandboxed);
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[test]
+    fn api_key_env_and_extra_headers_round_trip_through_store() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let store_path = temp_store_path("api_key_env_headers");
+
+        let mut headers = BTreeMap::new();
+        headers.insert("X-Custom-Header".to_string(), "custom-value".to_string());
+        headers.insert("X-Org".to_string(), "my-org".to_string());
+
+        let snapshot = new_snapshot(
+            "session-config".to_string(),
+            PathBuf::from("/repo"),
+            "model-a".to_string(),
+            "https://api.openai.com/v1".to_string(),
+            BackendKind::OpenAiResponses,
+            None,
+            None,
+            None,
+            vec![Message::User {
+                content: "hello".to_string(),
+            }],
+            Some("MY_CUSTOM_API_KEY".to_string()),
+            headers.clone(),
+        );
+        create_session(&store_path, &snapshot).unwrap();
+
+        let loaded = load_session(&store_path, "session-config").unwrap();
+        assert_eq!(
+            loaded.api_key_env.as_deref(),
+            Some("MY_CUSTOM_API_KEY"),
+            "api_key_env must round-trip through the DB"
+        );
+        assert_eq!(
+            loaded.extra_headers, headers,
+            "extra_headers must round-trip through the DB"
+        );
+
+        // refresh_snapshot must preserve api_key_env and extra_headers
+        let refreshed = refresh_snapshot(&loaded, loaded.messages.clone(), None, None, None);
+        assert_eq!(refreshed.api_key_env.as_deref(), Some("MY_CUSTOM_API_KEY"));
+        assert_eq!(refreshed.extra_headers, headers);
+        save_session(&store_path, &refreshed).unwrap();
+
+        let reloaded = load_session(&store_path, "session-config").unwrap();
+        assert_eq!(reloaded.api_key_env.as_deref(), Some("MY_CUSTOM_API_KEY"));
+        assert_eq!(reloaded.extra_headers, headers);
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[test]
+    fn legacy_session_without_api_key_env_loads_with_defaults() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let store_path = temp_store_path("legacy_no_api_key_env");
+        std::fs::create_dir_all(store_path.parent().unwrap()).unwrap();
+        let messages_json = serde_json::to_string(&vec![Message::User {
+            content: "hello".to_string(),
+        }])
+        .unwrap();
+
+        {
+            let conn = rusqlite::Connection::open(&store_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY,
+                    cwd TEXT NOT NULL,
+                    store_path TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    base_url TEXT NOT NULL,
+                    backend TEXT,
+                    reasoning_effort TEXT,
+                    sandbox_json TEXT,
+                    messages_json TEXT NOT NULL,
+                    last_response_duration_ms INTEGER,
+                    previous_response_duration_ms INTEGER,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions (
+                    session_id, cwd, store_path, model, base_url, backend, reasoning_effort,
+                    sandbox_json, messages_json, last_response_duration_ms,
+                    previous_response_duration_ms, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                rusqlite::params![
+                    "legacy-session",
+                    "/repo",
+                    store_path.display().to_string(),
+                    "model-a",
+                    "https://api.openai.com/v1",
+                    "openai-responses",
+                    Option::<String>::None,
+                    Option::<String>::None,
+                    messages_json,
+                    12_345_u64,
+                    6_789_u64,
+                    "2026-01-01 00:00:00.000000000",
+                    "2026-01-01 00:00:01.000000000",
+                ],
+            )
+            .unwrap();
+        }
+
+        // load_session goes through open_connection which runs migrations
+        let loaded = load_session(&store_path, "legacy-session").unwrap();
+        assert_eq!(
+            loaded.api_key_env, None,
+            "legacy rows without api_key_env column load as None"
+        );
+        assert!(
+            loaded.extra_headers.is_empty(),
+            "legacy rows without extra_headers_json column load as empty map"
+        );
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -416,6 +416,8 @@ mod tests {
                 mounts: Vec::new(),
                 gpu_devices: Vec::new(),
                 shm_size: Some("0".to_string()),
+                cpus: 2,
+                memory_mib: 2048,
             }),
             None,
             vec![

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -42,6 +42,8 @@ pub struct SessionSnapshot {
     pub last_response_duration_ms: Option<u64>,
     pub previous_response_duration_ms: Option<u64>,
     pub response_durations_ms: Option<Vec<Option<u64>>>,
+    /// Per-response token usage, one entry per assistant response (in order).
+    pub token_usages: Vec<Option<crate::model::TokenUsage>>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -101,6 +103,23 @@ mod tests {
         snapshot.last_response_duration_ms = Some(12_345);
         snapshot.previous_response_duration_ms = Some(6_789);
         snapshot.response_durations_ms = Some(vec![Some(1_000), None, Some(12_345)]);
+        snapshot.token_usages = vec![
+            Some(crate::model::TokenUsage {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: 20,
+                cache_write_tokens: 0,
+                total_tokens: 150,
+            }),
+            None,
+            Some(crate::model::TokenUsage {
+                input_tokens: 200,
+                output_tokens: 80,
+                cache_read_tokens: 40,
+                cache_write_tokens: 10,
+                total_tokens: 330,
+            }),
+        ];
         create_session(&store_path, &snapshot).unwrap();
         let loaded = load_session(&store_path, "session-1").unwrap();
         assert_eq!(loaded.session_id, "session-1");
@@ -112,6 +131,11 @@ mod tests {
             loaded.response_durations_ms,
             Some(vec![Some(1_000), None, Some(12_345)])
         );
+        assert_eq!(loaded.token_usages.len(), 3);
+        assert_eq!(loaded.token_usages[0].as_ref().unwrap().input_tokens, 100);
+        assert_eq!(loaded.token_usages[0].as_ref().unwrap().output_tokens, 50);
+        assert!(loaded.token_usages[1].is_none());
+        assert_eq!(loaded.token_usages[2].as_ref().unwrap().total_tokens, 330);
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
@@ -176,6 +200,10 @@ mod tests {
         assert_eq!(loaded.last_response_duration_ms, Some(12_345));
         assert_eq!(loaded.previous_response_duration_ms, Some(6_789));
         assert_eq!(loaded.response_durations_ms, None);
+        assert!(
+            loaded.token_usages.is_empty(),
+            "legacy rows without token_usages_json column load as empty Vec"
+        );
         assert_eq!(
             loaded.ssh_host, None,
             "legacy rows without a host_id column load as local sessions"
@@ -229,6 +257,7 @@ mod tests {
             None,
             None,
             None,
+            loaded.token_usages.clone(),
         );
         save_session(&store_path, &refreshed).unwrap();
 
@@ -281,7 +310,7 @@ mod tests {
         let loaded = load_session(&store_path, "session-remote").unwrap();
         assert_eq!(loaded.ssh_host.as_deref(), Some("build-box"));
 
-        let refreshed = refresh_snapshot(&loaded, loaded.messages.clone(), None, None, None);
+        let refreshed = refresh_snapshot(&loaded, loaded.messages.clone(), None, None, None, loaded.token_usages.clone());
         assert_eq!(refreshed.ssh_host.as_deref(), Some("build-box"));
         save_session(&store_path, &refreshed).unwrap();
         assert_eq!(
@@ -458,7 +487,7 @@ mod tests {
         );
 
         // refresh_snapshot must preserve api_key_env and extra_headers
-        let refreshed = refresh_snapshot(&loaded, loaded.messages.clone(), None, None, None);
+        let refreshed = refresh_snapshot(&loaded, loaded.messages.clone(), None, None, None, loaded.token_usages.clone());
         assert_eq!(refreshed.api_key_env.as_deref(), Some("MY_CUSTOM_API_KEY"));
         assert_eq!(refreshed.extra_headers, headers);
         save_session(&store_path, &refreshed).unwrap();

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -14,7 +14,7 @@ mod db;
 mod snapshot;
 mod summary;
 
-pub use db::{create_session, list_sessions, load_last_session, load_session, save_session};
+pub use db::{create_session, delete_session, list_sessions, load_last_session, load_session, save_session};
 pub use snapshot::{new_snapshot, refresh_snapshot};
 
 use codec::*;
@@ -535,6 +535,87 @@ mod tests {
             loaded.extra_headers.is_empty(),
             "legacy rows without extra_headers_json column load as empty map"
         );
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[test]
+    fn delete_session_cascades_to_threads_episodes_and_worksets() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let store_path = temp_store_path("delete_cascade");
+
+        // Create a session
+        let snapshot = new_snapshot(
+            "session-del".to_string(),
+            PathBuf::from("/repo"),
+            "model-a".to_string(),
+            "https://api.openai.com/v1".to_string(),
+            BackendKind::OpenAiResponses,
+            None,
+            None,
+            None,
+            vec![Message::User {
+                content: "hello".to_string(),
+            }],
+            None,
+            BTreeMap::new(),
+        );
+        create_session(&store_path, &snapshot).unwrap();
+
+        // Add threads with episodes
+        crate::store::append_episode(
+            &store_path,
+            "session-del",
+            "auth",
+            "inspect",
+            "auth episode",
+        )
+        .unwrap();
+        crate::store::append_episode(
+            &store_path,
+            "session-del",
+            "tests",
+            "scan",
+            "test episode",
+        )
+        .unwrap();
+
+        // Add a workset with items
+        let workset = crate::store::WorksetDefinition {
+            id: "ws-1".to_string(),
+            goal: "refresh".to_string(),
+            status: "planned".to_string(),
+            summary: "summary".to_string(),
+            verification_recipe: None,
+            items: vec![crate::store::WorksetItemDefinition {
+                title: "item-1".to_string(),
+                scope: "src/main.rs".to_string(),
+                description: "do thing".to_string(),
+                role: "implement".to_string(),
+                depends_on: Vec::new(),
+                acceptance: "done".to_string(),
+                notes: None,
+            }],
+        };
+        crate::store::define_workset(&store_path, "session-del", &workset).unwrap();
+
+        // Verify data exists
+        assert!(!crate::store::list_threads(&store_path, "session-del").unwrap().is_empty());
+        assert!(crate::store::list_worksets(&store_path, "session-del").unwrap().len() == 1);
+        assert!(list_sessions(&store_path).unwrap().len() == 1);
+
+        // Delete the session
+        let deleted = delete_session(&store_path, "session-del").unwrap();
+        assert!(deleted, "delete_session should return true for existing session");
+
+        // Verify all related rows are gone
+        assert!(crate::store::list_threads(&store_path, "session-del").unwrap().is_empty());
+        assert!(crate::store::list_worksets(&store_path, "session-del").unwrap().is_empty());
+        assert!(list_sessions(&store_path).unwrap().is_empty());
+
+        // Deleting a non-existent session returns false
+        let deleted_again = delete_session(&store_path, "session-del").unwrap();
+        assert!(!deleted_again, "delete_session should return false for missing session");
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }

--- a/crates/nac-core/src/sessions/snapshot.rs
+++ b/crates/nac-core/src/sessions/snapshot.rs
@@ -81,6 +81,7 @@ pub fn new_snapshot(
         last_response_duration_ms: None,
         previous_response_duration_ms: None,
         response_durations_ms: None,
+        token_usages: Vec::new(),
         created_at: now.clone(),
         updated_at: now,
     }
@@ -92,6 +93,7 @@ pub fn refresh_snapshot(
     last_response_duration_ms: Option<u64>,
     previous_response_duration_ms: Option<u64>,
     response_durations_ms: Option<Vec<Option<u64>>>,
+    token_usages: Vec<Option<crate::model::TokenUsage>>,
 ) -> SessionSnapshot {
     SessionSnapshot {
         session_id: snapshot.session_id.clone(),
@@ -108,6 +110,7 @@ pub fn refresh_snapshot(
         last_response_duration_ms,
         previous_response_duration_ms,
         response_durations_ms,
+        token_usages,
         created_at: snapshot.created_at.clone(),
         updated_at: now_utc(),
     }

--- a/crates/nac-core/src/sessions/snapshot.rs
+++ b/crates/nac-core/src/sessions/snapshot.rs
@@ -62,6 +62,8 @@ pub fn new_snapshot(
     sandbox_spec: Option<SandboxSpec>,
     ssh_host: Option<String>,
     messages: Vec<Message>,
+    api_key_env: Option<String>,
+    extra_headers: BTreeMap<String, String>,
 ) -> SessionSnapshot {
     let now = now_utc();
     SessionSnapshot {
@@ -73,6 +75,8 @@ pub fn new_snapshot(
         reasoning_effort,
         sandbox_spec,
         ssh_host,
+        api_key_env,
+        extra_headers,
         messages,
         last_response_duration_ms: None,
         previous_response_duration_ms: None,
@@ -98,6 +102,8 @@ pub fn refresh_snapshot(
         reasoning_effort: snapshot.reasoning_effort,
         sandbox_spec: snapshot.sandbox_spec.clone(),
         ssh_host: snapshot.ssh_host.clone(),
+        api_key_env: snapshot.api_key_env.clone(),
+        extra_headers: snapshot.extra_headers.clone(),
         messages,
         last_response_duration_ms,
         previous_response_duration_ms,

--- a/crates/nac-core/src/skills/discovery.rs
+++ b/crates/nac-core/src/skills/discovery.rs
@@ -44,7 +44,8 @@ pub(super) fn discover_skill_sources(
     }
 
     sources.sort_by_key(|source| source.precedence);
-    sources.dedup_by(|a, b| a.host_root == b.host_root);
+    let mut seen = std::collections::HashSet::new();
+    sources.retain(|source| seen.insert(source.host_root.clone()));
     Ok(sources)
 }
 

--- a/crates/nac-core/src/skills/mod.rs
+++ b/crates/nac-core/src/skills/mod.rs
@@ -193,6 +193,8 @@ mod tests {
             workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
             gpu_devices: Vec::new(),
             shm_size: Some("0".to_string()),
+            cpus: 2,
+            memory_mib: 2048,
         });
 
         let registry = SkillRegistry::load(Some(&repo), Some(&sandbox), &PathContext::new(&repo))

--- a/crates/nac-core/src/skills/mod.rs
+++ b/crates/nac-core/src/skills/mod.rs
@@ -176,6 +176,7 @@ mod tests {
         let skill_dir = write_skill(&project_skills, "lint", "lint code", "body");
 
         let sandbox = SandboxSession::new_for_test(SandboxSpec {
+            backend: crate::sandbox::SandboxBackendType::Podman,
             image: DEFAULT_SANDBOX_IMAGE.to_string(),
             mounts: vec![
                 MountSpec {

--- a/crates/nac-core/src/skills/mod.rs
+++ b/crates/nac-core/src/skills/mod.rs
@@ -286,6 +286,28 @@ mod tests {
     }
 
     #[test]
+    fn cwd_equals_home_produces_no_duplicate_sources() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = temp_dir("cwd_eq_home");
+        let _env = isolate_user_skill_env(&root);
+        // Use the isolated home directory as both workspace and home.
+        // No .git inside, so find_project_root falls back to workspace_dir == home.
+        let home = root.join("home");
+        fs::create_dir_all(home.join(".agents/skills")).unwrap();
+        write_skill(&home.join(".agents/skills"), "demo", "demo skill", "body");
+
+        let sources = discover_skill_sources(Some(&home), &PathContext::new(&home)).unwrap();
+        let mut seen = std::collections::HashSet::new();
+        for source in &sources {
+            assert!(
+                seen.insert(source.host_root.clone()),
+                "duplicate host_root: {}",
+                source.host_root.display()
+            );
+        }
+    }
+
+    #[test]
     fn frontmatter_repairs_colons_and_ignores_disable_model_invocation() {
         let frontmatter = "name: lint\ndescription: Use when handling foo:bar tasks\ndisable-model-invocation: true\n";
         let parsed = parse_frontmatter(frontmatter).unwrap();

--- a/crates/nac-core/src/store/schema.rs
+++ b/crates/nac-core/src/store/schema.rs
@@ -81,6 +81,8 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
              last_response_duration_ms INTEGER,
              previous_response_duration_ms INTEGER,
              response_durations_ms_json TEXT,
+             api_key_env TEXT,
+             extra_headers_json TEXT,
              created_at TEXT NOT NULL,
              updated_at TEXT NOT NULL
          );
@@ -105,6 +107,8 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     )?;
     ensure_column(&conn, "sessions", "response_durations_ms_json", "TEXT")?;
     ensure_column(&conn, "sessions", "host_id", "TEXT")?;
+    ensure_column(&conn, "sessions", "api_key_env", "TEXT")?;
+    ensure_column(&conn, "sessions", "extra_headers_json", "TEXT")?;
     Ok(conn)
 }
 

--- a/crates/nac-core/src/store/schema.rs
+++ b/crates/nac-core/src/store/schema.rs
@@ -83,6 +83,7 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
              response_durations_ms_json TEXT,
              api_key_env TEXT,
              extra_headers_json TEXT,
+             token_usages_json TEXT,
              created_at TEXT NOT NULL,
              updated_at TEXT NOT NULL
          );
@@ -109,6 +110,7 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     ensure_column(&conn, "sessions", "host_id", "TEXT")?;
     ensure_column(&conn, "sessions", "api_key_env", "TEXT")?;
     ensure_column(&conn, "sessions", "extra_headers_json", "TEXT")?;
+    ensure_column(&conn, "sessions", "token_usages_json", "TEXT")?;
     Ok(conn)
 }
 

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -376,6 +376,8 @@ mod tests {
             workdir: DEFAULT_SANDBOX_WORKDIR.into(),
             gpu_devices: Vec::new(),
             shm_size: None,
+            cpus: 2,
+            memory_mib: 2048,
         });
 
         let envs = terminal_env_owned();

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -370,6 +370,7 @@ mod tests {
     #[test]
     fn terminal_pipe_command_delegates_to_sandbox_session() {
         let sandbox = SandboxSession::new_for_test(SandboxSpec {
+            backend: crate::sandbox::SandboxBackendType::Podman,
             image: DEFAULT_SANDBOX_IMAGE.to_string(),
             mounts: Vec::new(),
             workdir: DEFAULT_SANDBOX_WORKDIR.into(),

--- a/crates/nac-core/src/tools/edit.rs
+++ b/crates/nac-core/src/tools/edit.rs
@@ -192,6 +192,7 @@ mod tests {
             skills: None,
             terminal_manager: crate::terminal::TerminalManager::new(),
             thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
         }
     }
 

--- a/crates/nac-core/src/tools/exec_command.rs
+++ b/crates/nac-core/src/tools/exec_command.rs
@@ -209,6 +209,7 @@ mod tests {
             skills: None,
             terminal_manager: crate::terminal::TerminalManager::new(),
             thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
         }
     }
 

--- a/crates/nac-core/src/tools/mod.rs
+++ b/crates/nac-core/src/tools/mod.rs
@@ -39,6 +39,11 @@ pub struct ToolRuntime {
     pub skills: Option<Arc<SkillRegistry>>,
     pub terminal_manager: TerminalManager,
     pub thread_timeout_secs: u64,
+    /// Accumulated worker token usage from thread dispatches.  The agent
+    /// loop reads and resets this after each tool-execution round so worker
+    /// API costs are included in the session totals.  `total_tokens` is
+    /// intentionally NOT accumulated here — it stays orchestrator-only.
+    pub worker_usage: Arc<Mutex<crate::model::TokenUsage>>,
 }
 
 static WRITE_LOCK: Mutex<()> = Mutex::const_new(());

--- a/crates/nac-core/src/tools/read.rs
+++ b/crates/nac-core/src/tools/read.rs
@@ -185,6 +185,7 @@ mod tests {
             skills: None,
             terminal_manager: crate::terminal::TerminalManager::new(),
             thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
         }
     }
 

--- a/crates/nac-core/src/tools/thread.rs
+++ b/crates/nac-core/src/tools/thread.rs
@@ -641,11 +641,10 @@ async fn run_worker(
         command.arg("--api-key-env").arg(api_key_env);
     }
 
-    let extra_headers = client.extra_headers();
-    if !extra_headers.is_empty() {
-        if let Ok(json) = serde_json::to_string(extra_headers) {
-            command.arg("--extra-headers").arg(json);
-        }
+    // Always pass --extra-headers, even when empty, so the worker uses the
+    // session's headers (possibly {}) instead of falling back to config.toml.
+    if let Ok(json) = serde_json::to_string(client.extra_headers()) {
+        command.arg("--extra-headers").arg(json);
     }
 
     for source_thread in invocation.source_threads {

--- a/crates/nac-core/src/tools/thread.rs
+++ b/crates/nac-core/src/tools/thread.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 
 use crate::events::{decode_stderr_event, AgentEvent};
-use crate::model::ModelClient;
+use crate::model::{ModelClient, TokenUsage};
 use crate::process::{isolate_process_group, terminate_child_tree};
 use crate::skills::SkillRegistry;
 use crate::store;
@@ -169,6 +169,18 @@ pub async fn execute_dispatch(
     .await;
     unmark_thread_active(runtime, &thread_name).await;
 
+    // Fold worker token usage into the shared runtime accumulator so the
+    // orchestrator's agent loop can include it in session totals.
+    if let Ok(run) = &result {
+        if let Some(usage) = &run.usage {
+            let mut wu = runtime.worker_usage.lock().await;
+            wu.input_tokens += usage.input_tokens;
+            wu.output_tokens += usage.output_tokens;
+            wu.cache_read_tokens += usage.cache_read_tokens;
+            wu.cache_write_tokens += usage.cache_write_tokens;
+        }
+    }
+
     match result {
         Err(e) => {
             runtime.event_sink.emit(AgentEvent::Error {
@@ -187,6 +199,7 @@ pub async fn execute_dispatch(
                 exit_code: run.exit_code,
                 timed_out: true,
                 timeout_reason: timeout_reason.clone(),
+                usage: run.usage.clone(),
             });
             ToolResult {
                 content: match timeout_reason {
@@ -207,6 +220,7 @@ pub async fn execute_dispatch(
                 exit_code: run.exit_code,
                 timed_out: false,
                 timeout_reason: None,
+                usage: run.usage.clone(),
             });
             let details = if !run.stderr.trim().is_empty() {
                 run.stderr.trim().to_string()
@@ -229,6 +243,7 @@ pub async fn execute_dispatch(
                 exit_code: run.exit_code,
                 timed_out: false,
                 timeout_reason: None,
+                usage: run.usage.clone(),
             });
             ToolResult {
                 content: run.stdout.trim().to_string(),
@@ -451,6 +466,7 @@ struct WorkerRun {
     exit_code: i32,
     timed_out: bool,
     timeout_reason: Option<String>,
+    usage: Option<TokenUsage>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -642,9 +658,16 @@ async fn run_worker(
         let reader = BufReader::new(stderr);
         let mut lines = reader.lines();
         let mut output = String::new();
+        let mut worker_usage = TokenUsage::default();
         while let Ok(Some(line)) = lines.next_line().await {
             if let Some(event) = decode_stderr_event(&line) {
                 timeout_trace_for_logs.lock().await.observe(&event);
+                if let AgentEvent::AssistantMessage {
+                    usage: Some(usage), ..
+                } = &event
+                {
+                    worker_usage += usage.clone();
+                }
                 event_sink.emit(event);
             } else {
                 event_sink.emit(AgentEvent::ThreadLog {
@@ -657,7 +680,16 @@ async fn run_worker(
                 output.push_str(&line);
             }
         }
-        output
+        let usage = if worker_usage.input_tokens == 0
+            && worker_usage.output_tokens == 0
+            && worker_usage.cache_read_tokens == 0
+            && worker_usage.cache_write_tokens == 0
+        {
+            None
+        } else {
+            Some(worker_usage)
+        };
+        (output, usage)
     });
 
     let stdout = child.stdout.take().unwrap();
@@ -680,7 +712,7 @@ async fn run_worker(
         terminate_child_tree(&mut child).await;
     }
 
-    let stderr = stderr_handle.await.unwrap_or_default();
+    let (stderr, worker_usage) = stderr_handle.await.unwrap_or_default();
     let stdout = stdout_handle.await.unwrap_or_default();
     let timeout_reason = if timed_out {
         Some(timeout_trace.lock().await.timeout_reason())
@@ -698,6 +730,7 @@ async fn run_worker(
         exit_code,
         timed_out,
         timeout_reason,
+        usage: worker_usage,
     })
 }
 

--- a/crates/nac-core/src/tools/thread.rs
+++ b/crates/nac-core/src/tools/thread.rs
@@ -637,6 +637,17 @@ async fn run_worker(
         command.arg("--effort").arg(reasoning_effort.as_str());
     }
 
+    if let Some(api_key_env) = client.api_key_env() {
+        command.arg("--api-key-env").arg(api_key_env);
+    }
+
+    let extra_headers = client.extra_headers();
+    if !extra_headers.is_empty() {
+        if let Ok(json) = serde_json::to_string(extra_headers) {
+            command.arg("--extra-headers").arg(json);
+        }
+    }
+
     for source_thread in invocation.source_threads {
         command.arg("--source-thread").arg(source_thread);
     }

--- a/crates/nac-core/src/tools/write.rs
+++ b/crates/nac-core/src/tools/write.rs
@@ -128,6 +128,7 @@ mod tests {
             skills: None,
             terminal_manager: crate::terminal::TerminalManager::new(),
             thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
         }
     }
 

--- a/crates/nac-core/src/view.rs
+++ b/crates/nac-core/src/view.rs
@@ -225,6 +225,10 @@ pub fn list_sessions(store_path: &Path) -> Result<Vec<SessionSummarySnapshot>> {
         .map(|sessions| sessions.into_iter().map(Into::into).collect())
 }
 
+pub fn delete_session(store_path: &Path, session_id: &str) -> Result<bool> {
+    sessions::delete_session(store_path, session_id)
+}
+
 pub fn list_threads(store_path: &Path, session_id: Option<&str>) -> Result<Vec<ThreadSnapshot>> {
     let Some(session_id) = session_id else {
         return Ok(Vec::new());

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -390,6 +390,10 @@ textarea {
   white-space: nowrap;
 }
 
+#snapRun {
+  font-variant-numeric: tabular-nums;
+}
+
 .matrix-toolbar {
   display: flex;
   align-items: center;
@@ -601,6 +605,14 @@ button.session-card {
   white-space: nowrap;
 }
 
+.run-tile {
+  font-variant-numeric: tabular-nums;
+}
+
+.run-tile-active {
+  color: #4fd2a8;
+}
+
 .last-prompt {
   display: -webkit-box;
   height: 30px;
@@ -743,6 +755,22 @@ button.session-card {
 
 .message-role.tool {
   color: #dc767e;
+}
+
+.message-duration {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.message-meta-left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
+.message-meta-sep {
+  color: var(--faint);
 }
 
 .message-body,

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -394,6 +394,11 @@ textarea {
   font-variant-numeric: tabular-nums;
 }
 
+#snapTokens,
+#snapContext {
+  font-variant-numeric: tabular-nums;
+}
+
 .matrix-toolbar {
   display: flex;
   align-items: center;
@@ -659,7 +664,7 @@ button.session-card {
 
 .summary-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: var(--space-sm);
 }
 

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -490,6 +490,38 @@ button.session-card {
   box-shadow: var(--neu-selected);
 }
 
+.session-card.pinned {
+  border-color: rgba(110, 168, 255, 0.22);
+}
+
+.session-card.pinned::after {
+  content: "";
+  position: absolute;
+  bottom: var(--space-xs);
+  right: var(--space-xs);
+  width: 5px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--blue);
+  box-shadow: 0 0 6px rgba(110, 168, 255, 0.5);
+}
+
+.pinned-section-label {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: var(--type-meta);
+  font-weight: var(--type-weight-strong);
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.pinned-separator {
+  grid-column: 1 / -1;
+  height: 1px;
+  background: var(--line-soft);
+}
+
 .session-card {
   position: relative;
 }

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -1226,6 +1226,32 @@ button.session-card {
   box-shadow: var(--neu-sunken-soft);
 }
 
+/* Nested episode panels inside thread-detail — raised from the sunken background */
+.thread-detail .dense-section-title {
+  margin-top: var(--space-md);
+}
+
+.thread-detail .dense-sublist {
+  gap: var(--space-sm);
+}
+
+.thread-detail .dense-subitem {
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.thread-detail .dense-subitem .dense-detail-grid {
+  margin-top: 0;
+}
+
+.thread-detail .dense-subitem .dense-body {
+  margin-top: var(--space-xs);
+  color: var(--text);
+}
+
 .thread-row .dense-title > span:first-child {
   display: inline-flex;
   align-items: center;

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -521,39 +521,6 @@ button.session-card {
   white-space: nowrap;
 }
 
-.meta-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: var(--space-sm);
-  margin-top: var(--space-sm);
-}
-
-.meta-grid div {
-  min-width: 0;
-  border-radius: var(--radius-sm);
-  padding: var(--space-sm);
-  background: var(--bg-sunken);
-  box-shadow: var(--neu-sunken-soft);
-}
-
-.meta-grid span {
-  display: block;
-  color: var(--faint);
-  font-family: var(--mono);
-  font-size: var(--type-label);
-  text-transform: uppercase;
-}
-
-.meta-grid strong {
-  display: block;
-  overflow: hidden;
-  color: var(--text);
-  font-family: var(--mono);
-  font-size: var(--type-meta);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .sandbox-icon {
   display: inline-block;
   width: 12px;

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -485,6 +485,10 @@ button.session-card {
   box-shadow: var(--neu-selected);
 }
 
+.session-card {
+  position: relative;
+}
+
 .session-card-head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -652,6 +656,11 @@ button.session-card {
   align-items: start;
   gap: var(--space-lg);
   min-width: 0;
+}
+
+.inspector-actions {
+  display: flex;
+  gap: var(--space-sm);
 }
 
 .inspector-head h1 {
@@ -1511,6 +1520,19 @@ button.session-card {
   background: var(--panel);
   box-shadow: var(--neu-dialog);
   padding: var(--space-lg);
+}
+
+.launch-dialog--compact {
+  width: min(420px, 100%);
+  max-height: min(320px, calc(100vh - 28px));
+}
+
+.confirm-text {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: var(--type-body);
+  line-height: 1.5;
 }
 
 .launch-dialog-head {

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -1184,6 +1184,48 @@ button.session-card {
   box-shadow: var(--neu-selected);
 }
 
+.thread-block {
+  display: grid;
+  gap: 0;
+}
+
+.thread-row {
+  width: 100%;
+  display: block;
+  text-align: left;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.thread-row:hover,
+.thread-row:focus-visible {
+  box-shadow: var(--neu-pressed), 0 0 0 1px var(--highlight);
+}
+
+.thread-row.expanded {
+  border-color: rgba(255, 255, 255, 0.28);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018)), var(--panel-2);
+  box-shadow: var(--neu-selected);
+}
+
+.thread-row.thread-active.expanded {
+  box-shadow: var(--neu-selected);
+}
+
+.thread-detail {
+  display: grid;
+  gap: var(--space-sm);
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  background: var(--bg-sunken);
+  padding: var(--space-sm);
+  box-shadow: var(--neu-sunken-soft);
+}
+
 .thread-row .dense-title > span:first-child {
   display: inline-flex;
   align-items: center;

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -490,22 +490,6 @@ button.session-card {
   box-shadow: var(--neu-selected);
 }
 
-.session-card.pinned {
-  border-color: rgba(110, 168, 255, 0.22);
-}
-
-.session-card.pinned::after {
-  content: "";
-  position: absolute;
-  bottom: var(--space-xs);
-  right: var(--space-xs);
-  width: 5px;
-  height: 5px;
-  border-radius: var(--radius-pill);
-  background: var(--blue);
-  box-shadow: 0 0 6px rgba(110, 168, 255, 0.5);
-}
-
 .pinned-section-label {
   grid-column: 1 / -1;
   color: var(--muted);

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -21,6 +21,7 @@ const state = {
   workspaceSelectedPathBySession: new Map(),
   workspaceDiffEntries: new Map(),
   workspaceDiffRequestSeq: 0,
+  expandedThreadNamesBySession: new Map(),
   renderRafId: null,
   renderMetricsPending: false,
   renderSessionsPending: false,
@@ -154,6 +155,7 @@ function bindEvents() {
   });
 
   el.workspaceView.addEventListener("click", handleWorkspaceFileClick);
+  el.threadsView.addEventListener("click", handleThreadClick);
 }
 
 async function boot() {
@@ -663,6 +665,7 @@ async function confirmDeleteSession() {
     state.lastSequence.delete(sessionId);
     state.workspaceSelectedPathBySession.delete(sessionId);
     state.workspaceDiffEntries.delete(sessionId);
+    state.expandedThreadNamesBySession.delete(sessionId);
     // If the deleted session was selected, pick a new one or clear
     if (state.selectedId === sessionId) {
       if (state.eventSource) {
@@ -1857,6 +1860,29 @@ function renderEvents() {
   }).join("");
 }
 
+function handleThreadClick(event) {
+  const button = event.target.closest("button[data-thread-name]");
+  if (!button || !el.threadsView.contains(button)) return;
+
+  const sessionId = state.selectedId;
+  const name = button.dataset.threadName;
+  if (!sessionId || !name) return;
+
+  let expanded = state.expandedThreadNamesBySession.get(sessionId);
+  if (!expanded) {
+    expanded = new Set();
+    state.expandedThreadNamesBySession.set(sessionId, expanded);
+  }
+
+  if (expanded.has(name)) {
+    expanded.delete(name);
+  } else {
+    expanded.add(name);
+  }
+
+  requestInspectorRender();
+}
+
 function renderThreads(snapshot) {
   const sessionId = snapshot.metadata.session_id;
   const persisted = new Map((snapshot.threads || []).map((thread) => [thread.name, thread]));
@@ -1871,6 +1897,8 @@ function renderThreads(snapshot) {
     return;
   }
 
+  const expanded = state.expandedThreadNamesBySession.get(sessionId) || new Set();
+
   el.threadsView.innerHTML = names.map((name) => {
     const thread = persisted.get(name);
     const liveThread = live.get(name);
@@ -1878,30 +1906,48 @@ function renderThreads(snapshot) {
     const episodes = snapshot.thread_episodes?.[name] || [];
     const action = liveThread?.action || thread?.latest_action || "no action";
     const episodeCount = thread?.episode_count ?? episodes.length;
-    return `
-      <div class="dense-item thread-row ${status === "active" ? "thread-active" : ""}">
-        <div class="dense-title">
+    const isExpanded = expanded.has(name);
+    const classes = [
+      "dense-item",
+      "thread-row",
+      status === "active" ? "thread-active" : "",
+      isExpanded ? "expanded" : "",
+    ].filter(Boolean).join(" ");
+
+    const header = `
+        <span class="dense-title">
           <span><span class="status-dot ${status === "active" ? "active" : "idle"}"></span>${escapeHtml(name)}</span>
           <span>${escapeHtml(status)} / ${episodeCount} eps</span>
-        </div>
-        <div class="dense-meta"><span>${escapeHtml(action)}</span><span>${episodes.length} retained</span></div>
-        ${renderDetailRows([
-          ["session", thread?.session_id || sessionId],
-          ["created", thread?.created_at],
-          ["updated", thread?.updated_at],
-          ["latest action", thread?.latest_action],
-          ["live action", liveThread?.action],
-          ["sources", liveThread?.source_threads],
-          ["started seq", liveThread?.started_sequence_id ?? liveThread?.started_sequence],
-          ["finished seq", liveThread?.finished_sequence_id ?? liveThread?.finished_sequence],
-          ["exit code", liveThread?.exit_code],
-          ["timed out", liveThread?.timed_out],
-          ["last log", liveThread?.last_log],
-        ])}
-        <div class="dense-section-title">retained episodes</div>
-        ${episodes.length === 0
-          ? `<div class="dense-body muted">No retained episodes.</div>`
-          : `<div class="dense-sublist">${episodes.map(renderThreadEpisode).join("")}</div>`}
+        </span>
+        <span class="dense-meta"><span>${escapeHtml(action)}</span><span>${episodes.length} retained</span></span>`;
+
+    const detail = isExpanded ? `
+        <div class="thread-detail">
+          ${renderDetailRows([
+            ["session", thread?.session_id || sessionId],
+            ["created", thread?.created_at],
+            ["updated", thread?.updated_at],
+            ["latest action", thread?.latest_action],
+            ["live action", liveThread?.action],
+            ["sources", liveThread?.source_threads],
+            ["started seq", liveThread?.started_sequence_id ?? liveThread?.started_sequence],
+            ["finished seq", liveThread?.finished_sequence_id ?? liveThread?.finished_sequence],
+            ["exit code", liveThread?.exit_code],
+            ["timed out", liveThread?.timed_out],
+            ["last log", liveThread?.last_log],
+          ])}
+          <div class="dense-section-title">retained episodes</div>
+          ${episodes.length === 0
+            ? `<div class="dense-body muted">No retained episodes.</div>`
+            : `<div class="dense-sublist">${episodes.map(renderThreadEpisode).join("")}</div>`}
+        </div>` : "";
+
+    return `
+      <div class="thread-block">
+        <button type="button" class="${classes}" data-thread-name="${escapeAttr(name)}" aria-expanded="${isExpanded ? "true" : "false"}">
+          ${header}
+        </button>
+        ${detail}
       </div>`;
   }).join("");
 }

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -100,6 +100,8 @@ function bindElements() {
     "snapBackend",
     "snapMessages",
     "snapRun",
+    "snapTokens",
+    "snapContext",
     "transcript",
     "promptForm",
     "promptInput",
@@ -1042,6 +1044,8 @@ function renderInspector() {
     el.snapBackend.textContent = "--";
     el.snapMessages.textContent = "0";
     el.snapRun.textContent = "idle";
+    el.snapTokens.textContent = "--";
+    el.snapContext.textContent = "--";
     el.cancelRun.disabled = true;
     el.deleteSessionBtn.disabled = true;
     el.transcript.innerHTML = `<div class="empty-state">No selected session.</div>`;
@@ -1073,6 +1077,17 @@ function renderInspector() {
   }
   el.cancelRun.disabled = !runActive;
   el.deleteSessionBtn.disabled = false;
+
+  const lastUsage = snapshot.response_timing?.last_token_usage;
+  if (lastUsage) {
+    const cacheRead = lastUsage.cache_read_tokens > 0 ? ` R${formatTokens(lastUsage.cache_read_tokens)}` : "";
+    el.snapTokens.textContent = `↑${formatTokens(lastUsage.input_tokens)}${cacheRead} ↓${formatTokens(lastUsage.output_tokens)}`;
+    el.snapContext.textContent = formatTokens(lastUsage.total_tokens);
+  } else {
+    el.snapTokens.textContent = "--";
+    el.snapContext.textContent = "--";
+  }
+
   renderTabs();
   syncPromptBusy(metadata.session_id, snapshot);
   renderActiveInspectorPanel(snapshot);
@@ -2763,6 +2778,14 @@ function formatRuntime(ms) {
 function formatDuration(ms) {
   if (ms == null) return null;
   return formatRuntime(ms);
+}
+
+function formatTokens(n) {
+  if (n == null || !Number.isFinite(n)) return "--";
+  if (n < 1000) return String(n);
+  if (n < 10000) return (n / 1000).toFixed(1) + "k";
+  if (n < 1000000) return Math.round(n / 1000) + "k";
+  return (n / 1000000).toFixed(1) + "M";
 }
 
 function startLiveTimer() {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -36,6 +36,7 @@ const state = {
   lastWorkspaceStatsRefresh: 0,
   transcriptRenderedSessionId: null,
   transcriptRenderedSignature: "",
+  pendingDeleteSessionId: null,
 };
 
 const el = {};
@@ -106,6 +107,12 @@ function bindElements() {
     "threadsView",
     "worksetsView",
     "workspaceView",
+    "deleteOverlay",
+    "closeDelete",
+    "confirmDelete",
+    "deleteConfirmText",
+    "deleteStatus",
+    "deleteSessionBtn",
   ]) {
     el[id] = document.getElementById(id);
   }
@@ -117,14 +124,23 @@ function bindEvents() {
   el.promptForm.addEventListener("submit", submitPrompt);
   el.promptInput.addEventListener("keydown", handlePromptKeydown);
   el.cancelRun.addEventListener("click", cancelActiveRun);
+  el.deleteSessionBtn.addEventListener("click", () => {
+    if (state.selectedId) deleteSession(state.selectedId);
+  });
   el.mobileBack.addEventListener("click", showMobileSessions);
   el.closeLaunch.addEventListener("click", hideLaunchOverlay);
   el.launchOverlay.addEventListener("click", (event) => {
     if (event.target === el.launchOverlay) hideLaunchOverlay();
   });
+  el.closeDelete.addEventListener("click", hideDeleteOverlay);
+  el.deleteOverlay.addEventListener("click", (event) => {
+    if (event.target === el.deleteOverlay) hideDeleteOverlay();
+  });
+  el.confirmDelete.addEventListener("click", confirmDeleteSession);
   document.addEventListener("keydown", (event) => {
     if (event.key !== "Escape") return;
     if (!el.launchOverlay.hidden) hideLaunchOverlay();
+    if (!el.deleteOverlay.hidden) hideDeleteOverlay();
   });
 
   el.tabs.addEventListener("click", (event) => {
@@ -164,6 +180,11 @@ async function apiPost(path, body) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+  return readJson(response);
+}
+
+async function apiDelete(path) {
+  const response = await fetch(path, { method: "DELETE" });
   return readJson(response);
 }
 
@@ -483,6 +504,25 @@ function hideLaunchOverlay() {
   el.launchOverlay.hidden = true;
 }
 
+function showDeleteOverlay(sessionId) {
+  if (!sessionId) return;
+  state.pendingDeleteSessionId = sessionId;
+  el.deleteConfirmText.textContent = `Delete session ${shortId(sessionId)}? This permanently removes all threads, episodes, and worksets.`;
+  el.deleteStatus.textContent = "";
+  el.deleteStatus.classList.remove("error");
+  el.deleteOverlay.hidden = false;
+}
+
+function hideDeleteOverlay() {
+  el.deleteOverlay.hidden = true;
+  state.pendingDeleteSessionId = null;
+}
+
+function setDeleteStatus(message, error) {
+  el.deleteStatus.textContent = message || "";
+  el.deleteStatus.classList.toggle("error", Boolean(error));
+}
+
 function showMobileSessions() {
   state.mobileDetailOpen = false;
   renderMobileMode();
@@ -597,6 +637,56 @@ async function cancelActiveRun() {
     await loadSnapshot(sessionId, false);
   } catch (error) {
     pushLocalEvent("cancel_error", error.message, sessionId);
+  }
+}
+
+async function deleteSession(sessionId) {
+  if (!sessionId) return;
+  showDeleteOverlay(sessionId);
+}
+
+async function confirmDeleteSession() {
+  const sessionId = state.pendingDeleteSessionId;
+  if (!sessionId) return;
+  setDeleteStatus("deleting", false);
+  el.confirmDelete.disabled = true;
+  try {
+    await apiDelete(`/sessions/${encodeURIComponent(sessionId)}`);
+    // Clean up all client-side state for this session
+    state.snapshots.delete(sessionId);
+    state.eventsBySession.delete(sessionId);
+    state.activeThreadsBySession.delete(sessionId);
+    state.attentionSessions.delete(sessionId);
+    state.activeRunsBySession.delete(sessionId);
+    state.terminalRunsBySession.delete(sessionId);
+    state.submittingRunsBySession.delete(sessionId);
+    state.submittingRunTimersBySession.delete(sessionId);
+    state.runStartedAtBySession.delete(sessionId);
+    state.lastSequence.delete(sessionId);
+    state.workspaceSelectedPathBySession.delete(sessionId);
+    state.workspaceDiffEntries.delete(sessionId);
+    // If the deleted session was selected, pick a new one or clear
+    if (state.selectedId === sessionId) {
+      if (state.eventSource) {
+        state.eventSource.close();
+        state.eventSource = null;
+      }
+      state.selectedId = null;
+      state.transcriptRenderedSessionId = null;
+      state.transcriptRenderedSignature = "";
+    }
+    hideDeleteOverlay();
+    await loadSessions({ forceFetch: true, forceRender: true });
+    if (state.selectedId) {
+      selectSession(state.selectedId);
+    } else {
+      requestRender({ inspector: true });
+    }
+  } catch (error) {
+    pushLocalEvent("delete_error", error.message, sessionId);
+    setDeleteStatus(error.message, true);
+  } finally {
+    el.confirmDelete.disabled = false;
   }
 }
 
@@ -961,6 +1051,7 @@ function renderInspector() {
     el.snapMessages.textContent = "0";
     el.snapRun.textContent = "idle";
     el.cancelRun.disabled = true;
+    el.deleteSessionBtn.disabled = true;
     el.transcript.innerHTML = `<div class="empty-state">No selected session.</div>`;
     state.transcriptRenderedSessionId = null;
     el.threadsView.innerHTML = "";
@@ -989,6 +1080,7 @@ function renderInspector() {
     el.snapRun.textContent = lastDur != null ? formatDuration(lastDur) : "idle";
   }
   el.cancelRun.disabled = !runActive;
+  el.deleteSessionBtn.disabled = false;
   renderTabs();
   syncPromptBusy(metadata.session_id, snapshot);
   renderActiveInspectorPanel(snapshot);

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -381,8 +381,6 @@ function sessionCardViewModel(entry) {
     sessionId,
     shortId: shortId(sessionId),
     cwd: summary.cwd || "",
-    backend: summary.backend || "",
-    model: summary.model || "",
     sshHost: summary.ssh_host || "",
     sandboxed: Boolean(summary.sandboxed),
     selected: sessionId === state.selectedId,
@@ -405,8 +403,6 @@ function sessionCardRenderDigest(card) {
     card.sessionId,
     card.shortId,
     card.cwd,
-    card.backend,
-    card.model,
     card.sshHost,
     card.sandboxed ? "1" : "0",
     card.selected ? "1" : "0",
@@ -1026,10 +1022,6 @@ function renderSessionCard(card) {
           <div class="cwd">${escapeHtml(card.cwd)}</div>
         </div>
         <span class="status-dot ${card.statusClass}"></span>
-      </div>
-      <div class="meta-grid">
-        <div><span>model</span><strong>${escapeHtml(card.model)}</strong></div>
-        <div><span>backend</span><strong>${escapeHtml(card.backend)}</strong></div>
       </div>
       <div class="telemetry-grid">
         <div><span>run</span><strong data-run-timer="${escapeAttr(card.sessionId)}" class="run-tile${card.runActive ? " run-tile-active" : ""}">${card.runDisplay}</strong></div>

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -116,6 +116,17 @@ function bindElements() {
     "deleteConfirmText",
     "deleteStatus",
     "deleteSessionBtn",
+    "settingsBtn",
+    "settingsOverlay",
+    "closeSettings",
+    "settingsForm",
+    "settingsStatus",
+    "settingsBackend",
+    "settingsEffort",
+    "settingsModel",
+    "settingsBaseUrl",
+    "settingsApiKeyEnv",
+    "settingsExtraHeaders",
   ]) {
     el[id] = document.getElementById(id);
   }
@@ -130,6 +141,12 @@ function bindEvents() {
   el.deleteSessionBtn.addEventListener("click", () => {
     if (state.selectedId) deleteSession(state.selectedId);
   });
+  el.settingsBtn.addEventListener("click", showSettingsOverlay);
+  el.closeSettings.addEventListener("click", hideSettingsOverlay);
+  el.settingsOverlay.addEventListener("click", (event) => {
+    if (event.target === el.settingsOverlay) hideSettingsOverlay();
+  });
+  el.settingsForm.addEventListener("submit", updateSessionConfig);
   el.mobileBack.addEventListener("click", showMobileSessions);
   el.closeLaunch.addEventListener("click", hideLaunchOverlay);
   el.launchOverlay.addEventListener("click", (event) => {
@@ -144,6 +161,7 @@ function bindEvents() {
     if (event.key !== "Escape") return;
     if (!el.launchOverlay.hidden) hideLaunchOverlay();
     if (!el.deleteOverlay.hidden) hideDeleteOverlay();
+    if (!el.settingsOverlay.hidden) hideSettingsOverlay();
   });
 
   el.tabs.addEventListener("click", (event) => {
@@ -521,6 +539,85 @@ function hideDeleteOverlay() {
 function setDeleteStatus(message, error) {
   el.deleteStatus.textContent = message || "";
   el.deleteStatus.classList.toggle("error", Boolean(error));
+}
+
+function showSettingsOverlay() {
+  const sessionId = state.selectedId;
+  if (!sessionId) return;
+  const snapshot = state.snapshots.get(sessionId);
+  const metadata = snapshot?.metadata;
+  if (metadata) {
+    el.settingsModel.value = metadata.model || "";
+    el.settingsBaseUrl.value = metadata.base_url || "";
+    el.settingsBackend.value = metadata.backend || "";
+    el.settingsEffort.value = metadata.reasoning_effort || "";
+    el.settingsApiKeyEnv.value = metadata.api_key_env || "";
+    el.settingsExtraHeaders.value = metadata.extra_headers
+      && Object.keys(metadata.extra_headers).length > 0
+      ? JSON.stringify(metadata.extra_headers, null, 2)
+      : "";
+  }
+  setSettingsStatus("", false);
+  el.settingsOverlay.hidden = false;
+}
+
+function hideSettingsOverlay() {
+  el.settingsOverlay.hidden = true;
+}
+
+function setSettingsStatus(message, error) {
+  el.settingsStatus.textContent = message || "";
+  el.settingsStatus.classList.toggle("error", Boolean(error));
+}
+
+async function updateSessionConfig(event) {
+  event.preventDefault();
+  const sessionId = state.selectedId;
+  if (!sessionId) return;
+  setSettingsStatus("saving", false);
+
+  const extraHeadersRaw = el.settingsExtraHeaders.value.trim();
+  let extraHeaders = null;
+  if (extraHeadersRaw) {
+    try {
+      extraHeaders = JSON.stringify(JSON.parse(extraHeadersRaw));
+    } catch (parseError) {
+      setSettingsStatus("Extra Headers must be valid JSON", true);
+      return;
+    }
+  }
+
+  const body = {
+    model: nullable(el.settingsModel.value),
+    base_url: nullable(el.settingsBaseUrl.value),
+    backend: nullable(el.settingsBackend.value),
+    reasoning_effort: nullable(el.settingsEffort.value),
+    api_key_env: nullable(el.settingsApiKeyEnv.value),
+    extra_headers: extraHeaders,
+  };
+
+  try {
+    const response = await fetch(
+      `/sessions/${encodeURIComponent(sessionId)}/config`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!response.ok) {
+      let payload = {};
+      try { payload = await response.json(); } catch (_) {}
+      throw new Error(payload.error || `${response.status} ${response.statusText}`);
+    }
+    hideSettingsOverlay();
+    // Reconnect SSE and reload snapshot to pick up the new config.
+    openEventStream(sessionId);
+    await loadSnapshot(sessionId, false);
+    await loadSessions({ forceFetch: true });
+  } catch (error) {
+    setSettingsStatus(error.message, true);
+  }
 }
 
 function showMobileSessions() {
@@ -1051,6 +1148,7 @@ function renderInspector() {
     el.snapContext.textContent = "--";
     el.cancelRun.disabled = true;
     el.deleteSessionBtn.disabled = true;
+    el.settingsBtn.disabled = true;
     el.transcript.innerHTML = `<div class="empty-state">No selected session.</div>`;
     state.transcriptRenderedSessionId = null;
     el.threadsView.innerHTML = "";
@@ -1080,6 +1178,7 @@ function renderInspector() {
   }
   el.cancelRun.disabled = !runActive;
   el.deleteSessionBtn.disabled = false;
+  el.settingsBtn.disabled = false;
 
   const lastUsage = snapshot.response_timing?.last_token_usage;
   if (lastUsage) {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -1098,19 +1098,18 @@ function renderSessions() {
 
   let sessionCards;
   if (cards.length === 0) {
-    sessionCards = `<div class="empty-state matrix-empty">No sessions yet.</div>`;
+    sessionCards = renderNewSessionCard() + `<div class="empty-state matrix-empty">No sessions yet.</div>`;
   } else if (hasPinned) {
     sessionCards = `<div class="pinned-section-label">Pinned</div>`;
     sessionCards += pinnedCards.map(renderSessionCard).join("");
-    if (unpinnedCards.length > 0) {
-      sessionCards += `<div class="pinned-separator"></div>`;
-      sessionCards += unpinnedCards.map(renderSessionCard).join("");
-    }
+    sessionCards += `<div class="pinned-separator"></div>`;
+    sessionCards += renderNewSessionCard();
+    sessionCards += unpinnedCards.map(renderSessionCard).join("");
   } else {
-    sessionCards = cards.map(renderSessionCard).join("");
+    sessionCards = renderNewSessionCard() + cards.map(renderSessionCard).join("");
   }
 
-  el.sessionGrid.innerHTML = renderNewSessionCard() + sessionCards;
+  el.sessionGrid.innerHTML = sessionCards;
   el.sessionGrid.querySelector("[data-action='new-session']")?.addEventListener("click", showLaunchOverlay);
   el.sessionGrid.querySelectorAll("[data-session-id]").forEach((card) => {
     card.addEventListener("click", (event) => {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -345,6 +345,7 @@ function sessionCardViewModel(entry) {
     shortId: shortId(sessionId),
     cwd: summary.cwd || "",
     backend: summary.backend || "",
+    model: summary.model || "",
     sshHost: summary.ssh_host || "",
     sandboxed: Boolean(summary.sandboxed),
     selected: sessionId === state.selectedId,

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -38,6 +38,7 @@ const state = {
   transcriptRenderedSessionId: null,
   transcriptRenderedSignature: "",
   pendingDeleteSessionId: null,
+  pinnedSessionIds: new Set(),
 };
 
 const el = {};
@@ -177,6 +178,7 @@ function bindEvents() {
 }
 
 async function boot() {
+  state.pinnedSessionIds = new Set(JSON.parse(localStorage.getItem("nac:pinnedSessions") || "[]"));
   try {
     state.store = await apiGet("/store");
     el.storePath.textContent = basename(state.store.store_path);
@@ -406,6 +408,7 @@ function sessionCardViewModel(entry) {
     sshHost: summary.ssh_host || "",
     sandboxed: Boolean(summary.sandboxed),
     selected: sessionId === state.selectedId,
+    pinned: state.pinnedSessionIds.has(sessionId),
     tone: cardActive ? "" : summary.sandboxed ? "warn" : "",
     errorish: workspaceError && !workspaceError.includes("remote/sandbox-only") ? "errorish" : "",
     statusClass: sessionStatusClass(entry),
@@ -428,6 +431,7 @@ function sessionCardRenderDigest(card) {
     card.sshHost,
     card.sandboxed ? "1" : "0",
     card.selected ? "1" : "0",
+    card.pinned ? "1" : "0",
     card.tone,
     card.errorish,
     card.statusClass,
@@ -763,6 +767,8 @@ async function confirmDeleteSession() {
     state.workspaceSelectedPathBySession.delete(sessionId);
     state.workspaceDiffEntries.delete(sessionId);
     state.expandedThreadNamesBySession.delete(sessionId);
+    state.pinnedSessionIds.delete(sessionId);
+    savePinnedSessions();
     // If the deleted session was selected, pick a new one or clear
     if (state.selectedId === sessionId) {
       if (state.eventSource) {
@@ -1086,16 +1092,53 @@ function renderMetrics() {
 
 function renderSessions() {
   const cards = filteredSessions().map(sessionCardViewModel);
-  const sessionCards = cards.length === 0
-    ? `<div class="empty-state matrix-empty">No sessions yet.</div>`
-    : cards.map(renderSessionCard).join("");
+  const pinnedCards = cards.filter((card) => card && state.pinnedSessionIds.has(card.sessionId));
+  const unpinnedCards = cards.filter((card) => card && !state.pinnedSessionIds.has(card.sessionId));
+  const hasPinned = pinnedCards.length > 0;
+
+  let sessionCards;
+  if (cards.length === 0) {
+    sessionCards = `<div class="empty-state matrix-empty">No sessions yet.</div>`;
+  } else if (hasPinned) {
+    sessionCards = `<div class="pinned-section-label">Pinned</div>`;
+    sessionCards += pinnedCards.map(renderSessionCard).join("");
+    if (unpinnedCards.length > 0) {
+      sessionCards += `<div class="pinned-separator"></div>`;
+      sessionCards += unpinnedCards.map(renderSessionCard).join("");
+    }
+  } else {
+    sessionCards = cards.map(renderSessionCard).join("");
+  }
+
   el.sessionGrid.innerHTML = renderNewSessionCard() + sessionCards;
   el.sessionGrid.querySelector("[data-action='new-session']")?.addEventListener("click", showLaunchOverlay);
   el.sessionGrid.querySelectorAll("[data-session-id]").forEach((card) => {
-    card.addEventListener("click", () => selectSession(card.dataset.sessionId));
+    card.addEventListener("click", (event) => {
+      if (event.shiftKey) {
+        event.preventDefault();
+        toggleSessionPin(card.dataset.sessionId);
+        return;
+      }
+      selectSession(card.dataset.sessionId);
+    });
   });
   state.lastSessionsDigest = sessionCardListRenderDigest(cards);
   state.lastSelectedSessionDigest = sessionCardRenderDigest(cards.find((card) => card?.sessionId === state.selectedId));
+}
+
+function toggleSessionPin(sessionId) {
+  if (!sessionId) return;
+  if (state.pinnedSessionIds.has(sessionId)) {
+    state.pinnedSessionIds.delete(sessionId);
+  } else {
+    state.pinnedSessionIds.add(sessionId);
+  }
+  savePinnedSessions();
+  renderSessions();
+}
+
+function savePinnedSessions() {
+  localStorage.setItem("nac:pinnedSessions", JSON.stringify([...state.pinnedSessionIds]));
 }
 
 function renderNewSessionCard() {
@@ -1117,7 +1160,7 @@ function renderNewSessionCard() {
 function renderSessionCard(card) {
   if (!card) return "";
   return `
-    <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""}" data-session-id="${escapeAttr(card.sessionId)}">
+    <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
       <div class="session-card-head">
         <div>
           <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}${card.sshHost ? ` <svg class="icon ssh-icon" viewBox="0 0 24 24" aria-hidden="true" title="ssh: ${escapeAttr(card.sshHost)}"><rect x="4" y="5" width="16" height="14" rx="2"></rect><path d="M7 10l3 2-3 2"></path><path d="M13 14h4"></path></svg>` : ""}</h2>

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -10,6 +10,8 @@ const state = {
   terminalRunsBySession: new Map(),
   submittingRunsBySession: new Set(),
   submittingRunTimersBySession: new Map(),
+  runStartedAtBySession: new Map(),
+  liveTimerInterval: null,
   eventSource: null,
   lastSequence: new Map(),
   activeTab: "chat",
@@ -246,6 +248,11 @@ async function loadSessionsOnce(options) {
     preserveSessionWorkspaceStats(sessions);
     sanitizeSessionListActiveRuns(sessions);
     updateSessionActivity(sessions);
+    if (state.runStartedAtBySession.size > 0) {
+      startLiveTimer();
+    } else {
+      stopLiveTimer();
+    }
 
     if (options.workspaceStats) state.lastWorkspaceStatsRefresh = Date.now();
     if (!state.selectedId && sessions.length > 0) state.selectedId = sessions[0].summary.session_id;
@@ -340,6 +347,15 @@ function sessionCardViewModel(entry) {
   const promptPreview = latestPendingUserPrompt(sessionId, cardSnapshot)
     || displayPromptFromMessageText(summary.last_user_prompt)
     || "no prompt yet";
+  const runActive = activeRunCountsForSession(sessionId, entry.active_run);
+  const runStartedAt = runActive
+    ? (state.runStartedAtBySession.get(sessionId) || entry.active_run?.started_at_epoch_ms || null)
+    : null;
+  const snapshotForTiming = state.snapshots.get(sessionId);
+  const lastDur = snapshotForTiming?.response_timing?.last_response_duration_ms;
+  const runDisplay = runActive
+    ? (runStartedAt ? formatRuntime(Date.now() - runStartedAt) : "00:00:00")
+    : (lastDur != null ? formatRuntime(lastDur) : "--:--:--");
   return {
     sessionId,
     shortId: shortId(sessionId),
@@ -352,7 +368,10 @@ function sessionCardViewModel(entry) {
     tone: cardActive ? "" : summary.sandboxed ? "warn" : "",
     errorish: workspaceError && !workspaceError.includes("remote/sandbox-only") ? "errorish" : "",
     statusClass: sessionStatusClass(entry),
-    messageCount: summary.visible_message_count + pendingCount,
+    runActive,
+    runStartedAt,
+    lastDur: lastDur || null,
+    runDisplay,
     additions: diffStats.additions,
     deletions: diffStats.deletions,
     promptPreview,
@@ -373,7 +392,9 @@ function sessionCardRenderDigest(card) {
     card.tone,
     card.errorish,
     card.statusClass,
-    card.messageCount,
+    card.runActive ? "1" : "0",
+    String(card.runStartedAt || ""),
+    String(card.lastDur || ""),
     card.additions,
     card.deletions,
     card.promptPreview,
@@ -403,6 +424,9 @@ async function loadSnapshot(sessionId, openStream = false) {
     if (activeRunCountsForSession(sessionId, snapshot.active_run)) {
       clearRunSubmitting(sessionId);
       state.activeRunsBySession.set(sessionId, true);
+      if (snapshot.active_run?.started_at_epoch_ms) {
+        state.runStartedAtBySession.set(sessionId, snapshot.active_run.started_at_epoch_ms);
+      }
     }
     const previousCardDigest = sessionEntryRenderDigest(sessionEntryById(sessionId));
     state.snapshots.set(sessionId, snapshot);
@@ -413,6 +437,11 @@ async function loadSnapshot(sessionId, openStream = false) {
     }
     if (openStream) openEventStream(sessionId);
     if (state.selectedId === sessionId) {
+      if (sessionHasActiveRun(sessionId, snapshot)) {
+        startLiveTimer();
+      } else if (state.runStartedAtBySession.size === 0) {
+        stopLiveTimer();
+      }
       requestRender({ shell: false, sessions: cardChanged, inspector: true });
     }
     return snapshot;
@@ -756,6 +785,7 @@ function handleRunStarted(sessionId, envelope) {
   const activeRun = activeRunFromStartedEnvelope(envelope);
   state.terminalRunsBySession.delete(sessionId);
   state.activeRunsBySession.set(sessionId, true);
+  state.runStartedAtBySession.set(sessionId, activeRun.started_at_epoch_ms);
   clearRunSubmitting(sessionId);
   clearSessionAttention(sessionId);
   const snapshot = state.snapshots.get(sessionId);
@@ -764,7 +794,10 @@ function handleRunStarted(sessionId, envelope) {
   }
   const entry = sessionEntryById(sessionId);
   if (entry) entry.active_run = activeRun;
-  if (state.selectedId === sessionId) requestChatScrollToBottom();
+  if (state.selectedId === sessionId) {
+    requestChatScrollToBottom();
+  }
+  startLiveTimer();
 }
 
 function handleTerminalRun(sessionId, envelope) {
@@ -775,10 +808,16 @@ function handleTerminalRun(sessionId, envelope) {
     sequenceId: envelope.sequence_id || 0,
   });
   state.activeRunsBySession.set(sessionId, false);
+  state.runStartedAtBySession.delete(sessionId);
   clearRunSubmitting(sessionId);
   clearCachedActiveRun(sessionId, runId);
   if (wasActive) state.attentionSessions.add(sessionId);
-  if (state.selectedId === sessionId) stopWaitingLife();
+  if (state.selectedId === sessionId) {
+    stopWaitingLife();
+  }
+  if (state.runStartedAtBySession.size === 0) {
+    stopLiveTimer();
+  }
 }
 
 function requestRender(options = {}) {
@@ -903,7 +942,7 @@ function renderSessionCard(card) {
         <div><span>backend</span><strong>${escapeHtml(card.backend)}</strong></div>
       </div>
       <div class="telemetry-grid">
-        <div><span>msgs</span><strong>${card.messageCount}</strong></div>
+        <div><span>run</span><strong data-run-timer="${escapeAttr(card.sessionId)}" class="run-tile${card.runActive ? " run-tile-active" : ""}">${card.runDisplay}</strong></div>
         <div><span>add</span><strong>${escapeHtml(card.additions)}</strong></div>
         <div><span>del</span><strong>${escapeHtml(card.deletions)}</strong></div>
       </div>
@@ -939,7 +978,16 @@ function renderInspector() {
   el.snapModel.textContent = metadata.model;
   el.snapBackend.textContent = metadata.backend;
   el.snapMessages.textContent = effectiveMessageCount(metadata.session_id, snapshot);
-  el.snapRun.textContent = runActive ? "active" : "idle";
+  if (runActive) {
+    const startedAt = state.runStartedAtBySession.get(metadata.session_id)
+      || snapshot.active_run?.started_at_epoch_ms;
+    el.snapRun.textContent = startedAt
+      ? formatRuntime(Date.now() - startedAt)
+      : "active";
+  } else {
+    const lastDur = snapshot.response_timing?.last_response_duration_ms;
+    el.snapRun.textContent = lastDur != null ? formatDuration(lastDur) : "idle";
+  }
   el.cancelRun.disabled = !runActive;
   renderTabs();
   syncPromptBusy(metadata.session_id, snapshot);
@@ -973,7 +1021,23 @@ function renderTranscript(sessionId, messages, snapshot = state.snapshots.get(se
     ...effectivePendingMessages(sessionId, snapshot),
   ];
   const visibleMessages = transcriptMessages.slice(-80);
-  const signature = transcriptMessagesSignature(visibleMessages);
+
+  const durationArr = snapshot?.response_timing?.response_durations_ms;
+  const durations = Array.isArray(durationArr) ? durationArr : [];
+  const offset = transcriptMessages.length - visibleMessages.length;
+  const durationByTranscriptIdx = new Map();
+  let responseIdx = 0;
+  transcriptMessages.forEach((message, idx) => {
+    if (message.role === "assistant" && !(message.tool_calls?.length > 0) && !message.pending) {
+      const dur = durations[responseIdx];
+      if (dur != null) durationByTranscriptIdx.set(idx, dur);
+      responseIdx++;
+    }
+  });
+
+  const messageSig = transcriptMessagesSignature(visibleMessages);
+  const durationSig = JSON.stringify(durations);
+  const signature = `${messageSig}|${durationSig}`;
   if (state.transcriptRenderedSessionId === sessionId
     && state.transcriptRenderedSignature === signature) {
     scrollTranscriptToBottomIfRequested();
@@ -1002,16 +1066,32 @@ function renderTranscript(sessionId, messages, snapshot = state.snapshots.get(se
     const meta = document.createElement("div");
     meta.className = "message-meta";
 
+    const metaLeft = document.createElement("span");
+    metaLeft.className = "message-meta-left";
+
     const roleElement = document.createElement("span");
     roleElement.className = "message-role";
     const roleClass = safeClassToken(role);
     if (roleClass) roleElement.classList.add(roleClass);
     roleElement.textContent = role;
+    metaLeft.append(roleElement);
+
+    const transcriptIdx = offset + index;
+    const durationMs = durationByTranscriptIdx.get(transcriptIdx);
+    if (durationMs != null) {
+      const sep = document.createElement("span");
+      sep.className = "message-meta-sep";
+      sep.textContent = "•";
+      const durationElement = document.createElement("span");
+      durationElement.className = "message-duration";
+      durationElement.textContent = formatDuration(durationMs);
+      metaLeft.append(sep, durationElement);
+    }
 
     const markerElement = document.createElement("span");
     markerElement.textContent = message.pending ? "submitted" : `#${index + 1}`;
 
-    meta.append(roleElement, markerElement);
+    meta.append(metaLeft, markerElement);
 
     const bodyElement = document.createElement("div");
     bodyElement.className = "message-body markdown";
@@ -2407,7 +2487,12 @@ function updateSessionActivity(sessions) {
   for (const entry of sessions) {
     const sessionId = entry.summary.session_id;
     const remoteActive = activeRunCountsForSession(sessionId, entry.active_run);
-    if (remoteActive) clearRunSubmitting(sessionId);
+    if (remoteActive) {
+      clearRunSubmitting(sessionId);
+      if (entry.active_run?.started_at_epoch_ms) {
+        state.runStartedAtBySession.set(sessionId, entry.active_run.started_at_epoch_ms);
+      }
+    }
     const isSubmitting = state.submittingRunsBySession.has(sessionId);
     const isActive = remoteActive || isSubmitting;
     const wasActive = state.activeRunsBySession.get(sessionId) === true;
@@ -2415,6 +2500,9 @@ function updateSessionActivity(sessions) {
       clearSessionAttention(sessionId);
     } else if (wasActive) {
       state.attentionSessions.add(sessionId);
+    }
+    if (!isActive) {
+      state.runStartedAtBySession.delete(sessionId);
     }
     state.activeRunsBySession.set(sessionId, isActive);
     seen.add(sessionId);
@@ -2424,6 +2512,7 @@ function updateSessionActivity(sessions) {
     if (!seen.has(sessionId)) {
       state.activeRunsBySession.delete(sessionId);
       state.terminalRunsBySession.delete(sessionId);
+      state.runStartedAtBySession.delete(sessionId);
       clearRunSubmitting(sessionId);
       state.attentionSessions.delete(sessionId);
     }
@@ -2575,4 +2664,52 @@ function escapeAttr(value) {
 function safeClassToken(value) {
   const token = String(value || "");
   return /^[A-Za-z0-9_-]+$/.test(token) ? token : null;
+}
+
+function formatRuntime(ms) {
+  if (ms == null || ms < 0) return "00:00:00";
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+function formatDuration(ms) {
+  if (ms == null) return null;
+  return formatRuntime(ms);
+}
+
+function startLiveTimer() {
+  if (state.liveTimerInterval) return;
+  state.liveTimerInterval = setInterval(() => {
+    if (state.runStartedAtBySession.size === 0) {
+      stopLiveTimer();
+      return;
+    }
+    const now = Date.now();
+    const selectedId = state.selectedId;
+    if (selectedId) {
+      const startedAt = state.runStartedAtBySession.get(selectedId);
+      if (startedAt) {
+        el.snapRun.textContent = formatRuntime(now - startedAt);
+      }
+    }
+    document.querySelectorAll("[data-run-timer]").forEach((tile) => {
+      const sid = tile.dataset.runTimer;
+      if (!sid) return;
+      const startedAt = state.runStartedAtBySession.get(sid);
+      if (startedAt) {
+        tile.textContent = formatRuntime(now - startedAt);
+      }
+    });
+  }, 200);
+}
+
+function stopLiveTimer() {
+  if (state.liveTimerInterval) {
+    clearInterval(state.liveTimerInterval);
+    state.liveTimerInterval = null;
+  }
 }

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -51,11 +51,20 @@
             <h1 id="inspectorTitle">No session selected</h1>
             <p id="inspectorMeta">Launch or select a session.</p>
           </div>
-          <button id="cancelRun" class="icon-button icon-button-destructive" type="button" aria-label="Stop active run" title="Stop active run">
-            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
-              <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
-            </svg>
-          </button>
+          <div class="inspector-actions">
+            <button id="deleteSessionBtn" class="icon-button" type="button" aria-label="Delete session" title="Delete session">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M3 6h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+            <button id="cancelRun" class="icon-button icon-button-destructive" type="button" aria-label="Stop active run" title="Stop active run">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
+              </svg>
+            </button>
+          </div>
         </header>
 
         <nav class="tabs" id="tabs">
@@ -211,6 +220,35 @@
             <div class="form-status" id="launchStatus"></div>
           </div>
         </form>
+      </section>
+    </div>
+
+    <div class="launch-overlay" id="deleteOverlay" hidden>
+      <section class="launch-dialog launch-dialog--compact" role="dialog" aria-modal="true" aria-label="Delete session">
+        <header class="launch-dialog-head">
+          <div>
+            <div class="eyebrow">Delete</div>
+          </div>
+          <button id="closeDelete" class="icon-button" type="button" aria-label="Close delete dialog" title="Close">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M18 6 6 18"></path>
+              <path d="m6 6 12 12"></path>
+            </svg>
+          </button>
+        </header>
+        <div class="launch-form">
+          <p id="deleteConfirmText" class="confirm-text">Delete this session? This permanently removes all threads, episodes, and worksets.</p>
+          <div class="launch-actions">
+            <button class="primary-action icon-button icon-button-destructive launch-submit" id="confirmDelete" type="button" aria-label="Confirm delete" title="Confirm delete">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M3 6h18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+            <div class="form-status" id="deleteStatus"></div>
+          </div>
+        </div>
       </section>
     </div>
 

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -80,6 +80,8 @@
           <div><span>Backend</span><strong id="snapBackend">--</strong></div>
           <div><span>Msgs</span><strong id="snapMessages">0</strong></div>
           <div><span>Run</span><strong id="snapRun">idle</strong></div>
+          <div><span>Tokens</span><strong id="snapTokens">--</strong></div>
+          <div><span>Orch Context</span><strong id="snapContext">--</strong></div>
         </section>
 
         <div class="tab-panel active" id="tab-chat">

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -149,11 +149,11 @@
               <span>Backend</span>
               <select id="launchBackend" name="backend">
                 <option value="">config</option>
-                <option value="openai-responses">openai</option>
-                <option value="chatgpt-codex-responses">codex</option>
-                <option value="anthropic-messages">anthropic</option>
-                <option value="deepseek-chat">deepseek</option>
-                <option value="fireworks-chat">fireworks</option>
+                <option value="openai-responses">openai-responses</option>
+                <option value="chatgpt-codex-responses">chatgpt-codex-responses</option>
+                <option value="anthropic-messages">anthropic-messages</option>
+                <option value="deepseek-chat">deepseek-chat</option>
+                <option value="fireworks-chat">fireworks-chat</option>
               </select>
             </label>
             <label>
@@ -279,11 +279,11 @@
               <span>Backend</span>
               <select id="settingsBackend">
                 <option value="">config</option>
-                <option value="openai-responses">openai</option>
-                <option value="chatgpt-codex-responses">codex</option>
-                <option value="anthropic-messages">anthropic</option>
-                <option value="deepseek-chat">deepseek</option>
-                <option value="fireworks-chat">fireworks</option>
+                <option value="openai-responses">openai-responses</option>
+                <option value="chatgpt-codex-responses">chatgpt-codex-responses</option>
+                <option value="anthropic-messages">anthropic-messages</option>
+                <option value="deepseek-chat">deepseek-chat</option>
+                <option value="fireworks-chat">fireworks-chat</option>
               </select>
             </label>
             <label>

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -59,6 +59,12 @@
                 <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>
             </button>
+            <button id="settingsBtn" class="icon-button" type="button" aria-label="Session settings" title="Session settings">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="12" cy="12" r="3" fill="none" stroke="currentColor" stroke-width="2"/>
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
             <button id="cancelRun" class="icon-button icon-button-destructive" type="button" aria-label="Stop active run" title="Stop active run">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
@@ -251,6 +257,76 @@
             <div class="form-status" id="deleteStatus"></div>
           </div>
         </div>
+      </section>
+    </div>
+
+    <div class="launch-overlay" id="settingsOverlay" hidden>
+      <section class="launch-dialog" role="dialog" aria-modal="true" aria-label="Session settings">
+        <header class="launch-dialog-head">
+          <div>
+            <div class="eyebrow">Settings</div>
+          </div>
+          <button id="closeSettings" class="icon-button" type="button" aria-label="Close settings dialog" title="Close">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M18 6 6 18"></path>
+              <path d="m6 6 12 12"></path>
+            </svg>
+          </button>
+        </header>
+        <form id="settingsForm" class="launch-form">
+          <div class="form-grid two">
+            <label>
+              <span>Backend</span>
+              <select id="settingsBackend">
+                <option value="">config</option>
+                <option value="openai-responses">openai</option>
+                <option value="chatgpt-codex-responses">codex</option>
+                <option value="anthropic-messages">anthropic</option>
+                <option value="deepseek-chat">deepseek</option>
+                <option value="fireworks-chat">fireworks</option>
+              </select>
+            </label>
+            <label>
+              <span>Effort</span>
+              <select id="settingsEffort">
+                <option value="">config</option>
+                <option value="none">none</option>
+                <option value="minimal">minimal</option>
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+                <option value="xhigh">xhigh</option>
+              </select>
+            </label>
+          </div>
+          <div class="form-grid two">
+            <label>
+              <span>Model</span>
+              <input id="settingsModel" autocomplete="off" placeholder="config" />
+            </label>
+            <label>
+              <span>Base URL</span>
+              <input id="settingsBaseUrl" autocomplete="off" placeholder="config" />
+            </label>
+          </div>
+          <label>
+            <span>API Key Env</span>
+            <input id="settingsApiKeyEnv" autocomplete="off" placeholder="config" />
+          </label>
+          <label>
+            <span>Extra Headers (JSON)</span>
+            <textarea id="settingsExtraHeaders" rows="3" spellcheck="false" placeholder='{"X-Custom-Header": "value"}'></textarea>
+          </label>
+          <div class="launch-actions">
+            <button class="primary-action icon-button launch-submit" type="submit" aria-label="Save settings" title="Save settings">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M5 12h12"></path>
+                <path d="m13 6 6 6-6 6"></path>
+              </svg>
+            </button>
+            <div class="form-status" id="settingsStatus"></div>
+          </div>
+        </form>
       </section>
     </div>
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -477,6 +477,36 @@ impl SessionManager {
             .map_err(|error| anyhow!(error.to_string()))
     }
 
+    /// Deletes a session and all related data (threads, episodes, worksets,
+    /// workset_items) from the store. If the session is currently active in
+    /// memory, any running task is gracefully cancelled before removal.
+    pub async fn delete_session(&self, session_id: &str) -> Result<()> {
+        // Cancel any active run and remove from the in-memory map.
+        {
+            let active = self.inner.active_sessions.read().await;
+            if let Some(service) = active.get(session_id) {
+                if let Some(active_run) = service.active_run() {
+                    let _ = service
+                        .connect_client()
+                        .request_cancel(&active_run.run_id)
+                        .await;
+                }
+            }
+        }
+        self.inner
+            .active_sessions
+            .write()
+            .await
+            .remove(session_id);
+
+        // Cascade-delete all DB rows for this session.
+        let deleted = view::delete_session(&self.inner.store_path, session_id)?;
+        if !deleted {
+            return Err(anyhow!("session '{}' was not found", session_id));
+        }
+        Ok(())
+    }
+
     async fn resume_session(&self, session_id: &str) -> Result<SessionService> {
         let summary = self
             .list_sessions(false)
@@ -518,7 +548,7 @@ pub fn router(manager: SessionManager) -> Router {
         .route("/store", get(store_info))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/{session_id}/workspace/diff", get(workspace_diff))
-        .route("/sessions/{session_id}", get(session_snapshot))
+        .route("/sessions/{session_id}", get(session_snapshot).delete(delete_session_handler))
         .route("/sessions/{session_id}/runs", post(submit_prompt))
         .route("/sessions/{session_id}/events", get(recent_events))
         .route("/sessions/{session_id}/events/stream", get(stream_events))
@@ -697,6 +727,14 @@ async fn cancel_active_run(
 ) -> std::result::Result<StatusCode, ApiError> {
     manager.cancel_active_run(&session_id).await?;
     Ok(StatusCode::ACCEPTED)
+}
+
+async fn delete_session_handler(
+    State(manager): State<SessionManager>,
+    AxumPath(session_id): AxumPath<String>,
+) -> std::result::Result<StatusCode, ApiError> {
+    manager.delete_session(&session_id).await?;
+    Ok(StatusCode::OK)
 }
 
 fn model_options(

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, VecDeque},
     convert::Infallible,
     net::SocketAddr,
     path::PathBuf,
@@ -16,7 +16,7 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         Html, IntoResponse, Response,
     },
-    routing::{get, post},
+    routing::{get, patch, post},
     Json, Router,
 };
 use nac_core::{
@@ -28,6 +28,7 @@ use nac_core::{
         ActiveRunSnapshot, SessionEventReceiver, SessionFrontendSnapshot, SessionRunHandle,
         SessionService, SessionSubmitError,
     },
+    sessions,
     view::{self, SessionSummarySnapshot},
 };
 use serde::{Deserialize, Serialize};
@@ -115,6 +116,17 @@ pub struct SandboxRequest {
     pub shm_size: Option<String>,
     pub session_key: Option<String>,
     pub workdir: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateConfigRequest {
+    pub model: Option<String>,
+    pub base_url: Option<String>,
+    pub backend: Option<String>,
+    pub reasoning_effort: Option<String>,
+    pub api_key_env: Option<String>,
+    /// JSON string of `BTreeMap<String, String>`. An empty string clears the map.
+    pub extra_headers: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -507,6 +519,92 @@ impl SessionManager {
         Ok(())
     }
 
+    /// Updates the model configuration of an existing session in the DB,
+    /// then removes it from the in-memory `active_sessions` map so that the
+    /// next `attach_session` call re-resumes it with the new config.
+    /// Returns an error if a run is currently active.
+    pub async fn update_session_config(
+        &self,
+        session_id: &str,
+        request: UpdateConfigRequest,
+    ) -> Result<()> {
+        // 1. Check that no run is active.
+        {
+            let active = self.inner.active_sessions.read().await;
+            if let Some(service) = active.get(session_id) {
+                if service.active_run().is_some() {
+                    return Err(anyhow!(
+                        "session is busy with an active run; cancel it before updating config"
+                    ));
+                }
+            }
+        }
+
+        // 2. Load the current snapshot from DB.
+        let mut snapshot = sessions::load_session(&self.inner.store_path, session_id)?;
+
+        // 3. Apply overrides.
+        if let Some(model) = request.model {
+            let trimmed = model.trim().to_string();
+            snapshot.model = if trimmed.is_empty() {
+                // Fall back to a sensible default — keep current if empty.
+                snapshot.model
+            } else {
+                trimmed
+            };
+        }
+        if let Some(base_url) = request.base_url {
+            let trimmed = base_url.trim().to_string();
+            if !trimmed.is_empty() {
+                snapshot.base_url = trimmed;
+            }
+        }
+        if let Some(backend) = request.backend {
+            let trimmed = backend.trim();
+            if !trimmed.is_empty() {
+                snapshot.backend = parse_json_string_enum::<BackendKind>(trimmed)?;
+            }
+        }
+        if let Some(effort) = request.reasoning_effort {
+            let trimmed = effort.trim();
+            if trimmed.is_empty() {
+                snapshot.reasoning_effort = None;
+            } else {
+                snapshot.reasoning_effort =
+                    Some(parse_json_string_enum::<ReasoningEffort>(trimmed)?);
+            }
+        }
+        if let Some(api_key_env) = request.api_key_env {
+            let trimmed = api_key_env.trim();
+            snapshot.api_key_env = if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            };
+        }
+        if let Some(extra_headers_json) = request.extra_headers {
+            let trimmed = extra_headers_json.trim();
+            if trimmed.is_empty() {
+                snapshot.extra_headers = BTreeMap::new();
+            } else {
+                snapshot.extra_headers = serde_json::from_str::<BTreeMap<String, String>>(trimmed)
+                    .context("failed to parse extra_headers as JSON object")?;
+            }
+        }
+
+        // 4. Save the updated snapshot to DB.
+        sessions::save_session(&self.inner.store_path, &snapshot)?;
+
+        // 5. Remove from active_sessions so the next attach re-resumes.
+        self.inner
+            .active_sessions
+            .write()
+            .await
+            .remove(session_id);
+
+        Ok(())
+    }
+
     async fn resume_session(&self, session_id: &str) -> Result<SessionService> {
         let summary = self
             .list_sessions(false)
@@ -549,6 +647,7 @@ pub fn router(manager: SessionManager) -> Router {
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/{session_id}/workspace/diff", get(workspace_diff))
         .route("/sessions/{session_id}", get(session_snapshot).delete(delete_session_handler))
+        .route("/sessions/{session_id}/config", patch(update_config_handler))
         .route("/sessions/{session_id}/runs", post(submit_prompt))
         .route("/sessions/{session_id}/events", get(recent_events))
         .route("/sessions/{session_id}/events/stream", get(stream_events))
@@ -734,6 +833,15 @@ async fn delete_session_handler(
     AxumPath(session_id): AxumPath<String>,
 ) -> std::result::Result<StatusCode, ApiError> {
     manager.delete_session(&session_id).await?;
+    Ok(StatusCode::OK)
+}
+
+async fn update_config_handler(
+    State(manager): State<SessionManager>,
+    AxumPath(session_id): AxumPath<String>,
+    Json(request): Json<UpdateConfigRequest>,
+) -> std::result::Result<StatusCode, ApiError> {
+    manager.update_session_config(&session_id, request).await?;
     Ok(StatusCode::OK)
 }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -116,6 +116,7 @@ pub struct SandboxRequest {
     pub shm_size: Option<String>,
     pub session_key: Option<String>,
     pub workdir: Option<String>,
+    pub backend: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -876,6 +877,7 @@ fn sandbox_options(request: SandboxRequest) -> SandboxOptions {
         sandbox_shm_size: request.shm_size,
         sandbox_session_key: request.session_key,
         sandbox_workdir: request.workdir,
+        sandbox_backend: request.backend,
     }
 }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -752,6 +752,8 @@ fn model_options(
             .transpose()?,
         api_base_url: base_url,
         api_model: model,
+        api_key_env: None,
+        extra_headers: None,
     })
 }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -496,7 +496,8 @@ impl SessionManager {
     /// workset_items) from the store. If the session is currently active in
     /// memory, any running task is gracefully cancelled before removal.
     pub async fn delete_session(&self, session_id: &str) -> Result<()> {
-        // Cancel any active run and remove from the in-memory map.
+        // Cancel any active run, destroy the sandbox, and remove from the
+        // in-memory map.
         {
             let active = self.inner.active_sessions.read().await;
             if let Some(service) = active.get(session_id) {
@@ -506,6 +507,9 @@ impl SessionManager {
                         .request_cancel(&active_run.run_id)
                         .await;
                 }
+                // Explicitly destroy the sandbox so it is torn down even
+                // if SSE handlers or other clones keep the Arc alive.
+                service.destroy_sandbox().await;
             }
         }
         self.inner

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -117,6 +117,8 @@ pub struct SandboxRequest {
     pub session_key: Option<String>,
     pub workdir: Option<String>,
     pub backend: Option<String>,
+    pub cpus: Option<u8>,
+    pub memory_mib: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -878,6 +880,8 @@ fn sandbox_options(request: SandboxRequest) -> SandboxOptions {
         sandbox_session_key: request.session_key,
         sandbox_workdir: request.workdir,
         sandbox_backend: request.backend,
+        sandbox_cpus: request.cpus,
+        sandbox_mem: request.memory_mib,
     }
 }
 

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -217,6 +217,14 @@ struct SandboxArgs {
     #[arg(long = "sandbox-backend")]
     sandbox_backend: Option<String>,
 
+    /// Number of CPUs to allocate for the sandbox (default: 2).
+    #[arg(long = "sandbox-cpus")]
+    sandbox_cpus: Option<u8>,
+
+    /// Memory in MiB to allocate for the sandbox (default: 2048).
+    #[arg(long = "sandbox-mem")]
+    sandbox_mem: Option<u32>,
+
     /// Internal sandbox session key used to attach worker subprocesses.
     #[arg(long, hide = true)]
     sandbox_session_key: Option<String>,
@@ -330,6 +338,8 @@ async fn run_managed_worker(cli: ManagedWorkerCli) -> Result<()> {
             sandbox_session_key: cli.sandbox.sandbox_session_key,
             sandbox_workdir: cli.sandbox.sandbox_workdir,
             sandbox_backend: cli.sandbox.sandbox_backend,
+            sandbox_cpus: cli.sandbox.sandbox_cpus,
+            sandbox_mem: cli.sandbox.sandbox_mem,
         },
         ssh_host: cli.ssh_host,
     };

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -185,7 +185,7 @@ struct WorkerDispatchArgs {
 
 #[derive(clap::Args)]
 struct SandboxArgs {
-    /// Run tool execution inside a session-scoped Podman sandbox.
+    /// Run tool execution inside a session-scoped sandbox.
     #[arg(long)]
     sandbox: bool,
 
@@ -212,6 +212,10 @@ struct SandboxArgs {
     /// Sandbox /dev/shm size.
     #[arg(long = "sandbox-shm-size")]
     sandbox_shm_size: Option<String>,
+
+    /// Sandbox backend to use (podman or smolvm).
+    #[arg(long = "sandbox-backend")]
+    sandbox_backend: Option<String>,
 
     /// Internal sandbox session key used to attach worker subprocesses.
     #[arg(long, hide = true)]
@@ -325,6 +329,7 @@ async fn run_managed_worker(cli: ManagedWorkerCli) -> Result<()> {
             sandbox_shm_size: cli.sandbox.sandbox_shm_size,
             sandbox_session_key: cli.sandbox.sandbox_session_key,
             sandbox_workdir: cli.sandbox.sandbox_workdir,
+            sandbox_backend: cli.sandbox.sandbox_backend,
         },
         ssh_host: cli.ssh_host,
     };

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -150,6 +150,14 @@ struct ModelArgs {
     /// Internal model override used by managed workers.
     #[arg(long, hide = true)]
     api_model: Option<String>,
+
+    /// Internal api_key_env override used by managed workers to inherit session config.
+    #[arg(long = "api-key-env", hide = true)]
+    api_key_env: Option<String>,
+
+    /// Internal extra headers override (JSON object) used by managed workers to inherit session config.
+    #[arg(long = "extra-headers", hide = true)]
+    extra_headers: Option<String>,
 }
 
 #[derive(clap::Args)]
@@ -300,6 +308,12 @@ async fn run_managed_worker(cli: ManagedWorkerCli) -> Result<()> {
             reasoning_effort: cli.model.reasoning_effort.map(Into::into),
             api_base_url: cli.model.api_base_url,
             api_model: cli.model.api_model,
+            api_key_env: cli.model.api_key_env,
+            extra_headers: cli
+                .model
+                .extra_headers
+                .as_deref()
+                .and_then(runtime::parse_extra_headers_json),
         },
         sandbox: SandboxOptions {
             sandbox: cli.sandbox.sandbox,

--- a/crates/nac-tui/src/cli/args.rs
+++ b/crates/nac-tui/src/cli/args.rs
@@ -135,6 +135,14 @@ pub(super) struct ModelArgs {
     /// Internal model override used by managed workers and resume
     #[arg(long, hide = true)]
     pub(super) api_model: Option<String>,
+
+    /// Internal api_key_env override used by managed workers to inherit session config
+    #[arg(long = "api-key-env", hide = true)]
+    pub(super) api_key_env: Option<String>,
+
+    /// Internal extra headers override (JSON object) used by managed workers to inherit session config
+    #[arg(long = "extra-headers", hide = true)]
+    pub(super) extra_headers: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/nac-tui/src/cli/args.rs
+++ b/crates/nac-tui/src/cli/args.rs
@@ -202,6 +202,14 @@ pub(super) struct SandboxArgs {
     #[arg(long = "sandbox-backend")]
     pub(super) sandbox_backend: Option<String>,
 
+    /// Number of CPUs to allocate for the sandbox (default: 2)
+    #[arg(long = "sandbox-cpus")]
+    pub(super) sandbox_cpus: Option<u8>,
+
+    /// Memory in MiB to allocate for the sandbox (default: 2048)
+    #[arg(long = "sandbox-mem")]
+    pub(super) sandbox_mem: Option<u32>,
+
     /// Internal sandbox session key used to attach worker subprocesses
     #[arg(long, hide = true)]
     pub(super) sandbox_session_key: Option<String>,

--- a/crates/nac-tui/src/cli/args.rs
+++ b/crates/nac-tui/src/cli/args.rs
@@ -170,7 +170,7 @@ pub(super) struct WorkerDispatchArgs {
 
 #[derive(clap::Args)]
 pub(super) struct SandboxArgs {
-    /// Run tool execution inside a session-scoped Podman sandbox
+    /// Run tool execution inside a session-scoped sandbox
     #[arg(long)]
     pub(super) sandbox: bool,
 
@@ -197,6 +197,10 @@ pub(super) struct SandboxArgs {
     /// Sandbox /dev/shm size (default: 0, meaning uncapped by Podman)
     #[arg(long = "sandbox-shm-size")]
     pub(super) sandbox_shm_size: Option<String>,
+
+    /// Sandbox backend to use (podman or smolvm)
+    #[arg(long = "sandbox-backend")]
+    pub(super) sandbox_backend: Option<String>,
 
     /// Internal sandbox session key used to attach worker subprocesses
     #[arg(long, hide = true)]

--- a/crates/nac-tui/src/cli/mod.rs
+++ b/crates/nac-tui/src/cli/mod.rs
@@ -252,6 +252,7 @@ fn sandbox_options(cli: SandboxArgs) -> SandboxOptions {
         sandbox_shm_size: cli.sandbox_shm_size,
         sandbox_session_key: cli.sandbox_session_key,
         sandbox_workdir: cli.sandbox_workdir,
+        sandbox_backend: cli.sandbox_backend,
     }
 }
 

--- a/crates/nac-tui/src/cli/mod.rs
+++ b/crates/nac-tui/src/cli/mod.rs
@@ -253,6 +253,8 @@ fn sandbox_options(cli: SandboxArgs) -> SandboxOptions {
         sandbox_session_key: cli.sandbox_session_key,
         sandbox_workdir: cli.sandbox_workdir,
         sandbox_backend: cli.sandbox_backend,
+        sandbox_cpus: cli.sandbox_cpus,
+        sandbox_mem: cli.sandbox_mem,
     }
 }
 

--- a/crates/nac-tui/src/cli/mod.rs
+++ b/crates/nac-tui/src/cli/mod.rs
@@ -227,11 +227,17 @@ fn store_options(cli: StoreArgs) -> StoreOptions {
 }
 
 fn model_options(cli: ModelArgs) -> ModelOptions {
+    let extra_headers = cli
+        .extra_headers
+        .as_deref()
+        .and_then(runtime::parse_extra_headers_json);
     ModelOptions {
         backend: cli.backend.map(Into::into),
         reasoning_effort: cli.reasoning_effort.map(Into::into),
         api_base_url: cli.api_base_url,
         api_model: cli.api_model,
+        api_key_env: cli.api_key_env,
+        extra_headers,
     }
 }
 

--- a/crates/nac-tui/src/tui/app.rs
+++ b/crates/nac-tui/src/tui/app.rs
@@ -1083,6 +1083,7 @@ impl App {
                 exit_code,
                 timed_out,
                 timeout_reason,
+                ..
             } => {
                 let entry = self
                     .threads
@@ -1133,6 +1134,7 @@ impl App {
             AgentEvent::AssistantMessage {
                 thread_name,
                 content,
+                ..
             } => match thread_name {
                 Some(thread_name) => {
                     if let Some(thread) = self.threads.get_mut(&thread_name) {

--- a/crates/nac-tui/src/tui/mod.rs
+++ b/crates/nac-tui/src/tui/mod.rs
@@ -404,6 +404,7 @@ mod tests {
     };
     use nac_core::test_support::{sessions, store};
     use ratatui::backend::TestBackend;
+    use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1465,6 +1466,8 @@ mod tests {
             None,
             None,
             messages,
+        None,
+        BTreeMap::new(),
         );
         snapshot.last_response_duration_ms = Some(3_333);
         snapshot.previous_response_duration_ms = Some(2_222);

--- a/crates/nac-tui/src/tui/mod.rs
+++ b/crates/nac-tui/src/tui/mod.rs
@@ -1278,6 +1278,7 @@ mod tests {
             exit_code: 0,
             timed_out: false,
             timeout_reason: None,
+            usage: None,
         });
         let thread = app.threads.get("auth").unwrap();
         assert_eq!(thread.state, ThreadState::Idle);
@@ -1387,6 +1388,7 @@ mod tests {
         app.apply_agent_event(AgentEvent::AssistantMessage {
             thread_name: None,
             content: "ignored".to_string(),
+            usage: None,
         });
         assert!(app.responses.is_empty());
 

--- a/crates/nac-tui/src/tui/mod.rs
+++ b/crates/nac-tui/src/tui/mod.rs
@@ -428,6 +428,10 @@ mod tests {
             session_id: None,
             sandbox_status: "off".to_string(),
             agents_md_status: "off".to_string(),
+            base_url: String::new(),
+            reasoning_effort: None,
+            api_key_env: None,
+            extra_headers: std::collections::BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches sandbox lifecycle, SQLite session schema/migrations, model request shaping, and credential propagation to workers—wide surface area but mostly additive with tests; smolvm/sandbox destroy paths warrant careful manual verification.
> 
> **Overview**
> Adds a **smolvm** sandbox option (microVM isolation via `smolvm machine run/exec`) alongside Podman, with configurable **CPU/memory**, shared mounts/image defaults, and explicit **sandbox destroy** on session teardown. README documents `--sandbox-backend smolvm` and config `[sandbox].backend`.
> 
> Introduces end-to-end **token usage** (`TokenUsage`): parsed from OpenAI/Anthropic/chat responses (including cache read/write), accumulated across orchestrator turns and **worker threads**, attached to `AssistantMessage` / `ThreadFinished` events, persisted per assistant response in the session store, and surfaced in the web dashboard (tabular run/token/context stats and per-message duration).
> 
> **Anthropic** requests now attach **ephemeral prompt-cache** breakpoints (system, tools, last message) with optional **1-hour TTL** on the orchestrator (`with_cache_ttl("1h")` + beta header); workers keep the default 5-minute cache.
> 
> **Resume and workers** store **`api_key_env` and `extra_headers` on the session snapshot** so resumed runs and spawned workers match creation-time credentials/headers; CLI can override model headers without leaking config when an empty `{}` is passed. Session **delete** cascades DB rows and tears down sandboxes. Minor fixes: dedupe skill sources when cwd equals home; `sessions` module is public for callers.
> 
> Web **CSS** updates: pinned session sections, inspector delete actions, thread expand/detail styling, compact confirm dialog, and telemetry typography for runs/tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aaba97fcad39cedf4a46b7bd7424a185a9ea8b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->