### PR TITLE
dag threads

### DIFF
--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -1,0 +1,701 @@
+use std::collections::{HashMap, HashSet};
+
+use tokio::task::JoinSet;
+
+use super::*;
+use crate::tools::thread::{self, ParsedDispatchParams};
+
+/// A successfully parsed `thread` tool call, ready for DAG-ordered execution.
+pub(crate) struct ParsedThreadDispatch {
+    pub original_index: usize,
+    pub tool_call_id: String,
+    /// Original JSON arguments string — preserved for `ToolCallStarted` event
+    /// previews.
+    pub args_str: String,
+    pub params: ParsedDispatchParams,
+}
+
+/// Partition a batch of tool calls into:
+///
+/// 1. `Vec<ParsedThreadDispatch>` — successfully parsed `thread` calls
+/// 2. `Vec<(usize, String, String, String)>` — non-thread calls as
+///    `(original_index, tool_call_id, tool_name, args_str)`
+/// 3. `Vec<(usize, String, ToolResult)>` — parse errors for malformed thread
+///    calls as `(original_index, tool_call_id, error_result)`
+#[allow(clippy::type_complexity)]
+pub(crate) fn partition_tool_calls(
+    tool_calls: Vec<ToolCall>,
+    runtime: &ToolRuntime,
+) -> (
+    Vec<ParsedThreadDispatch>,
+    Vec<(usize, String, String, String)>,
+    Vec<(usize, String, ToolResult)>,
+) {
+    let mut thread_dispatches = Vec::new();
+    let mut other_calls = Vec::new();
+    let mut parse_errors = Vec::new();
+
+    for (index, tool_call) in tool_calls.into_iter().enumerate() {
+        let id = tool_call.id;
+        let name = tool_call.function.name;
+        let args_str = tool_call.function.arguments;
+
+        if name == "thread" {
+            let args: serde_json::Value = match serde_json::from_str(&args_str) {
+                Ok(value) => value,
+                Err(error) => {
+                    parse_errors.push((
+                        index,
+                        id,
+                        ToolResult {
+                            content: format!(
+                                "Error: failed to parse tool arguments for '{}': {}",
+                                name, error
+                            ),
+                            is_error: true,
+                        },
+                    ));
+                    continue;
+                }
+            };
+
+            match thread::parse_dispatch_args(&args, runtime) {
+                Ok(params) => {
+                    thread_dispatches.push(ParsedThreadDispatch {
+                        original_index: index,
+                        tool_call_id: id,
+                        args_str,
+                        params,
+                    });
+                }
+                Err(error_result) => {
+                    parse_errors.push((index, id, error_result));
+                }
+            }
+        } else {
+            other_calls.push((index, id, name, args_str));
+        }
+    }
+
+    (thread_dispatches, other_calls, parse_errors)
+}
+
+/// Dependency DAG for a batch of thread dispatches.
+#[derive(Debug)]
+pub(crate) struct Dag {
+    /// Topologically ordered waves.  Each wave is a list of indices into the
+    /// dispatches `Vec`.  All dispatches in a wave have zero in-batch
+    /// dependencies and can run concurrently.
+    pub waves: Vec<Vec<usize>>,
+    /// Thread name → dispatch index.  Used during construction; retained for
+    /// debugging and potential future lookups.
+    #[allow(dead_code)]
+    pub name_to_index: HashMap<String, usize>,
+    /// Dispatch index → list of source dispatch indices (in-batch deps only).
+    pub in_batch_deps: HashMap<usize, Vec<usize>>,
+}
+
+/// Error returned by [`build_dag`].
+#[derive(Debug)]
+pub(crate) enum DagError {
+    DuplicateName(String),
+    Cycle(String),
+}
+
+/// Build a [`Dag`] from a slice of parsed thread dispatches.
+///
+/// Only `source_threads` that name *other threads in the same batch* become
+/// edges.  Sources that refer to pre-existing threads from prior turns are
+/// ignored — those are loaded normally by the worker, not ordered by the DAG.
+pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagError> {
+    let n = dispatches.len();
+    if n == 0 {
+        return Ok(Dag {
+            waves: Vec::new(),
+            name_to_index: HashMap::new(),
+            in_batch_deps: HashMap::new(),
+        });
+    }
+
+    // 1. Build name→index map and check for duplicate names.
+    let mut name_to_index: HashMap<String, usize> = HashMap::new();
+    for (i, dispatch) in dispatches.iter().enumerate() {
+        let name = &dispatch.params.thread_name;
+        if name_to_index.contains_key(name) {
+            return Err(DagError::DuplicateName(name.clone()));
+        }
+        name_to_index.insert(name.clone(), i);
+    }
+
+    let batch_thread_names: HashSet<String> = name_to_index.keys().cloned().collect();
+
+    // 2. Build in-batch deps and adjacency list for Kahn's algorithm.
+    let mut in_batch_deps: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); n]; // adjacency[i] = nodes that depend on i
+    let mut in_degree = vec![0usize; n];
+
+    for (i, dispatch) in dispatches.iter().enumerate() {
+        let mut deps: Vec<usize> = Vec::new();
+        for source in &dispatch.params.source_threads {
+            // Only sources that are in this batch become edges.
+            if batch_thread_names.contains(source) {
+                let dep_idx = name_to_index[source];
+
+                // Self-dependency is a cycle.
+                if dep_idx == i {
+                    return Err(DagError::Cycle(format!(
+                        "Thread '{}' depends on itself",
+                        dispatch.params.thread_name
+                    )));
+                }
+
+                if !deps.contains(&dep_idx) {
+                    deps.push(dep_idx);
+                }
+            }
+        }
+
+        for &dep_idx in &deps {
+            adjacency[dep_idx].push(i);
+            in_degree[i] += 1;
+        }
+        in_batch_deps.insert(i, deps);
+    }
+
+    // 3. Kahn's algorithm — collect nodes level-by-level into waves.
+    let mut waves: Vec<Vec<usize>> = Vec::new();
+    let mut sorted_count = 0;
+    let mut current_in_degree = in_degree;
+
+    while sorted_count < n {
+        // Collect all nodes with in-degree 0 that haven't been sorted yet.
+        let wave: Vec<usize> = (0..n)
+            .filter(|&i| current_in_degree[i] == 0)
+            .collect();
+
+        if wave.is_empty() {
+            // Cycle detected — report the remaining nodes.
+            let remaining: Vec<String> = (0..n)
+                .filter(|i| current_in_degree[*i] > 0)
+                .map(|i| dispatches[i].params.thread_name.clone())
+                .collect();
+            return Err(DagError::Cycle(format!(
+                "Circular dependency detected among threads: {}",
+                remaining.join(", ")
+            )));
+        }
+
+        // Decrement in-degree for neighbors and mark wave nodes as sorted.
+        for &node in &wave {
+            for &neighbor in &adjacency[node] {
+                current_in_degree[neighbor] -= 1;
+            }
+            current_in_degree[node] = usize::MAX; // sentinel: sorted
+        }
+
+        sorted_count += wave.len();
+        waves.push(wave);
+    }
+
+    Ok(Dag {
+        waves,
+        name_to_index,
+        in_batch_deps,
+    })
+}
+
+/// Execute a batch of tool calls using the DAG coordinator.
+///
+/// Thread dispatches are executed in topological waves.  Non-thread tool calls
+/// run concurrently with wave 0.  Parse errors are returned immediately.
+///
+/// The caller is responsible for calling [`partition_tool_calls`] and
+/// [`build_dag`] first.  This function manages the `active_threads` lifecycle
+/// for all thread dispatches in the batch.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn execute_with_dag(
+    thread_dispatches: Vec<ParsedThreadDispatch>,
+    mut other_calls: Vec<(usize, String, String, String)>,
+    parse_errors: Vec<(usize, String, ToolResult)>,
+    dag: Dag,
+    runtime: ToolRuntime,
+    client: ModelClient,
+    event_sink: EventSink,
+    agent_thread_name: Option<String>,
+) -> Vec<(String, String, ToolResult)> {
+    // Results: (original_index, tool_call_id, tool_name, ToolResult)
+    let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
+
+    // Map tool_call_id → dispatch index for failed-dispatch tracking.
+    let call_id_to_dispatch_idx: HashMap<String, usize> = thread_dispatches
+        .iter()
+        .enumerate()
+        .map(|(i, d)| (d.tool_call_id.clone(), i))
+        .collect();
+
+    // 1. Collect parse errors immediately.
+    for (index, tool_call_id, error_result) in parse_errors {
+        event_sink.emit(AgentEvent::ToolCallFinished {
+            thread_name: agent_thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: "thread".to_string(),
+            content_preview: preview_tool_result("thread", &error_result),
+            is_error: error_result.is_error,
+        });
+        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
+    }
+
+    // 2. Pre-mark ALL thread names in active_threads.
+    let mut failed_indices: HashSet<usize> = HashSet::new();
+    for (i, dispatch) in thread_dispatches.iter().enumerate() {
+        if !thread::mark_thread_active(&runtime, &dispatch.params.thread_name).await {
+            let result = ToolResult {
+                content: format!(
+                    "Thread '{}' is already running; retry after the current dispatch completes.",
+                    dispatch.params.thread_name
+                ),
+                is_error: true,
+            };
+            event_sink.emit(AgentEvent::ToolCallFinished {
+                thread_name: agent_thread_name.clone(),
+                call_id: dispatch.tool_call_id.clone(),
+                name: "thread".to_string(),
+                content_preview: preview_tool_result("thread", &result),
+                is_error: true,
+            });
+            all_results.push((
+                dispatch.original_index,
+                dispatch.tool_call_id.clone(),
+                "thread".to_string(),
+                result,
+            ));
+            failed_indices.insert(i);
+        }
+    }
+
+    // 3. Execute waves.
+    let Dag {
+        waves,
+        name_to_index: _,
+        in_batch_deps,
+    } = dag;
+
+    // Ensure at least one wave exists if there are other_calls but no threads.
+    let waves = if waves.is_empty() && !other_calls.is_empty() {
+        vec![Vec::new()]
+    } else {
+        waves
+    };
+
+    for (wave_idx, wave) in waves.iter().enumerate() {
+        let mut join_set: JoinSet<(usize, String, String, ToolResult)> = JoinSet::new();
+
+        // Wave 0: also spawn all non-thread tool calls.
+        if wave_idx == 0 {
+            let calls = std::mem::take(&mut other_calls);
+            for (index, tool_call_id, tool_name, args_str) in calls {
+                let runtime = runtime.clone();
+                let client = client.clone();
+                let event_sink = event_sink.clone();
+                let thread_name = agent_thread_name.clone();
+
+                event_sink.emit(AgentEvent::ToolCallStarted {
+                    thread_name: thread_name.clone(),
+                    call_id: tool_call_id.clone(),
+                    name: tool_name.clone(),
+                    args_preview: preview_tool_args(&tool_name, &args_str),
+                    args_detail: Some(tool_args_detail(&args_str)),
+                });
+
+                join_set.spawn(async move {
+                    let parsed_args = match serde_json::from_str::<serde_json::Value>(&args_str) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            return (
+                                index,
+                                tool_call_id,
+                                tool_name.clone(),
+                                ToolResult {
+                                    content: format!(
+                                        "Error: failed to parse tool arguments for '{}': {}",
+                                        tool_name, error
+                                    ),
+                                    is_error: true,
+                                },
+                            );
+                        }
+                    };
+                    let result = tools::execute_tool(&tool_name, parsed_args, &runtime, &client)
+                        .await;
+                    (index, tool_call_id, tool_name, result)
+                });
+            }
+        }
+
+        // Spawn thread dispatches for this wave.
+        for &dispatch_idx in wave {
+            if failed_indices.contains(&dispatch_idx) {
+                continue;
+            }
+
+            let dispatch = &thread_dispatches[dispatch_idx];
+
+            // Check if any in-batch deps failed in a previous wave.
+            let deps = in_batch_deps
+                .get(&dispatch_idx)
+                .cloned()
+                .unwrap_or_default();
+            let any_dep_failed = deps.iter().any(|dep_idx| failed_indices.contains(dep_idx));
+
+            if any_dep_failed {
+                let failed_dep_name = deps
+                    .iter()
+                    .find(|dep_idx| failed_indices.contains(dep_idx))
+                    .map(|dep_idx| &thread_dispatches[*dep_idx].params.thread_name)
+                    .cloned()
+                    .unwrap_or_default();
+
+                let result = ToolResult {
+                    content: format!(
+                        "Source thread '{}' failed; dispatch '{}' skipped.",
+                        failed_dep_name,
+                        dispatch.params.thread_name
+                    ),
+                    is_error: true,
+                };
+
+                event_sink.emit(AgentEvent::ToolCallFinished {
+                    thread_name: agent_thread_name.clone(),
+                    call_id: dispatch.tool_call_id.clone(),
+                    name: "thread".to_string(),
+                    content_preview: preview_tool_result("thread", &result),
+                    is_error: true,
+                });
+
+                all_results.push((
+                    dispatch.original_index,
+                    dispatch.tool_call_id.clone(),
+                    "thread".to_string(),
+                    result,
+                ));
+
+                failed_indices.insert(dispatch_idx);
+                continue;
+            }
+
+            // Emit ToolCallStarted for the thread dispatch.
+            event_sink.emit(AgentEvent::ToolCallStarted {
+                thread_name: agent_thread_name.clone(),
+                call_id: dispatch.tool_call_id.clone(),
+                name: "thread".to_string(),
+                args_preview: preview_tool_args("thread", &dispatch.args_str),
+                args_detail: Some(tool_args_detail(&dispatch.args_str)),
+            });
+
+            // Spawn execute_parsed_dispatch.
+            let runtime = runtime.clone();
+            let client = client.clone();
+            let params = dispatch.params.clone();
+            let id = dispatch.tool_call_id.clone();
+            let original_index = dispatch.original_index;
+
+            join_set.spawn(async move {
+                let result = thread::execute_parsed_dispatch(params, &runtime, &client).await;
+                (original_index, id, "thread".to_string(), result)
+            });
+        }
+
+        // Await all tasks in the JoinSet.
+        while let Some(join_result) = join_set.join_next().await {
+            match join_result {
+                Ok((index, tool_call_id, tool_name, result)) => {
+                    event_sink.emit(AgentEvent::ToolCallFinished {
+                        thread_name: agent_thread_name.clone(),
+                        call_id: tool_call_id.clone(),
+                        name: tool_name.clone(),
+                        content_preview: preview_tool_result(&tool_name, &result),
+                        is_error: result.is_error,
+                    });
+
+                    // Track failed thread dispatches for dependency checking.
+                    if result.is_error {
+                        if let Some(&dispatch_idx) = call_id_to_dispatch_idx.get(&tool_call_id) {
+                            failed_indices.insert(dispatch_idx);
+                        }
+                    }
+
+                    all_results.push((index, tool_call_id, tool_name, result));
+                }
+                Err(error) => {
+                    all_results.push((
+                        usize::MAX,
+                        "unknown".to_string(),
+                        "unknown".to_string(),
+                        ToolResult {
+                            content: format!("Tool task panicked: {}", error),
+                            is_error: true,
+                        },
+                    ));
+                }
+            }
+        }
+    }
+
+    // 4. Unmark all thread names from active_threads (including skipped ones).
+    for dispatch in &thread_dispatches {
+        thread::unmark_thread_active(&runtime, &dispatch.params.thread_name).await;
+    }
+
+    // 5. Sort by original index and return.
+    all_results.sort_by_key(|(index, ..)| *index);
+    all_results
+        .into_iter()
+        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventSink;
+    use crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS;
+    use crate::types::{FunctionCall, ToolCall};
+    use serde_json::json;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    // ------------------------------------------------------------------
+    // Test helpers
+    // ------------------------------------------------------------------
+
+    fn make_dispatch(index: usize, name: &str, source_threads: &[&str]) -> ParsedThreadDispatch {
+        let args = json!({
+            "name": name,
+            "action": "test action",
+            "threads": source_threads,
+        });
+        let args_str = serde_json::to_string(&args).unwrap();
+        ParsedThreadDispatch {
+            original_index: index,
+            tool_call_id: format!("call_{}", index),
+            args_str,
+            params: ParsedDispatchParams {
+                thread_name: name.to_string(),
+                action: "test action".to_string(),
+                source_threads: source_threads.iter().map(|s| s.to_string()).collect(),
+                scheduled_skills: Vec::new(),
+                session_id: "test-session".to_string(),
+                timeout_secs: DEFAULT_THREAD_TIMEOUT_SECS,
+            },
+        }
+    }
+
+    fn make_tool_call(id: &str, name: &str, args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: serde_json::to_string(&args).unwrap(),
+            },
+        }
+    }
+
+    fn test_runtime() -> ToolRuntime {
+        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
+        ToolRuntime {
+            config_cwd: workspace_cwd.clone(),
+            workspace_cwd,
+            store_path: PathBuf::new(),
+            session_id: Some("test-session".to_string()),
+            worker_executable: None,
+            active_threads: Arc::new(Mutex::new(HashSet::new())),
+            event_sink: EventSink::none(),
+            backend,
+            mcp: None,
+            skills: None,
+            terminal_manager: crate::terminal::TerminalManager::new(),
+            thread_timeout_secs: DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // build_dag tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_build_dag_no_deps() {
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &[]),
+            make_dispatch(2, "C", &[]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 1, "3 independent threads → 1 wave");
+        assert_eq!(dag.waves[0].len(), 3);
+
+        // All three should be in the single wave.
+        let wave0: HashSet<usize> = dag.waves[0].iter().copied().collect();
+        assert!(wave0.contains(&0));
+        assert!(wave0.contains(&1));
+        assert!(wave0.contains(&2));
+
+        // No in-batch deps for any dispatch.
+        for i in 0..3 {
+            assert!(dag.in_batch_deps.get(&i).unwrap().is_empty());
+        }
+    }
+
+    #[test]
+    fn test_build_dag_linear_chain() {
+        // A → B → C
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A"]),
+            make_dispatch(2, "C", &["B"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 3, "linear chain → 3 waves");
+        assert_eq!(dag.waves[0], vec![0], "wave 0: A");
+        assert_eq!(dag.waves[1], vec![1], "wave 1: B");
+        assert_eq!(dag.waves[2], vec![2], "wave 2: C");
+
+        // B depends on A, C depends on B.
+        assert!(dag.in_batch_deps.get(&0).unwrap().is_empty());
+        assert_eq!(dag.in_batch_deps.get(&1).unwrap(), &vec![0usize]);
+        assert_eq!(dag.in_batch_deps.get(&2).unwrap(), &vec![1usize]);
+    }
+
+    #[test]
+    fn test_build_dag_diamond() {
+        // A → {B, C}, {B, C} → D
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A"]),
+            make_dispatch(2, "C", &["A"]),
+            make_dispatch(3, "D", &["B", "C"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 3, "diamond → 3 waves");
+        assert_eq!(dag.waves[0], vec![0], "wave 0: A");
+
+        // Wave 1 should contain both B and C (order may vary, but both present).
+        let wave1: HashSet<usize> = dag.waves[1].iter().copied().collect();
+        assert_eq!(wave1.len(), 2);
+        assert!(wave1.contains(&1));
+        assert!(wave1.contains(&2));
+
+        assert_eq!(dag.waves[2], vec![3], "wave 2: D");
+
+        // D depends on both B and C.
+        let d_deps = dag.in_batch_deps.get(&3).unwrap();
+        assert!(d_deps.contains(&1));
+        assert!(d_deps.contains(&2));
+    }
+
+    #[test]
+    fn test_build_dag_filters_out_of_batch_sources() {
+        // B has source_threads=["A", "preexisting"], only A is in the batch.
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A", "preexisting"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 2);
+        assert_eq!(dag.waves[0], vec![0], "wave 0: A");
+        assert_eq!(dag.waves[1], vec![1], "wave 1: B");
+
+        // B's only in-batch dep is A (index 0). "preexisting" is ignored.
+        let b_deps = dag.in_batch_deps.get(&1).unwrap();
+        assert_eq!(b_deps, &vec![0], "only A should be an in-batch dep");
+    }
+
+    #[test]
+    fn test_build_dag_detects_cycle() {
+        // A → B, B → A
+        let dispatches = vec![
+            make_dispatch(0, "A", &["B"]),
+            make_dispatch(1, "B", &["A"]),
+        ];
+
+        let err = build_dag(&dispatches).unwrap_err();
+        assert!(matches!(err, DagError::Cycle(_)));
+    }
+
+    #[test]
+    fn test_build_dag_detects_duplicate_names() {
+        let dispatches = vec![
+            make_dispatch(0, "X", &[]),
+            make_dispatch(1, "X", &[]),
+        ];
+
+        let err = build_dag(&dispatches).unwrap_err();
+        match err {
+            DagError::DuplicateName(name) => assert_eq!(name, "X"),
+            other => panic!("expected DuplicateName, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_build_dag_self_dependency() {
+        // A lists itself as a source thread.
+        let dispatches = vec![make_dispatch(0, "A", &["A"])];
+
+        let err = build_dag(&dispatches).unwrap_err();
+        assert!(matches!(err, DagError::Cycle(_)));
+    }
+
+    // ------------------------------------------------------------------
+    // partition_tool_calls tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_partition_separates_thread_and_non_thread() {
+        let runtime = test_runtime();
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({"name": "A", "action": "work"})),
+            make_tool_call("call_1", "read", json!({"path": "src/main.rs"})),
+            make_tool_call("call_2", "thread", json!({"name": "B", "action": "work", "threads": ["A"]})),
+        ];
+
+        let (thread_dispatches, other_calls, parse_errors) =
+            partition_tool_calls(tool_calls, &runtime);
+
+        assert_eq!(thread_dispatches.len(), 2);
+        assert_eq!(thread_dispatches[0].params.thread_name, "A");
+        assert_eq!(thread_dispatches[1].params.thread_name, "B");
+        assert_eq!(thread_dispatches[1].params.source_threads, vec!["A"]);
+
+        assert_eq!(other_calls.len(), 1);
+        assert_eq!(other_calls[0].0, 1, "original_index preserved");
+        assert_eq!(other_calls[0].1, "call_1");
+        assert_eq!(other_calls[0].2, "read");
+
+        assert!(parse_errors.is_empty());
+    }
+
+    #[test]
+    fn test_partition_returns_error_for_missing_name() {
+        let runtime = test_runtime();
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({"action": "work"})), // missing "name"
+        ];
+
+        let (thread_dispatches, other_calls, parse_errors) =
+            partition_tool_calls(tool_calls, &runtime);
+
+        assert!(thread_dispatches.is_empty());
+        assert!(other_calls.is_empty());
+        assert_eq!(parse_errors.len(), 1);
+        assert_eq!(parse_errors[0].0, 0, "original_index preserved");
+        assert_eq!(parse_errors[0].1, "call_0");
+        assert!(parse_errors[0].2.is_error);
+        assert!(parse_errors[0].2.content.contains("'name'"));
+    }
+}

--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -307,14 +307,16 @@ pub(crate) fn spawn_non_thread_into(
 /// Execute a batch of tool calls using the DAG coordinator.
 ///
 /// Thread dispatches are executed in topological waves.  Non-thread tool calls
-/// run concurrently with wave 0.  Parse errors are returned immediately.
+/// run concurrently in a separate `JoinSet` alongside all waves, so they
+/// neither block wave progression nor affect thread failure tracking.  Parse
+/// errors are returned immediately.
 ///
 /// The caller is responsible for calling [`partition_tool_calls`] and
 /// [`build_dag`] first.  This function manages the `active_threads` lifecycle
 /// for all thread dispatches in the batch.
 pub(crate) async fn execute_with_dag(
     thread_dispatches: Vec<ParsedThreadDispatch>,
-    mut other_calls: Vec<(usize, String, String, String)>,
+    other_calls: Vec<(usize, String, String, String)>,
     parse_errors: Vec<(usize, String, String, ToolResult)>,
     dag: Dag,
     ctx: DagExecContext,
@@ -377,32 +379,34 @@ pub(crate) async fn execute_with_dag(
         }
     }
 
-    // 3. Execute waves.
+    // 3. Spawn non-thread tools into a separate JoinSet that runs
+    //    concurrently with all waves.  This isolates non-thread tool panics
+    //    from thread failure tracking and prevents long-running non-thread
+    //    tools from blocking wave progression.
+    let mut non_thread_join_set: JoinSet<(usize, Option<usize>, String, String, ToolResult)> =
+        JoinSet::new();
+    spawn_non_thread_into(
+        &mut non_thread_join_set,
+        other_calls,
+        &runtime,
+        &client,
+        &event_sink,
+        &agent_thread_name,
+    );
+
+    // 4. Execute waves.
     let Dag {
         waves,
         in_batch_deps,
     } = dag;
 
-    for (wave_idx, wave) in waves.iter().enumerate() {
+    for wave in waves.iter() {
         let mut join_set: JoinSet<(usize, Option<usize>, String, String, ToolResult)> =
             JoinSet::new();
         // Track which thread dispatches are in-flight (spawned but not yet
         // completed).  If a task panics, all remaining in-flight dispatches
         // are marked as failed so their dependents are skipped.
         let mut in_flight: HashSet<usize> = HashSet::new();
-
-        // Wave 0: also spawn all non-thread tool calls.
-        if wave_idx == 0 {
-            let calls = std::mem::take(&mut other_calls);
-            spawn_non_thread_into(
-                &mut join_set,
-                calls,
-                &runtime,
-                &client,
-                &event_sink,
-                &agent_thread_name,
-            );
-        }
 
         // Spawn thread dispatches for this wave.
         for &dispatch_idx in wave {
@@ -533,14 +537,43 @@ pub(crate) async fn execute_with_dag(
         }
     }
 
-    // 4. Unmark only threads we successfully marked (including skipped ones
+    // 5. Drain the non-thread JoinSet.  These tasks ran concurrently with all
+    //    waves.  Panics here produce error results but do not affect thread
+    //    failure tracking.
+    while let Some(join_result) = non_thread_join_set.join_next().await {
+        match join_result {
+            Ok((index, _, tool_call_id, tool_name, result)) => {
+                event_sink.emit(AgentEvent::ToolCallFinished {
+                    thread_name: agent_thread_name.clone(),
+                    call_id: tool_call_id.clone(),
+                    name: tool_name.clone(),
+                    content_preview: preview_tool_result(&tool_name, &result),
+                    is_error: result.is_error,
+                });
+                all_results.push((index, tool_call_id, tool_name, result));
+            }
+            Err(error) => {
+                all_results.push((
+                    usize::MAX,
+                    "unknown".to_string(),
+                    "unknown".to_string(),
+                    ToolResult {
+                        content: format!("Tool task panicked: {}", error),
+                        is_error: true,
+                    },
+                ));
+            }
+        }
+    }
+
+    // 6. Unmark only threads we successfully marked (including skipped ones
     //    that were marked but not spawned).  Threads that were already active
     //    from a prior turn were NOT marked by us, so we must not unmark them.
     for name in &marked_by_us {
         thread::unmark_thread_active(&runtime, name).await;
     }
 
-    // 5. Sort by original index and return.
+    // 7. Sort by original index and return.
     sort_and_strip_index(all_results)
 }
 

--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -394,42 +394,9 @@ pub(crate) async fn execute_with_dag(
         &agent_thread_name,
     );
 
-    // Spawn a background task to drain non-thread results concurrently with
-    // wave execution.  This emits `ToolCallFinished` events as each non-thread
-    // tool completes, rather than delaying them until all waves are done.
-    // Panics inside non-thread tools are caught here and do not affect thread
-    // failure tracking.
-    let non_thread_event_sink = event_sink.clone();
-    let non_thread_agent_name = agent_thread_name.clone();
-    let non_thread_drain = tokio::spawn(async move {
-        let mut results: Vec<(usize, String, String, ToolResult)> = Vec::new();
-        while let Some(join_result) = non_thread_join_set.join_next().await {
-            match join_result {
-                Ok((index, _, tool_call_id, tool_name, result)) => {
-                    non_thread_event_sink.emit(AgentEvent::ToolCallFinished {
-                        thread_name: non_thread_agent_name.clone(),
-                        call_id: tool_call_id.clone(),
-                        name: tool_name.clone(),
-                        content_preview: preview_tool_result(&tool_name, &result),
-                        is_error: result.is_error,
-                    });
-                    results.push((index, tool_call_id, tool_name, result));
-                }
-                Err(error) => {
-                    results.push((
-                        usize::MAX,
-                        "unknown".to_string(),
-                        "unknown".to_string(),
-                        ToolResult {
-                            content: format!("Tool task panicked: {}", error),
-                            is_error: true,
-                        },
-                    ));
-                }
-            }
-        }
-        results
-    });
+    // Track whether the non-thread JoinSet has been fully drained.  Once
+    // empty, we skip polling it in the wave loop to avoid a busy-wait spin.
+    let mut non_thread_empty = non_thread_join_set.is_empty();
 
     // 4. Execute waves.
     let Dag {
@@ -530,10 +497,60 @@ pub(crate) async fn execute_with_dag(
             });
         }
 
-        // Await all tasks in the JoinSet.
-        while let Some(join_result) = join_set.join_next().await {
-            match join_result {
-                Ok((index, dispatch_idx_opt, tool_call_id, tool_name, result)) => {
+        // Drain the wave JoinSet, concurrently polling the non-thread
+        // JoinSet so `ToolCallFinished` events for non-thread tools are
+        // emitted promptly.  Using `select!` (instead of a detached
+        // `tokio::spawn`) keeps everything in this async function — when
+        // the outer future is dropped via `task.abort()`, both JoinSets
+        // are dropped, which aborts all spawned tasks.  A detached spawn
+        // would survive the abort and keep running non-thread tools after
+        // the user pressed stop.
+        //
+        // `biased` prioritises the non-thread branch so finish events are
+        // emitted as early as possible.  The non-thread branch never
+        // breaks the loop — only the wave branch returning `None` (JoinSet
+        // drained) advances to the next wave.
+        loop {
+            let wave_res = if non_thread_empty {
+                join_set.join_next().await
+            } else {
+                tokio::select! {
+                    biased;
+                    nt_res = non_thread_join_set.join_next() => {
+                        match nt_res {
+                            Some(Ok((index, _, tool_call_id, tool_name, result))) => {
+                                event_sink.emit(AgentEvent::ToolCallFinished {
+                                    thread_name: agent_thread_name.clone(),
+                                    call_id: tool_call_id.clone(),
+                                    name: tool_name.clone(),
+                                    content_preview: preview_tool_result(&tool_name, &result),
+                                    is_error: result.is_error,
+                                });
+                                all_results.push((index, tool_call_id, tool_name, result));
+                            }
+                            Some(Err(error)) => {
+                                all_results.push((
+                                    usize::MAX,
+                                    "unknown".to_string(),
+                                    "unknown".to_string(),
+                                    ToolResult {
+                                        content: format!("Tool task panicked: {}", error),
+                                        is_error: true,
+                                    },
+                                ));
+                            }
+                            None => {
+                                non_thread_empty = true;
+                            }
+                        }
+                        continue;
+                    }
+                    wave_res = join_set.join_next() => wave_res
+                }
+            };
+
+            match wave_res {
+                Some(Ok((index, dispatch_idx_opt, tool_call_id, tool_name, result))) => {
                     // Remove from in-flight and track failures for thread dispatches.
                     if let Some(dispatch_idx) = dispatch_idx_opt {
                         in_flight.remove(&dispatch_idx);
@@ -557,7 +574,7 @@ pub(crate) async fn execute_with_dag(
 
                     all_results.push((index, tool_call_id, tool_name, result));
                 }
-                Err(error) => {
+                Some(Err(error)) => {
                     // A task panicked.  Mark all remaining in-flight thread
                     // dispatches as failed so dependents are skipped.
                     for &dispatch_idx in in_flight.iter() {
@@ -575,15 +592,39 @@ pub(crate) async fn execute_with_dag(
                         },
                     ));
                 }
+                None => break,
             }
         }
     }
 
-    // 5. Collect non-thread results from the background drain task.  The
-    //    tasks ran concurrently with all waves; `ToolCallFinished` events
-    //    were already emitted as each completed.
-    let non_thread_results = non_thread_drain.await.unwrap_or_default();
-    all_results.extend(non_thread_results);
+    // 5. Drain any remaining non-thread tools that did not finish during
+    //    wave execution.  `ToolCallFinished` events are emitted as each
+    //    completes.
+    while let Some(join_result) = non_thread_join_set.join_next().await {
+        match join_result {
+            Ok((index, _, tool_call_id, tool_name, result)) => {
+                event_sink.emit(AgentEvent::ToolCallFinished {
+                    thread_name: agent_thread_name.clone(),
+                    call_id: tool_call_id.clone(),
+                    name: tool_name.clone(),
+                    content_preview: preview_tool_result(&tool_name, &result),
+                    is_error: result.is_error,
+                });
+                all_results.push((index, tool_call_id, tool_name, result));
+            }
+            Err(error) => {
+                all_results.push((
+                    usize::MAX,
+                    "unknown".to_string(),
+                    "unknown".to_string(),
+                    ToolResult {
+                        content: format!("Tool task panicked: {}", error),
+                        is_error: true,
+                    },
+                ));
+            }
+        }
+    }
 
     // 6. Unmark only threads we successfully marked (including skipped ones
     //    that were marked but not spawned).  Threads that were already active

--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -246,9 +246,15 @@ pub(crate) async fn execute_with_dag(
     }
 
     // 2. Pre-mark ALL thread names in active_threads.
+    // Track which threads we successfully marked so we only unmark those
+    // at the end — unmarking a thread that was already active from a prior
+    // turn would clobber its mutual-exclusion guarantee.
     let mut failed_indices: HashSet<usize> = HashSet::new();
+    let mut marked_by_us: HashSet<String> = HashSet::new();
     for (i, dispatch) in thread_dispatches.iter().enumerate() {
-        if !thread::mark_thread_active(&runtime, &dispatch.params.thread_name).await {
+        if thread::mark_thread_active(&runtime, &dispatch.params.thread_name).await {
+            marked_by_us.insert(dispatch.params.thread_name.clone());
+        } else {
             let result = ToolResult {
                 content: format!(
                     "Thread '{}' is already running; retry after the current dispatch completes.",
@@ -441,9 +447,11 @@ pub(crate) async fn execute_with_dag(
         }
     }
 
-    // 4. Unmark all thread names from active_threads (including skipped ones).
-    for dispatch in &thread_dispatches {
-        thread::unmark_thread_active(&runtime, &dispatch.params.thread_name).await;
+    // 4. Unmark only threads we successfully marked (including skipped ones
+    //    that were marked but not spawned).  Threads that were already active
+    //    from a prior turn were NOT marked by us, so we must not unmark them.
+    for name in &marked_by_us {
+        thread::unmark_thread_active(&runtime, name).await;
     }
 
     // 5. Sort by original index and return.

--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -15,13 +15,21 @@ pub(crate) struct ParsedThreadDispatch {
     pub params: ParsedDispatchParams,
 }
 
+/// Shared execution context for DAG-based tool dispatch.
+pub(crate) struct DagExecContext {
+    pub runtime: ToolRuntime,
+    pub client: ModelClient,
+    pub event_sink: EventSink,
+    pub agent_thread_name: Option<String>,
+}
+
 /// Partition a batch of tool calls into:
 ///
 /// 1. `Vec<ParsedThreadDispatch>` — successfully parsed `thread` calls
 /// 2. `Vec<(usize, String, String, String)>` — non-thread calls as
 ///    `(original_index, tool_call_id, tool_name, args_str)`
-/// 3. `Vec<(usize, String, ToolResult)>` — parse errors for malformed thread
-///    calls as `(original_index, tool_call_id, error_result)`
+/// 3. `Vec<(usize, String, String, ToolResult)>` — parse errors for malformed
+///    thread calls as `(original_index, tool_call_id, args_str, error_result)`
 #[allow(clippy::type_complexity)]
 pub(crate) fn partition_tool_calls(
     tool_calls: Vec<ToolCall>,
@@ -29,7 +37,7 @@ pub(crate) fn partition_tool_calls(
 ) -> (
     Vec<ParsedThreadDispatch>,
     Vec<(usize, String, String, String)>,
-    Vec<(usize, String, ToolResult)>,
+    Vec<(usize, String, String, ToolResult)>,
 ) {
     let mut thread_dispatches = Vec::new();
     let mut other_calls = Vec::new();
@@ -47,6 +55,7 @@ pub(crate) fn partition_tool_calls(
                     parse_errors.push((
                         index,
                         id,
+                        args_str,
                         ToolResult {
                             content: format!(
                                 "Error: failed to parse tool arguments for '{}': {}",
@@ -69,7 +78,7 @@ pub(crate) fn partition_tool_calls(
                     });
                 }
                 Err(error_result) => {
-                    parse_errors.push((index, id, error_result));
+                    parse_errors.push((index, id, args_str, error_result));
                 }
             }
         } else {
@@ -87,12 +96,8 @@ pub(crate) struct Dag {
     /// dispatches `Vec`.  All dispatches in a wave have zero in-batch
     /// dependencies and can run concurrently.
     pub waves: Vec<Vec<usize>>,
-    /// Thread name → dispatch index.  Used during construction; retained for
-    /// debugging and potential future lookups.
-    #[allow(dead_code)]
-    pub name_to_index: HashMap<String, usize>,
     /// Dispatch index → list of source dispatch indices (in-batch deps only).
-    pub in_batch_deps: HashMap<usize, Vec<usize>>,
+    pub in_batch_deps: Vec<Vec<usize>>,
 }
 
 /// Error returned by [`build_dag`].
@@ -112,8 +117,7 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
     if n == 0 {
         return Ok(Dag {
             waves: Vec::new(),
-            name_to_index: HashMap::new(),
-            in_batch_deps: HashMap::new(),
+            in_batch_deps: Vec::new(),
         });
     }
 
@@ -130,12 +134,13 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
     let batch_thread_names: HashSet<String> = name_to_index.keys().cloned().collect();
 
     // 2. Build in-batch deps and adjacency list for Kahn's algorithm.
-    let mut in_batch_deps: HashMap<usize, Vec<usize>> = HashMap::new();
+    let mut in_batch_deps: Vec<Vec<usize>> = vec![Vec::new(); n];
     let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); n]; // adjacency[i] = nodes that depend on i
     let mut in_degree = vec![0usize; n];
 
     for (i, dispatch) in dispatches.iter().enumerate() {
         let mut deps: Vec<usize> = Vec::new();
+        let mut seen: HashSet<usize> = HashSet::new();
         for source in &dispatch.params.source_threads {
             // Only sources that are in this batch become edges.
             if batch_thread_names.contains(source) {
@@ -149,7 +154,7 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
                     )));
                 }
 
-                if !deps.contains(&dep_idx) {
+                if seen.insert(dep_idx) {
                     deps.push(dep_idx);
                 }
             }
@@ -159,24 +164,25 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
             adjacency[dep_idx].push(i);
             in_degree[i] += 1;
         }
-        in_batch_deps.insert(i, deps);
+        in_batch_deps[i] = deps;
     }
 
     // 3. Kahn's algorithm — collect nodes level-by-level into waves.
     let mut waves: Vec<Vec<usize>> = Vec::new();
     let mut sorted_count = 0;
     let mut current_in_degree = in_degree;
+    let mut sorted = vec![false; n];
 
     while sorted_count < n {
         // Collect all nodes with in-degree 0 that haven't been sorted yet.
         let wave: Vec<usize> = (0..n)
-            .filter(|&i| current_in_degree[i] == 0)
+            .filter(|&i| !sorted[i] && current_in_degree[i] == 0)
             .collect();
 
         if wave.is_empty() {
             // Cycle detected — report the remaining nodes.
             let remaining: Vec<String> = (0..n)
-                .filter(|i| current_in_degree[*i] > 0)
+                .filter(|i| !sorted[*i] && current_in_degree[*i] > 0)
                 .map(|i| dispatches[i].params.thread_name.clone())
                 .collect();
             return Err(DagError::Cycle(format!(
@@ -190,7 +196,7 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
             for &neighbor in &adjacency[node] {
                 current_in_degree[neighbor] -= 1;
             }
-            current_in_degree[node] = usize::MAX; // sentinel: sorted
+            sorted[node] = true;
         }
 
         sorted_count += wave.len();
@@ -199,10 +205,104 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
 
     Ok(Dag {
         waves,
-        name_to_index,
         in_batch_deps,
     })
 }
+
+// ------------------------------------------------------------------
+// Shared helpers (used by execute_with_dag and tool_exec.rs)
+// ------------------------------------------------------------------
+
+/// Emit `ToolCallStarted` + `ToolCallFinished` for each parse error and return
+/// them as `(original_index, tool_call_id, tool_name, result)` tuples.
+pub(crate) fn collect_parse_errors(
+    parse_errors: Vec<(usize, String, String, ToolResult)>,
+    event_sink: &EventSink,
+    thread_name: &Option<String>,
+) -> Vec<(usize, String, String, ToolResult)> {
+    let mut results = Vec::new();
+    for (index, tool_call_id, args_str, error_result) in parse_errors {
+        event_sink.emit(AgentEvent::ToolCallStarted {
+            thread_name: thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: "thread".to_string(),
+            args_preview: preview_tool_args("thread", &args_str),
+            args_detail: Some(tool_args_detail(&args_str)),
+        });
+        event_sink.emit(AgentEvent::ToolCallFinished {
+            thread_name: thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: "thread".to_string(),
+            content_preview: preview_tool_result("thread", &error_result),
+            is_error: error_result.is_error,
+        });
+        results.push((index, tool_call_id, "thread".to_string(), error_result));
+    }
+    results
+}
+
+/// Sort results by original index, strip the index, and return as
+/// `Vec<(tool_call_id, tool_name, ToolResult)>`.
+pub(crate) fn sort_and_strip_index(
+    mut results: Vec<(usize, String, String, ToolResult)>,
+) -> Vec<(String, String, ToolResult)> {
+    results.sort_by_key(|(index, ..)| *index);
+    results
+        .into_iter()
+        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
+        .collect()
+}
+
+/// Spawn non-thread tool calls into a `JoinSet`, emitting `ToolCallStarted`
+/// for each.  Each spawned task returns
+/// `(original_index, None, tool_call_id, tool_name, result)`.
+pub(crate) fn spawn_non_thread_into(
+    join_set: &mut JoinSet<(usize, Option<usize>, String, String, ToolResult)>,
+    other_calls: Vec<(usize, String, String, String)>,
+    runtime: &ToolRuntime,
+    client: &ModelClient,
+    event_sink: &EventSink,
+    thread_name: &Option<String>,
+) {
+    for (index, tool_call_id, tool_name, args_str) in other_calls {
+        let runtime = runtime.clone();
+        let client = client.clone();
+        event_sink.emit(AgentEvent::ToolCallStarted {
+            thread_name: thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: tool_name.clone(),
+            args_preview: preview_tool_args(&tool_name, &args_str),
+            args_detail: Some(tool_args_detail(&args_str)),
+        });
+
+        join_set.spawn(async move {
+            let parsed_args = match serde_json::from_str::<serde_json::Value>(&args_str) {
+                Ok(value) => value,
+                Err(error) => {
+                    return (
+                        index,
+                        None,
+                        tool_call_id,
+                        tool_name.clone(),
+                        ToolResult {
+                            content: format!(
+                                "Error: failed to parse tool arguments for '{}': {}",
+                                tool_name, error
+                            ),
+                            is_error: true,
+                        },
+                    );
+                }
+            };
+            let result = tools::execute_tool(&tool_name, parsed_args, &runtime, &client).await;
+            (index, None, tool_call_id, tool_name, result)
+        });
+    }
+}
+
+// ------------------------------------------------------------------
+// DAG execution
+// ------------------------------------------------------------------
 
 /// Execute a batch of tool calls using the DAG coordinator.
 ///
@@ -212,38 +312,29 @@ pub(crate) fn build_dag(dispatches: &[ParsedThreadDispatch]) -> Result<Dag, DagE
 /// The caller is responsible for calling [`partition_tool_calls`] and
 /// [`build_dag`] first.  This function manages the `active_threads` lifecycle
 /// for all thread dispatches in the batch.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn execute_with_dag(
     thread_dispatches: Vec<ParsedThreadDispatch>,
     mut other_calls: Vec<(usize, String, String, String)>,
-    parse_errors: Vec<(usize, String, ToolResult)>,
+    parse_errors: Vec<(usize, String, String, ToolResult)>,
     dag: Dag,
-    runtime: ToolRuntime,
-    client: ModelClient,
-    event_sink: EventSink,
-    agent_thread_name: Option<String>,
+    ctx: DagExecContext,
 ) -> Vec<(String, String, ToolResult)> {
+    let DagExecContext {
+        runtime,
+        client,
+        event_sink,
+        agent_thread_name,
+    } = ctx;
+
     // Results: (original_index, tool_call_id, tool_name, ToolResult)
     let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
 
-    // Map tool_call_id → dispatch index for failed-dispatch tracking.
-    let call_id_to_dispatch_idx: HashMap<String, usize> = thread_dispatches
-        .iter()
-        .enumerate()
-        .map(|(i, d)| (d.tool_call_id.clone(), i))
-        .collect();
-
     // 1. Collect parse errors immediately.
-    for (index, tool_call_id, error_result) in parse_errors {
-        event_sink.emit(AgentEvent::ToolCallFinished {
-            thread_name: agent_thread_name.clone(),
-            call_id: tool_call_id.clone(),
-            name: "thread".to_string(),
-            content_preview: preview_tool_result("thread", &error_result),
-            is_error: error_result.is_error,
-        });
-        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
-    }
+    all_results.extend(collect_parse_errors(
+        parse_errors,
+        &event_sink,
+        &agent_thread_name,
+    ));
 
     // 2. Pre-mark ALL thread names in active_threads.
     // Track which threads we successfully marked so we only unmark those
@@ -262,6 +353,13 @@ pub(crate) async fn execute_with_dag(
                 ),
                 is_error: true,
             };
+            event_sink.emit(AgentEvent::ToolCallStarted {
+                thread_name: agent_thread_name.clone(),
+                call_id: dispatch.tool_call_id.clone(),
+                name: "thread".to_string(),
+                args_preview: preview_tool_args("thread", &dispatch.args_str),
+                args_detail: Some(tool_args_detail(&dispatch.args_str)),
+            });
             event_sink.emit(AgentEvent::ToolCallFinished {
                 thread_name: agent_thread_name.clone(),
                 call_id: dispatch.tool_call_id.clone(),
@@ -282,60 +380,28 @@ pub(crate) async fn execute_with_dag(
     // 3. Execute waves.
     let Dag {
         waves,
-        name_to_index: _,
         in_batch_deps,
     } = dag;
 
-    // Ensure at least one wave exists if there are other_calls but no threads.
-    let waves = if waves.is_empty() && !other_calls.is_empty() {
-        vec![Vec::new()]
-    } else {
-        waves
-    };
-
     for (wave_idx, wave) in waves.iter().enumerate() {
-        let mut join_set: JoinSet<(usize, String, String, ToolResult)> = JoinSet::new();
+        let mut join_set: JoinSet<(usize, Option<usize>, String, String, ToolResult)> =
+            JoinSet::new();
+        // Track which thread dispatches are in-flight (spawned but not yet
+        // completed).  If a task panics, all remaining in-flight dispatches
+        // are marked as failed so their dependents are skipped.
+        let mut in_flight: HashSet<usize> = HashSet::new();
 
         // Wave 0: also spawn all non-thread tool calls.
         if wave_idx == 0 {
             let calls = std::mem::take(&mut other_calls);
-            for (index, tool_call_id, tool_name, args_str) in calls {
-                let runtime = runtime.clone();
-                let client = client.clone();
-                let event_sink = event_sink.clone();
-                let thread_name = agent_thread_name.clone();
-
-                event_sink.emit(AgentEvent::ToolCallStarted {
-                    thread_name: thread_name.clone(),
-                    call_id: tool_call_id.clone(),
-                    name: tool_name.clone(),
-                    args_preview: preview_tool_args(&tool_name, &args_str),
-                    args_detail: Some(tool_args_detail(&args_str)),
-                });
-
-                join_set.spawn(async move {
-                    let parsed_args = match serde_json::from_str::<serde_json::Value>(&args_str) {
-                        Ok(value) => value,
-                        Err(error) => {
-                            return (
-                                index,
-                                tool_call_id,
-                                tool_name.clone(),
-                                ToolResult {
-                                    content: format!(
-                                        "Error: failed to parse tool arguments for '{}': {}",
-                                        tool_name, error
-                                    ),
-                                    is_error: true,
-                                },
-                            );
-                        }
-                    };
-                    let result = tools::execute_tool(&tool_name, parsed_args, &runtime, &client)
-                        .await;
-                    (index, tool_call_id, tool_name, result)
-                });
-            }
+            spawn_non_thread_into(
+                &mut join_set,
+                calls,
+                &runtime,
+                &client,
+                &event_sink,
+                &agent_thread_name,
+            );
         }
 
         // Spawn thread dispatches for this wave.
@@ -347,10 +413,7 @@ pub(crate) async fn execute_with_dag(
             let dispatch = &thread_dispatches[dispatch_idx];
 
             // Check if any in-batch deps failed in a previous wave.
-            let deps = in_batch_deps
-                .get(&dispatch_idx)
-                .cloned()
-                .unwrap_or_default();
+            let deps = &in_batch_deps[dispatch_idx];
             let any_dep_failed = deps.iter().any(|dep_idx| failed_indices.contains(dep_idx));
 
             if any_dep_failed {
@@ -370,6 +433,13 @@ pub(crate) async fn execute_with_dag(
                     is_error: true,
                 };
 
+                event_sink.emit(AgentEvent::ToolCallStarted {
+                    thread_name: agent_thread_name.clone(),
+                    call_id: dispatch.tool_call_id.clone(),
+                    name: "thread".to_string(),
+                    args_preview: preview_tool_args("thread", &dispatch.args_str),
+                    args_detail: Some(tool_args_detail(&dispatch.args_str)),
+                });
                 event_sink.emit(AgentEvent::ToolCallFinished {
                     thread_name: agent_thread_name.clone(),
                     call_id: dispatch.tool_call_id.clone(),
@@ -405,16 +475,32 @@ pub(crate) async fn execute_with_dag(
             let id = dispatch.tool_call_id.clone();
             let original_index = dispatch.original_index;
 
+            in_flight.insert(dispatch_idx);
+
             join_set.spawn(async move {
                 let result = thread::execute_parsed_dispatch(params, &runtime, &client).await;
-                (original_index, id, "thread".to_string(), result)
+                (
+                    original_index,
+                    Some(dispatch_idx),
+                    id,
+                    "thread".to_string(),
+                    result,
+                )
             });
         }
 
         // Await all tasks in the JoinSet.
         while let Some(join_result) = join_set.join_next().await {
             match join_result {
-                Ok((index, tool_call_id, tool_name, result)) => {
+                Ok((index, dispatch_idx_opt, tool_call_id, tool_name, result)) => {
+                    // Remove from in-flight and track failures for thread dispatches.
+                    if let Some(dispatch_idx) = dispatch_idx_opt {
+                        in_flight.remove(&dispatch_idx);
+                        if result.is_error {
+                            failed_indices.insert(dispatch_idx);
+                        }
+                    }
+
                     event_sink.emit(AgentEvent::ToolCallFinished {
                         thread_name: agent_thread_name.clone(),
                         call_id: tool_call_id.clone(),
@@ -423,16 +509,16 @@ pub(crate) async fn execute_with_dag(
                         is_error: result.is_error,
                     });
 
-                    // Track failed thread dispatches for dependency checking.
-                    if result.is_error {
-                        if let Some(&dispatch_idx) = call_id_to_dispatch_idx.get(&tool_call_id) {
-                            failed_indices.insert(dispatch_idx);
-                        }
-                    }
-
                     all_results.push((index, tool_call_id, tool_name, result));
                 }
                 Err(error) => {
+                    // A task panicked.  Mark all remaining in-flight thread
+                    // dispatches as failed so dependents are skipped.
+                    for &dispatch_idx in in_flight.iter() {
+                        failed_indices.insert(dispatch_idx);
+                    }
+                    in_flight.clear();
+
                     all_results.push((
                         usize::MAX,
                         "unknown".to_string(),
@@ -455,22 +541,16 @@ pub(crate) async fn execute_with_dag(
     }
 
     // 5. Sort by original index and return.
-    all_results.sort_by_key(|(index, ..)| *index);
-    all_results
-        .into_iter()
-        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
-        .collect()
+    sort_and_strip_index(all_results)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::EventSink;
+    use crate::tools::test_runtime;
     use crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS;
     use crate::types::{FunctionCall, ToolCall};
     use serde_json::json;
-    use std::path::PathBuf;
-    use std::sync::Arc;
 
     // ------------------------------------------------------------------
     // Test helpers
@@ -509,26 +589,6 @@ mod tests {
         }
     }
 
-    fn test_runtime() -> ToolRuntime {
-        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
-        ToolRuntime {
-            config_cwd: workspace_cwd.clone(),
-            workspace_cwd,
-            store_path: PathBuf::new(),
-            session_id: Some("test-session".to_string()),
-            worker_executable: None,
-            active_threads: Arc::new(Mutex::new(HashSet::new())),
-            event_sink: EventSink::none(),
-            backend,
-            mcp: None,
-            skills: None,
-            terminal_manager: crate::terminal::TerminalManager::new(),
-            thread_timeout_secs: DEFAULT_THREAD_TIMEOUT_SECS,
-            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
-        }
-    }
-
     // ------------------------------------------------------------------
     // build_dag tests
     // ------------------------------------------------------------------
@@ -553,7 +613,7 @@ mod tests {
 
         // No in-batch deps for any dispatch.
         for i in 0..3 {
-            assert!(dag.in_batch_deps.get(&i).unwrap().is_empty());
+            assert!(dag.in_batch_deps[i].is_empty());
         }
     }
 
@@ -573,9 +633,9 @@ mod tests {
         assert_eq!(dag.waves[2], vec![2], "wave 2: C");
 
         // B depends on A, C depends on B.
-        assert!(dag.in_batch_deps.get(&0).unwrap().is_empty());
-        assert_eq!(dag.in_batch_deps.get(&1).unwrap(), &vec![0usize]);
-        assert_eq!(dag.in_batch_deps.get(&2).unwrap(), &vec![1usize]);
+        assert!(dag.in_batch_deps[0].is_empty());
+        assert_eq!(dag.in_batch_deps[1], vec![0usize]);
+        assert_eq!(dag.in_batch_deps[2], vec![1usize]);
     }
 
     #[test]
@@ -601,7 +661,7 @@ mod tests {
         assert_eq!(dag.waves[2], vec![3], "wave 2: D");
 
         // D depends on both B and C.
-        let d_deps = dag.in_batch_deps.get(&3).unwrap();
+        let d_deps = &dag.in_batch_deps[3];
         assert!(d_deps.contains(&1));
         assert!(d_deps.contains(&2));
     }
@@ -620,8 +680,7 @@ mod tests {
         assert_eq!(dag.waves[1], vec![1], "wave 1: B");
 
         // B's only in-batch dep is A (index 0). "preexisting" is ignored.
-        let b_deps = dag.in_batch_deps.get(&1).unwrap();
-        assert_eq!(b_deps, &vec![0], "only A should be an in-batch dep");
+        assert_eq!(dag.in_batch_deps[1], vec![0], "only A should be an in-batch dep");
     }
 
     #[test]
@@ -692,7 +751,7 @@ mod tests {
     fn test_partition_returns_error_for_missing_name() {
         let runtime = test_runtime();
         let tool_calls = vec![
-            make_tool_call("call_0", "thread", json!({"action": "work"})), // missing "name"
+            make_tool_call("call_0", "thread", json!({"action": "work"})),
         ];
 
         let (thread_dispatches, other_calls, parse_errors) =
@@ -703,7 +762,236 @@ mod tests {
         assert_eq!(parse_errors.len(), 1);
         assert_eq!(parse_errors[0].0, 0, "original_index preserved");
         assert_eq!(parse_errors[0].1, "call_0");
-        assert!(parse_errors[0].2.is_error);
-        assert!(parse_errors[0].2.content.contains("'name'"));
+        assert!(parse_errors[0].3.is_error);
+        assert!(parse_errors[0].3.content.contains("'name'"));
+    }
+
+    // ------------------------------------------------------------------
+    // Transitive failure propagation tests
+    // ------------------------------------------------------------------
+
+    /// When A fails → B (depends on A) is skipped → C (depends on B) is also
+    /// skipped.  This simulates the wave-by-wave skip logic from
+    /// `execute_with_dag` using the DAG structure.
+    #[test]
+    fn test_transitive_failure_propagation_chain() {
+        // Chain: A → B → C
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A"]),
+            make_dispatch(2, "C", &["B"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 3, "chain → 3 waves");
+
+        // Simulate the wave-by-wave skip logic from execute_with_dag.
+        let mut failed_indices: HashSet<usize> = HashSet::new();
+
+        // Wave 0: A fails.
+        failed_indices.insert(0);
+
+        // Wave 1: B checks its deps. A (dep of B) is in failed_indices → B skipped.
+        for &dispatch_idx in &dag.waves[1] {
+            let deps = &dag.in_batch_deps[dispatch_idx];
+            let any_dep_failed = deps.iter().any(|dep| failed_indices.contains(dep));
+            assert!(
+                any_dep_failed,
+                "dispatch {} in wave 1 should have a failed dep",
+                dispatch_idx
+            );
+            if any_dep_failed {
+                failed_indices.insert(dispatch_idx);
+            }
+        }
+
+        // Wave 2: C checks its deps. B (dep of C) is now in failed_indices → C skipped.
+        for &dispatch_idx in &dag.waves[2] {
+            let deps = &dag.in_batch_deps[dispatch_idx];
+            let any_dep_failed = deps.iter().any(|dep| failed_indices.contains(dep));
+            assert!(
+                any_dep_failed,
+                "dispatch {} in wave 2 should have a failed dep (transitive)",
+                dispatch_idx
+            );
+            if any_dep_failed {
+                failed_indices.insert(dispatch_idx);
+            }
+        }
+
+        // All three should be in failed_indices.
+        assert!(failed_indices.contains(&0), "A failed");
+        assert!(failed_indices.contains(&1), "B skipped due to A");
+        assert!(failed_indices.contains(&2), "C skipped due to B (transitive)");
+    }
+
+    /// When A fails in a diamond A→{B,C}→D, both B and C are skipped, and
+    /// then D is skipped because all its deps failed.
+    #[test]
+    fn test_transitive_failure_propagation_diamond() {
+        // Diamond: A → {B, C} → D
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A"]),
+            make_dispatch(2, "C", &["A"]),
+            make_dispatch(3, "D", &["B", "C"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+        assert_eq!(dag.waves.len(), 3, "diamond → 3 waves");
+
+        let mut failed_indices: HashSet<usize> = HashSet::new();
+
+        // Wave 0: A fails.
+        failed_indices.insert(0);
+
+        // Wave 1: B and C both depend on A → both skipped.
+        for &dispatch_idx in &dag.waves[1] {
+            let deps = &dag.in_batch_deps[dispatch_idx];
+            let any_dep_failed = deps.iter().any(|dep| failed_indices.contains(dep));
+            assert!(any_dep_failed, "wave 1 dispatch should have failed dep A");
+            if any_dep_failed {
+                failed_indices.insert(dispatch_idx);
+            }
+        }
+
+        // Wave 2: D depends on B and C, both now failed → D skipped.
+        for &dispatch_idx in &dag.waves[2] {
+            let deps = &dag.in_batch_deps[dispatch_idx];
+            let any_dep_failed = deps.iter().any(|dep| failed_indices.contains(dep));
+            assert!(any_dep_failed, "D should have a failed dep (B or C)");
+            if any_dep_failed {
+                failed_indices.insert(dispatch_idx);
+            }
+        }
+
+        assert_eq!(failed_indices.len(), 4, "all four dispatches should be failed/skipped");
+    }
+
+    // ------------------------------------------------------------------
+    // Wave ordering tests
+    // ------------------------------------------------------------------
+
+    /// Verify that every dispatch in wave N > 0 has at least one in-batch dep
+    /// in an earlier wave, and that wave 0 dispatches have no in-batch deps.
+    /// This is the structural guarantee behind wave concurrency: wave 1
+    /// threads don't start until wave 0 completes.
+    #[test]
+    fn test_wave_ordering_respects_dependencies() {
+        // Diamond: A → {B, C} → D
+        let dispatches = vec![
+            make_dispatch(0, "A", &[]),
+            make_dispatch(1, "B", &["A"]),
+            make_dispatch(2, "C", &["A"]),
+            make_dispatch(3, "D", &["B", "C"]),
+        ];
+
+        let dag = build_dag(&dispatches).unwrap();
+
+        let mut earlier_waves: HashSet<usize> = HashSet::new();
+
+        for (wave_idx, wave) in dag.waves.iter().enumerate() {
+            for &dispatch_idx in wave {
+                if wave_idx > 0 {
+                    let deps = &dag.in_batch_deps[dispatch_idx];
+                    let has_earlier_dep = deps.iter().any(|dep| earlier_waves.contains(dep));
+                    assert!(
+                        has_earlier_dep,
+                        "dispatch {} in wave {} must have a dep in an earlier wave",
+                        dispatch_idx,
+                        wave_idx
+                    );
+                } else {
+                    assert!(
+                        dag.in_batch_deps[dispatch_idx].is_empty(),
+                        "dispatch {} in wave 0 must have no in-batch deps",
+                        dispatch_idx
+                    );
+                }
+            }
+
+            for &dispatch_idx in wave {
+                earlier_waves.insert(dispatch_idx);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Additional partition tests
+    // ------------------------------------------------------------------
+
+    /// Partition should handle a mix of thread calls with and without source
+    /// threads, plus non-thread calls.
+    #[test]
+    fn test_partition_mixed_source_and_no_source_threads() {
+        let runtime = test_runtime();
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({"name": "A", "action": "work"})),
+            make_tool_call("call_1", "thread", json!({"name": "B", "action": "work", "threads": ["A"]})),
+            make_tool_call("call_2", "thread", json!({"name": "C", "action": "work", "threads": ["A", "preexisting"]})),
+            make_tool_call("call_3", "read", json!({"path": "src/main.rs"})),
+        ];
+
+        let (thread_dispatches, other_calls, parse_errors) =
+            partition_tool_calls(tool_calls, &runtime);
+
+        assert_eq!(thread_dispatches.len(), 3);
+        assert_eq!(thread_dispatches[0].params.thread_name, "A");
+        assert!(thread_dispatches[0].params.source_threads.is_empty());
+
+        assert_eq!(thread_dispatches[1].params.thread_name, "B");
+        assert_eq!(thread_dispatches[1].params.source_threads, vec!["A"]);
+
+        assert_eq!(thread_dispatches[2].params.thread_name, "C");
+        assert_eq!(thread_dispatches[2].params.source_threads, vec!["A", "preexisting"]);
+
+        assert_eq!(other_calls.len(), 1);
+        assert_eq!(other_calls[0].2, "read");
+
+        assert!(parse_errors.is_empty());
+    }
+
+    /// Partition should produce a parse error when a thread call specifies
+    /// skills but no skill registry is available.
+    #[test]
+    fn test_partition_skills_error_without_registry() {
+        let runtime = test_runtime();
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({
+                "name": "A",
+                "action": "work",
+                "skills": ["lint"]
+            })),
+        ];
+
+        let (thread_dispatches, other_calls, parse_errors) =
+            partition_tool_calls(tool_calls, &runtime);
+
+        assert!(thread_dispatches.is_empty());
+        assert!(other_calls.is_empty());
+        assert_eq!(parse_errors.len(), 1);
+        assert!(parse_errors[0].3.is_error);
+        assert!(parse_errors[0].3.content.contains("no skills are available"));
+    }
+
+    /// Partition should succeed when a thread call has an empty skills array.
+    #[test]
+    fn test_partition_empty_skills_succeeds() {
+        let runtime = test_runtime();
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({
+                "name": "A",
+                "action": "work",
+                "skills": []
+            })),
+        ];
+
+        let (thread_dispatches, other_calls, parse_errors) =
+            partition_tool_calls(tool_calls, &runtime);
+
+        assert_eq!(thread_dispatches.len(), 1);
+        assert!(thread_dispatches[0].params.scheduled_skills.is_empty());
+        assert!(other_calls.is_empty());
+        assert!(parse_errors.is_empty());
     }
 }

--- a/crates/nac-core/src/agent/dag.rs
+++ b/crates/nac-core/src/agent/dag.rs
@@ -394,6 +394,43 @@ pub(crate) async fn execute_with_dag(
         &agent_thread_name,
     );
 
+    // Spawn a background task to drain non-thread results concurrently with
+    // wave execution.  This emits `ToolCallFinished` events as each non-thread
+    // tool completes, rather than delaying them until all waves are done.
+    // Panics inside non-thread tools are caught here and do not affect thread
+    // failure tracking.
+    let non_thread_event_sink = event_sink.clone();
+    let non_thread_agent_name = agent_thread_name.clone();
+    let non_thread_drain = tokio::spawn(async move {
+        let mut results: Vec<(usize, String, String, ToolResult)> = Vec::new();
+        while let Some(join_result) = non_thread_join_set.join_next().await {
+            match join_result {
+                Ok((index, _, tool_call_id, tool_name, result)) => {
+                    non_thread_event_sink.emit(AgentEvent::ToolCallFinished {
+                        thread_name: non_thread_agent_name.clone(),
+                        call_id: tool_call_id.clone(),
+                        name: tool_name.clone(),
+                        content_preview: preview_tool_result(&tool_name, &result),
+                        is_error: result.is_error,
+                    });
+                    results.push((index, tool_call_id, tool_name, result));
+                }
+                Err(error) => {
+                    results.push((
+                        usize::MAX,
+                        "unknown".to_string(),
+                        "unknown".to_string(),
+                        ToolResult {
+                            content: format!("Tool task panicked: {}", error),
+                            is_error: true,
+                        },
+                    ));
+                }
+            }
+        }
+        results
+    });
+
     // 4. Execute waves.
     let Dag {
         waves,
@@ -502,6 +539,11 @@ pub(crate) async fn execute_with_dag(
                         in_flight.remove(&dispatch_idx);
                         if result.is_error {
                             failed_indices.insert(dispatch_idx);
+                        } else if failed_indices.contains(&dispatch_idx) {
+                            // Was marked failed by the panic handler but actually
+                            // succeeded — un-fail it so dependents in later waves
+                            // are not incorrectly skipped.
+                            failed_indices.remove(&dispatch_idx);
                         }
                     }
 
@@ -537,34 +579,11 @@ pub(crate) async fn execute_with_dag(
         }
     }
 
-    // 5. Drain the non-thread JoinSet.  These tasks ran concurrently with all
-    //    waves.  Panics here produce error results but do not affect thread
-    //    failure tracking.
-    while let Some(join_result) = non_thread_join_set.join_next().await {
-        match join_result {
-            Ok((index, _, tool_call_id, tool_name, result)) => {
-                event_sink.emit(AgentEvent::ToolCallFinished {
-                    thread_name: agent_thread_name.clone(),
-                    call_id: tool_call_id.clone(),
-                    name: tool_name.clone(),
-                    content_preview: preview_tool_result(&tool_name, &result),
-                    is_error: result.is_error,
-                });
-                all_results.push((index, tool_call_id, tool_name, result));
-            }
-            Err(error) => {
-                all_results.push((
-                    usize::MAX,
-                    "unknown".to_string(),
-                    "unknown".to_string(),
-                    ToolResult {
-                        content: format!("Tool task panicked: {}", error),
-                        is_error: true,
-                    },
-                ));
-            }
-        }
-    }
+    // 5. Collect non-thread results from the background drain task.  The
+    //    tasks ran concurrently with all waves; `ToolCallFinished` events
+    //    were already emitted as each completed.
+    let non_thread_results = non_thread_drain.await.unwrap_or_default();
+    all_results.extend(non_thread_results);
 
     // 6. Unmark only threads we successfully marked (including skipped ones
     //    that were marked but not spawned).  Threads that were already active

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -318,6 +318,11 @@ impl Agent {
     }
 
     pub async fn send(&mut self, prompt: &str) -> Result<String> {
+        // Clear any stale active_threads from a previous turn that was
+        // cancelled or panicked. At the start of a new turn, no threads
+        // should be running — prior child processes were killed by kill_on_drop.
+        self.tool_runtime.active_threads.lock().await.clear();
+
         self.emit(AgentEvent::RunStarted {
             thread_name: self.thread_name.clone(),
             prompt_preview: preview(prompt, 160),

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -16,6 +16,7 @@ use crate::types::{Message, ToolCall, ToolDefinition};
 
 mod preview;
 mod tool_exec;
+mod dag;
 
 #[cfg(test)]
 mod live_tests;
@@ -185,7 +186,17 @@ impl Agent {
                      `notes` for durable context discovered while planning or running.\n\
                      Avoid creating extra Markdown documents or notes files unless the user explicitly \
                      asks for them.\n\
-                     You may dispatch independent threads in parallel when useful.\n\n\
+                     You may dispatch multiple threads in a single response. When you do, the system \
+                     builds a dependency DAG from the threads parameters of each dispatched thread. \
+                     Threads with no in-batch source dependencies launch immediately and run \
+                     concurrently. Threads that reference other threads being dispatched in the same \
+                     response automatically wait for those source threads to complete before \
+                     starting. Source threads that already exist from prior turns are loaded \
+                     normally — only same-batch dependencies are ordered. Do not create circular \
+                     dependencies (thread A depends on B while B depends on A); the system will \
+                     reject them. This enables patterns like best-of-N: dispatch multiple \
+                     independent explorations in one response, then a synthesis thread that takes \
+                     all of them as source threads and waits for them to finish.\n\n\
                      Your tools:\n\
                      - thread(name, action, threads?, skills?, timeout?)\n\
                      - threads()\n\

--- a/crates/nac-core/src/agent/tool_exec.rs
+++ b/crates/nac-core/src/agent/tool_exec.rs
@@ -7,43 +7,96 @@ pub(super) async fn execute_tools_parallel(
     event_sink: EventSink,
     thread_name: Option<String>,
 ) -> Vec<(String, String, ToolResult)> {
+    // 1. Partition tool calls into thread dispatches, non-thread calls, and
+    //    parse errors.
+    let (thread_dispatches, other_calls, parse_errors) =
+        dag::partition_tool_calls(tool_calls, &runtime);
+
+    // 2. If there are no thread dispatches, use the simple path — just spawn
+    //    all non-thread calls into a JoinSet, same as the original logic.
+    if thread_dispatches.is_empty() {
+        return execute_simple(other_calls, parse_errors, runtime, client, event_sink, thread_name)
+            .await;
+    }
+
+    // 3. Build the DAG from thread dispatches.
+    let dag = match dag::build_dag(&thread_dispatches) {
+        Ok(d) => d,
+        Err(dag_err) => {
+            // DAG construction failed (cycle or duplicate names).  Execute
+            // non-thread tools normally and return error ToolResults for all
+            // thread calls.
+            return execute_with_dag_error(
+                thread_dispatches,
+                other_calls,
+                parse_errors,
+                dag_err,
+                runtime,
+                client,
+                event_sink,
+                thread_name,
+            )
+            .await;
+        }
+    };
+
+    // 4. Execute with the DAG coordinator.
+    dag::execute_with_dag(
+        thread_dispatches,
+        other_calls,
+        parse_errors,
+        dag,
+        runtime,
+        client,
+        event_sink,
+        thread_name,
+    )
+    .await
+}
+
+/// Execute a batch of non-thread tool calls, emitting start/finish events for
+/// each.  Returns `(original_index, tool_call_id, tool_name, ToolResult)` tuples
+/// in completion order — the caller is responsible for sorting.
+async fn spawn_and_collect_non_thread(
+    other_calls: Vec<(usize, String, String, String)>,
+    runtime: &ToolRuntime,
+    client: &ModelClient,
+    event_sink: &EventSink,
+    thread_name: &Option<String>,
+) -> Vec<(usize, String, String, ToolResult)> {
     let mut join_set: JoinSet<(usize, String, String, ToolResult)> = JoinSet::new();
 
-    for (index, tool_call) in tool_calls.into_iter().enumerate() {
-        let id = tool_call.id;
-        let name = tool_call.function.name;
-        let args_str = tool_call.function.arguments;
+    for (index, tool_call_id, tool_name, args_str) in other_calls {
         let runtime = runtime.clone();
         let client = client.clone();
         event_sink.emit(AgentEvent::ToolCallStarted {
             thread_name: thread_name.clone(),
-            call_id: id.clone(),
-            name: name.clone(),
-            args_preview: preview_tool_args(&name, &args_str),
+            call_id: tool_call_id.clone(),
+            name: tool_name.clone(),
+            args_preview: preview_tool_args(&tool_name, &args_str),
             args_detail: Some(tool_args_detail(&args_str)),
         });
 
         join_set.spawn(async move {
-            let args = match serde_json::from_str::<serde_json::Value>(&args_str) {
+            let parsed_args = match serde_json::from_str::<serde_json::Value>(&args_str) {
                 Ok(value) => value,
                 Err(error) => {
                     return (
                         index,
-                        id,
-                        name.clone(),
+                        tool_call_id,
+                        tool_name.clone(),
                         ToolResult {
                             content: format!(
                                 "Error: failed to parse tool arguments for '{}': {}",
-                                name, error
+                                tool_name, error
                             ),
                             is_error: true,
                         },
                     );
                 }
             };
-
-            let result = tools::execute_tool(&name, args, &runtime, &client).await;
-            (index, id, name, result)
+            let result = tools::execute_tool(&tool_name, parsed_args, &runtime, &client).await;
+            (index, tool_call_id, tool_name, result)
         });
     }
 
@@ -60,21 +113,407 @@ pub(super) async fn execute_tools_parallel(
                 });
                 results.push((index, tool_call_id, tool_name, result));
             }
-            Err(error) => results.push((
-                usize::MAX,
-                "unknown".to_string(),
-                "unknown".to_string(),
-                ToolResult {
-                    content: format!("Tool task panicked: {}", error),
-                    is_error: true,
-                },
-            )),
+            Err(error) => {
+                results.push((
+                    usize::MAX,
+                    "unknown".to_string(),
+                    "unknown".to_string(),
+                    ToolResult {
+                        content: format!("Tool task panicked: {}", error),
+                        is_error: true,
+                    },
+                ));
+            }
         }
     }
-
-    results.sort_by_key(|(index, ..)| *index);
     results
+}
+
+/// Simple execution path: no thread dispatches, just non-thread tools and parse
+/// errors.  Preserves the original `execute_tools_parallel` behavior for the
+/// common case.
+async fn execute_simple(
+    other_calls: Vec<(usize, String, String, String)>,
+    parse_errors: Vec<(usize, String, ToolResult)>,
+    runtime: ToolRuntime,
+    client: ModelClient,
+    event_sink: EventSink,
+    thread_name: Option<String>,
+) -> Vec<(String, String, ToolResult)> {
+    let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
+
+    // Collect parse errors immediately (emit finish event for each).
+    for (index, tool_call_id, error_result) in parse_errors {
+        event_sink.emit(AgentEvent::ToolCallFinished {
+            thread_name: thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: "thread".to_string(),
+            content_preview: preview_tool_result("thread", &error_result),
+            is_error: error_result.is_error,
+        });
+        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
+    }
+
+    // Execute non-thread calls.
+    let non_thread_results =
+        spawn_and_collect_non_thread(other_calls, &runtime, &client, &event_sink, &thread_name)
+            .await;
+    all_results.extend(non_thread_results);
+
+    all_results.sort_by_key(|(index, ..)| *index);
+    all_results
         .into_iter()
         .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
         .collect()
+}
+
+/// Fallback when DAG construction fails (cycle or duplicate thread names).
+///
+/// Non-thread tool calls are executed normally.  All thread dispatches receive
+/// an error ToolResult describing the DAG error.  Parse errors are included.
+/// Results are sorted by original index.
+#[allow(clippy::too_many_arguments)]
+async fn execute_with_dag_error(
+    thread_dispatches: Vec<dag::ParsedThreadDispatch>,
+    other_calls: Vec<(usize, String, String, String)>,
+    parse_errors: Vec<(usize, String, ToolResult)>,
+    dag_err: dag::DagError,
+    runtime: ToolRuntime,
+    client: ModelClient,
+    event_sink: EventSink,
+    thread_name: Option<String>,
+) -> Vec<(String, String, ToolResult)> {
+    let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
+
+    // Collect parse errors immediately.
+    for (index, tool_call_id, error_result) in parse_errors {
+        event_sink.emit(AgentEvent::ToolCallFinished {
+            thread_name: thread_name.clone(),
+            call_id: tool_call_id.clone(),
+            name: "thread".to_string(),
+            content_preview: preview_tool_result("thread", &error_result),
+            is_error: error_result.is_error,
+        });
+        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
+    }
+
+    // Produce error ToolResults for all thread dispatches.
+    let error_message = match &dag_err {
+        dag::DagError::DuplicateName(name) => {
+            format!("Duplicate thread name '{}' in parallel dispatch", name)
+        }
+        dag::DagError::Cycle(desc) => {
+            format!("Circular dependency in thread dispatch: {}", desc)
+        }
+    };
+
+    for dispatch in &thread_dispatches {
+        let result = ToolResult {
+            content: error_message.clone(),
+            is_error: true,
+        };
+        event_sink.emit(AgentEvent::ToolCallFinished {
+            thread_name: thread_name.clone(),
+            call_id: dispatch.tool_call_id.clone(),
+            name: "thread".to_string(),
+            content_preview: preview_tool_result("thread", &result),
+            is_error: true,
+        });
+        all_results.push((
+            dispatch.original_index,
+            dispatch.tool_call_id.clone(),
+            "thread".to_string(),
+            result,
+        ));
+    }
+
+    // Execute non-thread calls normally.
+    let non_thread_results =
+        spawn_and_collect_non_thread(other_calls, &runtime, &client, &event_sink, &thread_name)
+            .await;
+    all_results.extend(non_thread_results);
+
+    all_results.sort_by_key(|(index, ..)| *index);
+    all_results
+        .into_iter()
+        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::FunctionCall;
+    use serde_json::json;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    // ------------------------------------------------------------------
+    // Test helpers
+    // ------------------------------------------------------------------
+
+    fn make_tool_call(id: &str, name: &str, args: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: name.to_string(),
+                arguments: serde_json::to_string(&args).unwrap(),
+            },
+        }
+    }
+
+    fn test_runtime() -> ToolRuntime {
+        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
+        ToolRuntime {
+            config_cwd: workspace_cwd.clone(),
+            workspace_cwd,
+            store_path: PathBuf::new(),
+            session_id: Some("test-session".to_string()),
+            worker_executable: None,
+            active_threads: Arc::new(Mutex::new(HashSet::new())),
+            event_sink: EventSink::none(),
+            backend,
+            mcp: None,
+            skills: None,
+            terminal_manager: crate::terminal::TerminalManager::new(),
+            thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Integration tests
+    // ------------------------------------------------------------------
+
+    /// When there are no thread calls, the simple path executes non-thread
+    /// tools and returns results sorted by original index.
+    #[tokio::test]
+    async fn test_simple_path_no_thread_calls() {
+        let tool_calls = vec![
+            make_tool_call("call_0", "nonexistent_tool", json!({})),
+            make_tool_call("call_1", "nonexistent_tool", json!({})),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 2);
+        // Results should be sorted by original index.
+        assert_eq!(results[0].0, "call_0");
+        assert_eq!(results[1].0, "call_1");
+        // Unknown tool → error result.
+        assert!(results[0].2.is_error);
+        assert!(results[1].2.is_error);
+    }
+
+    /// Results from a mix of thread and non-thread calls should come back
+    /// sorted by original index, even when the DAG fails (cycle path).
+    #[tokio::test]
+    async fn test_results_sorted_by_original_index() {
+        // Thread calls with a cycle at indices 1 and 3, non-thread at 0 and 2.
+        let tool_calls = vec![
+            make_tool_call("call_0", "nonexistent_tool", json!({})),
+            make_tool_call(
+                "call_1",
+                "thread",
+                json!({"name": "A", "action": "work", "threads": ["B"]}),
+            ),
+            make_tool_call("call_2", "nonexistent_tool", json!({})),
+            make_tool_call(
+                "call_3",
+                "thread",
+                json!({"name": "B", "action": "work", "threads": ["A"]}),
+            ),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 4);
+        // Sorted by original index.
+        assert_eq!(results[0].0, "call_0");
+        assert_eq!(results[1].0, "call_1");
+        assert_eq!(results[2].0, "call_2");
+        assert_eq!(results[3].0, "call_3");
+    }
+
+    /// When DAG construction fails due to a cycle, all thread calls should
+    /// receive error results describing the cycle, while non-thread tools
+    /// still execute normally.
+    #[tokio::test]
+    async fn test_dag_error_returns_errors_for_all_thread_calls() {
+        // A → B, B → A (cycle)
+        let tool_calls = vec![
+            make_tool_call(
+                "call_0",
+                "thread",
+                json!({"name": "A", "action": "work", "threads": ["B"]}),
+            ),
+            make_tool_call(
+                "call_1",
+                "thread",
+                json!({"name": "B", "action": "work", "threads": ["A"]}),
+            ),
+            make_tool_call("call_2", "nonexistent_tool", json!({})),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 3);
+
+        // Thread calls should have error results mentioning circular dependency.
+        let a_result = results.iter().find(|(id, _, _)| id == "call_0").unwrap();
+        let b_result = results.iter().find(|(id, _, _)| id == "call_1").unwrap();
+        assert!(a_result.2.is_error);
+        assert!(b_result.2.is_error);
+        assert!(
+            a_result.2.content.contains("Circular dependency"),
+            "expected cycle message, got: {}",
+            a_result.2.content
+        );
+        assert!(
+            b_result.2.content.contains("Circular dependency"),
+            "expected cycle message, got: {}",
+            b_result.2.content
+        );
+
+        // Non-thread call should still have a result (error for unknown tool,
+        // but it executed).
+        let non_thread = results.iter().find(|(id, _, _)| id == "call_2").unwrap();
+        assert!(non_thread.2.is_error);
+        assert!(
+            non_thread.2.content.contains("unknown tool"),
+            "non-thread tool should have executed, got: {}",
+            non_thread.2.content
+        );
+    }
+
+    /// When DAG construction fails due to duplicate thread names, all thread
+    /// calls should receive error results mentioning the duplicate.
+    #[tokio::test]
+    async fn test_dag_error_duplicate_name() {
+        let tool_calls = vec![
+            make_tool_call(
+                "call_0",
+                "thread",
+                json!({"name": "X", "action": "work"}),
+            ),
+            make_tool_call(
+                "call_1",
+                "thread",
+                json!({"name": "X", "action": "work"}),
+            ),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|(_, _, r)| r.is_error));
+        assert!(
+            results
+                .iter()
+                .all(|(_, _, r)| r.content.contains("Duplicate thread name 'X'")),
+            "expected duplicate name message"
+        );
+    }
+
+    /// Non-thread tools should still execute when mixed with thread calls that
+    /// trigger the DAG error path.  This verifies the `execute_with_dag_error`
+    /// fallback runs non-thread tools concurrently.
+    #[tokio::test]
+    async fn test_non_thread_tools_work_with_dag_error_path() {
+        let tool_calls = vec![
+            make_tool_call(
+                "call_0",
+                "thread",
+                json!({"name": "A", "action": "work", "threads": ["B"]}),
+            ),
+            make_tool_call(
+                "call_1",
+                "thread",
+                json!({"name": "B", "action": "work", "threads": ["A"]}),
+            ),
+            make_tool_call("call_2", "nonexistent_tool", json!({})),
+            make_tool_call("call_3", "nonexistent_tool", json!({})),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 4);
+
+        // Thread calls → cycle errors.
+        let thread_results: Vec<_> = results
+            .iter()
+            .filter(|(id, _, _)| id == "call_0" || id == "call_1")
+            .collect();
+        assert_eq!(thread_results.len(), 2);
+        assert!(thread_results.iter().all(|(_, _, r)| r.is_error));
+
+        // Non-thread calls → executed (error for unknown tool, but not a DAG error).
+        for id in &["call_2", "call_3"] {
+            let result = results.iter().find(|(rid, _, _)| rid == id).unwrap();
+            assert!(
+                result.2.content.contains("unknown tool"),
+                "non-thread tool {} should have executed, got: {}",
+                id,
+                result.2.content
+            );
+        }
+    }
+
+    /// Parse errors for malformed thread calls should be included in results
+    /// alongside non-thread tool results, sorted by original index.
+    #[tokio::test]
+    async fn test_parse_error_included_in_results() {
+        // Thread call missing "name" → parse error at index 0.
+        // Non-thread call at index 1.
+        let tool_calls = vec![
+            make_tool_call("call_0", "thread", json!({"action": "work"})),
+            make_tool_call("call_1", "nonexistent_tool", json!({})),
+        ];
+
+        let runtime = test_runtime();
+        let client = ModelClient::new_for_test();
+        let event_sink = EventSink::none();
+
+        let results = execute_tools_parallel(tool_calls, runtime, client, event_sink, None).await;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].0, "call_0");
+        assert_eq!(results[1].0, "call_1");
+
+        // Parse error for the malformed thread call.
+        assert!(results[0].2.is_error);
+        assert!(
+            results[0].2.content.contains("'name'"),
+            "expected missing 'name' error, got: {}",
+            results[0].2.content
+        );
+
+        // Non-thread tool executed.
+        assert!(results[1].2.is_error);
+        assert!(results[1].2.content.contains("unknown tool"));
+    }
 }

--- a/crates/nac-core/src/agent/tool_exec.rs
+++ b/crates/nac-core/src/agent/tool_exec.rs
@@ -31,10 +31,12 @@ pub(super) async fn execute_tools_parallel(
                 other_calls,
                 parse_errors,
                 dag_err,
-                runtime,
-                client,
-                event_sink,
-                thread_name,
+                dag::DagExecContext {
+                    runtime,
+                    client,
+                    event_sink,
+                    agent_thread_name: thread_name,
+                },
             )
             .await;
         }
@@ -46,10 +48,12 @@ pub(super) async fn execute_tools_parallel(
         other_calls,
         parse_errors,
         dag,
-        runtime,
-        client,
-        event_sink,
-        thread_name,
+        dag::DagExecContext {
+            runtime,
+            client,
+            event_sink,
+            agent_thread_name: thread_name,
+        },
     )
     .await
 }
@@ -64,46 +68,21 @@ async fn spawn_and_collect_non_thread(
     event_sink: &EventSink,
     thread_name: &Option<String>,
 ) -> Vec<(usize, String, String, ToolResult)> {
-    let mut join_set: JoinSet<(usize, String, String, ToolResult)> = JoinSet::new();
+    let mut join_set: JoinSet<(usize, Option<usize>, String, String, ToolResult)> = JoinSet::new();
 
-    for (index, tool_call_id, tool_name, args_str) in other_calls {
-        let runtime = runtime.clone();
-        let client = client.clone();
-        event_sink.emit(AgentEvent::ToolCallStarted {
-            thread_name: thread_name.clone(),
-            call_id: tool_call_id.clone(),
-            name: tool_name.clone(),
-            args_preview: preview_tool_args(&tool_name, &args_str),
-            args_detail: Some(tool_args_detail(&args_str)),
-        });
-
-        join_set.spawn(async move {
-            let parsed_args = match serde_json::from_str::<serde_json::Value>(&args_str) {
-                Ok(value) => value,
-                Err(error) => {
-                    return (
-                        index,
-                        tool_call_id,
-                        tool_name.clone(),
-                        ToolResult {
-                            content: format!(
-                                "Error: failed to parse tool arguments for '{}': {}",
-                                tool_name, error
-                            ),
-                            is_error: true,
-                        },
-                    );
-                }
-            };
-            let result = tools::execute_tool(&tool_name, parsed_args, &runtime, &client).await;
-            (index, tool_call_id, tool_name, result)
-        });
-    }
+    dag::spawn_non_thread_into(
+        &mut join_set,
+        other_calls,
+        runtime,
+        client,
+        event_sink,
+        thread_name,
+    );
 
     let mut results = Vec::new();
     while let Some(join_result) = join_set.join_next().await {
         match join_result {
-            Ok((index, tool_call_id, tool_name, result)) => {
+            Ok((index, _, tool_call_id, tool_name, result)) => {
                 event_sink.emit(AgentEvent::ToolCallFinished {
                     thread_name: thread_name.clone(),
                     call_id: tool_call_id.clone(),
@@ -134,7 +113,7 @@ async fn spawn_and_collect_non_thread(
 /// common case.
 async fn execute_simple(
     other_calls: Vec<(usize, String, String, String)>,
-    parse_errors: Vec<(usize, String, ToolResult)>,
+    parse_errors: Vec<(usize, String, String, ToolResult)>,
     runtime: ToolRuntime,
     client: ModelClient,
     event_sink: EventSink,
@@ -142,17 +121,12 @@ async fn execute_simple(
 ) -> Vec<(String, String, ToolResult)> {
     let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
 
-    // Collect parse errors immediately (emit finish event for each).
-    for (index, tool_call_id, error_result) in parse_errors {
-        event_sink.emit(AgentEvent::ToolCallFinished {
-            thread_name: thread_name.clone(),
-            call_id: tool_call_id.clone(),
-            name: "thread".to_string(),
-            content_preview: preview_tool_result("thread", &error_result),
-            is_error: error_result.is_error,
-        });
-        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
-    }
+    // Collect parse errors immediately (emit start + finish events for each).
+    all_results.extend(dag::collect_parse_errors(
+        parse_errors,
+        &event_sink,
+        &thread_name,
+    ));
 
     // Execute non-thread calls.
     let non_thread_results =
@@ -160,11 +134,7 @@ async fn execute_simple(
             .await;
     all_results.extend(non_thread_results);
 
-    all_results.sort_by_key(|(index, ..)| *index);
-    all_results
-        .into_iter()
-        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
-        .collect()
+    dag::sort_and_strip_index(all_results)
 }
 
 /// Fallback when DAG construction fails (cycle or duplicate thread names).
@@ -172,30 +142,28 @@ async fn execute_simple(
 /// Non-thread tool calls are executed normally.  All thread dispatches receive
 /// an error ToolResult describing the DAG error.  Parse errors are included.
 /// Results are sorted by original index.
-#[allow(clippy::too_many_arguments)]
 async fn execute_with_dag_error(
     thread_dispatches: Vec<dag::ParsedThreadDispatch>,
     other_calls: Vec<(usize, String, String, String)>,
-    parse_errors: Vec<(usize, String, ToolResult)>,
+    parse_errors: Vec<(usize, String, String, ToolResult)>,
     dag_err: dag::DagError,
-    runtime: ToolRuntime,
-    client: ModelClient,
-    event_sink: EventSink,
-    thread_name: Option<String>,
+    ctx: dag::DagExecContext,
 ) -> Vec<(String, String, ToolResult)> {
+    let dag::DagExecContext {
+        runtime,
+        client,
+        event_sink,
+        agent_thread_name: thread_name,
+    } = ctx;
+
     let mut all_results: Vec<(usize, String, String, ToolResult)> = Vec::new();
 
     // Collect parse errors immediately.
-    for (index, tool_call_id, error_result) in parse_errors {
-        event_sink.emit(AgentEvent::ToolCallFinished {
-            thread_name: thread_name.clone(),
-            call_id: tool_call_id.clone(),
-            name: "thread".to_string(),
-            content_preview: preview_tool_result("thread", &error_result),
-            is_error: error_result.is_error,
-        });
-        all_results.push((index, tool_call_id, "thread".to_string(), error_result));
-    }
+    all_results.extend(dag::collect_parse_errors(
+        parse_errors,
+        &event_sink,
+        &thread_name,
+    ));
 
     // Produce error ToolResults for all thread dispatches.
     let error_message = match &dag_err {
@@ -212,6 +180,13 @@ async fn execute_with_dag_error(
             content: error_message.clone(),
             is_error: true,
         };
+        event_sink.emit(AgentEvent::ToolCallStarted {
+            thread_name: thread_name.clone(),
+            call_id: dispatch.tool_call_id.clone(),
+            name: "thread".to_string(),
+            args_preview: preview_tool_args("thread", &dispatch.args_str),
+            args_detail: Some(tool_args_detail(&dispatch.args_str)),
+        });
         event_sink.emit(AgentEvent::ToolCallFinished {
             thread_name: thread_name.clone(),
             call_id: dispatch.tool_call_id.clone(),
@@ -233,22 +208,15 @@ async fn execute_with_dag_error(
             .await;
     all_results.extend(non_thread_results);
 
-    all_results.sort_by_key(|(index, ..)| *index);
-    all_results
-        .into_iter()
-        .map(|(_, tool_call_id, tool_name, result)| (tool_call_id, tool_name, result))
-        .collect()
+    dag::sort_and_strip_index(all_results)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::test_runtime;
     use crate::types::FunctionCall;
     use serde_json::json;
-    use std::collections::HashSet;
-    use std::path::PathBuf;
-    use std::sync::Arc;
-    use tokio::sync::Mutex;
 
     // ------------------------------------------------------------------
     // Test helpers
@@ -262,26 +230,6 @@ mod tests {
                 name: name.to_string(),
                 arguments: serde_json::to_string(&args).unwrap(),
             },
-        }
-    }
-
-    fn test_runtime() -> ToolRuntime {
-        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
-        ToolRuntime {
-            config_cwd: workspace_cwd.clone(),
-            workspace_cwd,
-            store_path: PathBuf::new(),
-            session_id: Some("test-session".to_string()),
-            worker_executable: None,
-            active_threads: Arc::new(Mutex::new(HashSet::new())),
-            event_sink: EventSink::none(),
-            backend,
-            mcp: None,
-            skills: None,
-            terminal_manager: crate::terminal::TerminalManager::new(),
-            thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
-            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
         }
     }
 

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -579,6 +579,11 @@ impl SessionService {
             let _ = task.await;
         }
 
+        // Clear stale active_threads — the aborted task could not run
+        // unmark cleanup.  All child processes have been killed by
+        // kill_on_drop, so no threads are actually running anymore.
+        self.active_threads.lock().await.clear();
+
         // Capture partial token usage from the cancelled run.  Because
         // `send()` now updates `last_usage` mid-loop, this includes all
         // model-call usage accumulated before the cancel.

--- a/crates/nac-core/src/tools/mod.rs
+++ b/crates/nac-core/src/tools/mod.rs
@@ -223,3 +223,31 @@ pub async fn execute_tool(
         },
     }
 }
+
+// ------------------------------------------------------------------
+// Test helpers (shared across agent::dag, agent::tool_exec, tools::thread)
+// ------------------------------------------------------------------
+
+/// Create a `ToolRuntime` suitable for unit tests.  Uses the current
+/// directory as the workspace, an empty store path, a dummy session id,
+/// and no MCP / skills / worker executable.
+#[cfg(test)]
+pub(crate) fn test_runtime() -> ToolRuntime {
+    let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
+    ToolRuntime {
+        config_cwd: workspace_cwd.clone(),
+        workspace_cwd,
+        store_path: PathBuf::new(),
+        session_id: Some("test-session".to_string()),
+        worker_executable: None,
+        active_threads: Arc::new(Mutex::new(HashSet::new())),
+        event_sink: EventSink::none(),
+        backend,
+        mcp: None,
+        skills: None,
+        terminal_manager: TerminalManager::new(),
+        thread_timeout_secs: thread::DEFAULT_THREAD_TIMEOUT_SECS,
+        worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+    }
+}

--- a/crates/nac-core/src/tools/thread.rs
+++ b/crates/nac-core/src/tools/thread.rs
@@ -110,43 +110,55 @@ pub fn thread_delete_definition() -> ToolDefinition {
     )
 }
 
-pub async fn execute_dispatch(
-    args: Value,
+#[derive(Debug, Clone)]
+pub struct ParsedDispatchParams {
+    pub thread_name: String,
+    pub action: String,
+    pub source_threads: Vec<String>,
+    pub scheduled_skills: Vec<String>,
+    pub session_id: String,
+    pub timeout_secs: u64,
+}
+
+/// Parse tool args into [`ParsedDispatchParams`].  Pure — no side effects.
+pub fn parse_dispatch_args(
+    args: &Value,
+    runtime: &ToolRuntime,
+) -> Result<ParsedDispatchParams, ToolResult> {
+    let thread_name = require_str(args, "name")?;
+    let action = require_str(args, "action")?;
+    let source_threads = require_string_array(args, "threads")?;
+    let scheduled_skills = resolve_scheduled_skills(args, runtime.skills.as_deref())?;
+    let session_id = require_session(runtime)?.to_string();
+    let timeout_secs = resolve_thread_timeout_secs(args, runtime.thread_timeout_secs);
+
+    Ok(ParsedDispatchParams {
+        thread_name,
+        action,
+        source_threads,
+        scheduled_skills,
+        session_id,
+        timeout_secs,
+    })
+}
+
+/// Execute a dispatch from already-parsed params.  Emits `ThreadStarted`,
+/// calls `run_worker`, folds worker usage, and maps the `WorkerRun` to a
+/// `ToolResult`.  Does **not** call `mark_thread_active` / `unmark_thread_active`
+/// — the caller manages the `active_threads` lifecycle.
+pub async fn execute_parsed_dispatch(
+    params: ParsedDispatchParams,
     runtime: &ToolRuntime,
     client: &ModelClient,
 ) -> ToolResult {
-    let thread_name = match require_str(&args, "name") {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    let action = match require_str(&args, "action") {
-        Ok(s) => s,
-        Err(e) => return e,
-    };
-    let source_threads = match require_string_array(&args, "threads") {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
-    let scheduled_skills = match resolve_scheduled_skills(&args, runtime.skills.as_deref()) {
-        Ok(v) => v,
-        Err(e) => return e,
-    };
-    let session_id = match require_session(runtime) {
-        Ok(s) => s.to_string(),
-        Err(e) => return e,
-    };
-
-    if !mark_thread_active(runtime, &thread_name).await {
-        return ToolResult {
-            content: format!(
-                "Thread '{}' is already running; retry after the current dispatch completes.",
-                thread_name
-            ),
-            is_error: true,
-        };
-    }
-
-    let timeout_secs = resolve_thread_timeout_secs(&args, runtime.thread_timeout_secs);
+    let ParsedDispatchParams {
+        thread_name,
+        action,
+        source_threads,
+        scheduled_skills,
+        session_id,
+        timeout_secs,
+    } = params;
 
     runtime.event_sink.emit(AgentEvent::ThreadStarted {
         name: thread_name.clone(),
@@ -167,7 +179,6 @@ pub async fn execute_dispatch(
         },
     )
     .await;
-    unmark_thread_active(runtime, &thread_name).await;
 
     // Fold worker token usage into the shared runtime accumulator so the
     // orchestrator's agent loop can include it in session totals.
@@ -203,12 +214,10 @@ pub async fn execute_dispatch(
             });
             ToolResult {
                 content: match timeout_reason {
-                    Some(reason) => {
-                        format!(
-                            "Thread '{}' timed out after {}s.\n{}",
-                            thread_name, timeout_secs, reason
-                        )
-                    }
+                    Some(reason) => format!(
+                        "Thread '{}' timed out after {}s.\n{}",
+                        thread_name, timeout_secs, reason
+                    ),
                     None => format!("Thread '{}' timed out after {}s", thread_name, timeout_secs),
                 },
                 is_error: true,
@@ -251,6 +260,30 @@ pub async fn execute_dispatch(
             }
         }
     }
+}
+
+pub async fn execute_dispatch(
+    args: Value,
+    runtime: &ToolRuntime,
+    client: &ModelClient,
+) -> ToolResult {
+    let params = match parse_dispatch_args(&args, runtime) {
+        Ok(p) => p,
+        Err(e) => return e,
+    };
+    let thread_name = params.thread_name.clone();
+    if !mark_thread_active(runtime, &thread_name).await {
+        return ToolResult {
+            content: format!(
+                "Thread '{}' is already running; retry after the current dispatch completes.",
+                thread_name
+            ),
+            is_error: true,
+        };
+    }
+    let result = execute_parsed_dispatch(params, runtime, client).await;
+    unmark_thread_active(runtime, &thread_name).await;
+    result
 }
 
 pub async fn execute_threads(runtime: &ToolRuntime) -> ToolResult {
@@ -442,7 +475,7 @@ fn resolve_thread_timeout_secs(args: &Value, default_timeout_secs: u64) -> u64 {
         .max(MIN_THREAD_TIMEOUT_SECS)
 }
 
-async fn mark_thread_active(runtime: &ToolRuntime, thread_name: &str) -> bool {
+pub(crate) async fn mark_thread_active(runtime: &ToolRuntime, thread_name: &str) -> bool {
     let mut active = runtime.active_threads.lock().await;
     if active.contains(thread_name) {
         false
@@ -452,7 +485,7 @@ async fn mark_thread_active(runtime: &ToolRuntime, thread_name: &str) -> bool {
     }
 }
 
-async fn unmark_thread_active(runtime: &ToolRuntime, thread_name: &str) {
+pub(crate) async fn unmark_thread_active(runtime: &ToolRuntime, thread_name: &str) {
     runtime.active_threads.lock().await.remove(thread_name);
 }
 
@@ -750,7 +783,11 @@ async fn run_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::events::EventSink;
     use serde_json::json;
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+    use std::sync::Arc;
 
     fn skill_record(
         name: &str,
@@ -772,6 +809,32 @@ mod tests {
             skill_record("lint", "Run linting workflows.", None),
             skill_record("review", "Review code quality.", Some("Rust")),
         ])
+    }
+
+    fn test_runtime() -> ToolRuntime {
+        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
+        ToolRuntime {
+            config_cwd: workspace_cwd.clone(),
+            workspace_cwd,
+            store_path: PathBuf::new(),
+            session_id: Some("test-session".to_string()),
+            worker_executable: None,
+            active_threads: Arc::new(Mutex::new(HashSet::new())),
+            event_sink: EventSink::none(),
+            backend,
+            mcp: None,
+            skills: None,
+            terminal_manager: crate::terminal::TerminalManager::new(),
+            thread_timeout_secs: DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+        }
+    }
+
+    fn test_runtime_with_skills() -> ToolRuntime {
+        let mut rt = test_runtime();
+        rt.skills = Some(Arc::new(test_registry()));
+        rt
     }
 
     #[test]
@@ -871,5 +934,76 @@ mod tests {
             trace.timeout_reason(),
             "The thread timed out at a tool call.\nTool call: exec_command call_123\narguments: {\"cmd\":\"cargo test -p nac-core\",\"tty\":false,\"yield_time_ms\":300000}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // parse_dispatch_args
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn parse_dispatch_args_extracts_all_fields() {
+        let runtime = test_runtime_with_skills();
+        let args = json!({
+            "name": "impl/auth",
+            "action": "Implement authentication",
+            "threads": ["design", "research"],
+            "skills": ["lint", "review"],
+            "timeout": 7200,
+        });
+
+        let params = parse_dispatch_args(&args, &runtime).unwrap();
+        assert_eq!(params.thread_name, "impl/auth");
+        assert_eq!(params.action, "Implement authentication");
+        assert_eq!(params.source_threads, vec!["design", "research"]);
+        assert_eq!(params.scheduled_skills, vec!["lint", "review"]);
+        assert_eq!(params.session_id, "test-session");
+        assert_eq!(params.timeout_secs, 7200);
+    }
+
+    #[test]
+    fn parse_dispatch_args_errors_when_name_missing() {
+        let runtime = test_runtime();
+        let args = json!({ "action": "Do something" });
+
+        let err = parse_dispatch_args(&args, &runtime).unwrap_err();
+        assert!(err.is_error);
+        assert!(err.content.contains("'name'"));
+    }
+
+    #[test]
+    fn parse_dispatch_args_errors_when_action_missing() {
+        let runtime = test_runtime();
+        let args = json!({ "name": "impl/auth" });
+
+        let err = parse_dispatch_args(&args, &runtime).unwrap_err();
+        assert!(err.is_error);
+        assert!(err.content.contains("'action'"));
+    }
+
+    #[test]
+    fn parse_dispatch_args_defaults_threads_to_empty() {
+        let runtime = test_runtime();
+        let args = json!({ "name": "t1", "action": "work" });
+
+        let params = parse_dispatch_args(&args, &runtime).unwrap();
+        assert!(params.source_threads.is_empty());
+    }
+
+    #[test]
+    fn parse_dispatch_args_defaults_skills_to_empty() {
+        let runtime = test_runtime();
+        let args = json!({ "name": "t1", "action": "work" });
+
+        let params = parse_dispatch_args(&args, &runtime).unwrap();
+        assert!(params.scheduled_skills.is_empty());
+    }
+
+    #[test]
+    fn parse_dispatch_args_applies_default_timeout() {
+        let runtime = test_runtime();
+        let args = json!({ "name": "t1", "action": "work" });
+
+        let params = parse_dispatch_args(&args, &runtime).unwrap();
+        assert_eq!(params.timeout_secs, DEFAULT_THREAD_TIMEOUT_SECS);
     }
 }

--- a/crates/nac-core/src/tools/thread/mod.rs
+++ b/crates/nac-core/src/tools/thread/mod.rs
@@ -1,21 +1,14 @@
-use std::collections::BTreeMap;
-use std::process::Stdio;
-use std::sync::Arc;
-use std::time::Duration;
-
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
-use tokio::sync::Mutex;
-use tokio::time::timeout;
 
-use crate::events::{decode_stderr_event, AgentEvent};
-use crate::model::{ModelClient, TokenUsage};
-use crate::process::{isolate_process_group, terminate_child_tree};
+use crate::events::AgentEvent;
+use crate::model::ModelClient;
 use crate::skills::SkillRegistry;
 use crate::store;
 use crate::tools::{require_str, require_string_array, ToolResult, ToolRuntime};
 use crate::types::ToolDefinition;
+
+mod worker;
+use worker::{run_worker, WorkerInvocation};
 
 pub const DEFAULT_THREAD_TIMEOUT_SECS: u64 = 60 * 60;
 pub const MIN_THREAD_TIMEOUT_SECS: u64 = 30 * 60;
@@ -493,300 +486,12 @@ async fn is_thread_active(runtime: &ToolRuntime, thread_name: &str) -> bool {
     runtime.active_threads.lock().await.contains(thread_name)
 }
 
-struct WorkerRun {
-    stdout: String,
-    stderr: String,
-    exit_code: i32,
-    timed_out: bool,
-    timeout_reason: Option<String>,
-    usage: Option<TokenUsage>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct ActiveToolCallTrace {
-    name: String,
-    args_detail: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
-enum TimeoutLocation {
-    #[default]
-    Startup,
-    ModelApi {
-        iteration: usize,
-    },
-    ToolCall,
-    BetweenToolAndModel,
-    Finalizing,
-}
-
-#[derive(Default)]
-struct WorkerTimeoutTrace {
-    location: TimeoutLocation,
-    active_tool_calls: BTreeMap<String, ActiveToolCallTrace>,
-}
-
-impl WorkerTimeoutTrace {
-    fn observe(&mut self, event: &AgentEvent) {
-        match event {
-            AgentEvent::RunStarted { .. } => {
-                self.location = TimeoutLocation::Startup;
-                self.active_tool_calls.clear();
-            }
-            AgentEvent::ModelCallStarted { iteration, .. } => {
-                self.location = TimeoutLocation::ModelApi {
-                    iteration: *iteration,
-                };
-                self.active_tool_calls.clear();
-            }
-            AgentEvent::ToolCallStarted {
-                call_id,
-                name,
-                args_detail,
-                ..
-            } => {
-                self.location = TimeoutLocation::ToolCall;
-                self.active_tool_calls.insert(
-                    call_id.clone(),
-                    ActiveToolCallTrace {
-                        name: name.clone(),
-                        args_detail: args_detail.clone(),
-                    },
-                );
-            }
-            AgentEvent::ToolCallFinished { call_id, .. } => {
-                self.active_tool_calls.remove(call_id);
-                if self.active_tool_calls.is_empty() {
-                    self.location = TimeoutLocation::BetweenToolAndModel;
-                } else {
-                    self.location = TimeoutLocation::ToolCall;
-                }
-            }
-            AgentEvent::AssistantMessage { .. } | AgentEvent::RunFinished { .. } => {
-                self.location = TimeoutLocation::Finalizing;
-                self.active_tool_calls.clear();
-            }
-            AgentEvent::Error { .. } | AgentEvent::ThreadLog { .. } => {}
-            AgentEvent::ThreadStarted { .. } | AgentEvent::ThreadFinished { .. } => {}
-        }
-    }
-
-    fn timeout_reason(&self) -> String {
-        match &self.location {
-            TimeoutLocation::ModelApi { iteration } => format!(
-                "The thread timed out at a call to the model API.\nModel call: iteration {}",
-                iteration
-            ),
-            TimeoutLocation::ToolCall if !self.active_tool_calls.is_empty() => {
-                if self.active_tool_calls.len() == 1 {
-                    let (call_id, call) = self.active_tool_calls.iter().next().unwrap();
-                    return format!(
-                        "The thread timed out at a tool call.\nTool call: {} {}\narguments: {}",
-                        call.name,
-                        call_id,
-                        call.args_detail.as_deref().unwrap_or("<not captured>")
-                    );
-                }
-
-                let mut reason = String::from("The thread timed out at tool calls:");
-                for (call_id, call) in &self.active_tool_calls {
-                    reason.push_str(&format!("\n- {} {}", call.name, call_id));
-                    match call.args_detail.as_deref() {
-                        Some(args_detail) => {
-                            reason.push_str(&format!("\n  arguments: {}", args_detail));
-                        }
-                        None => reason.push_str("\n  arguments: <not captured>"),
-                    }
-                }
-                reason
-            }
-            TimeoutLocation::BetweenToolAndModel => {
-                "The thread timed out after tool call completion while preparing the next model API call."
-                    .to_string()
-            }
-            TimeoutLocation::Finalizing => {
-                "The thread timed out after producing a final response while the worker was exiting."
-                    .to_string()
-            }
-            TimeoutLocation::Startup | TimeoutLocation::ToolCall => {
-                "The thread timed out before entering a model API call or tool call.".to_string()
-            }
-        }
-    }
-}
-
-struct WorkerInvocation<'a> {
-    session_id: &'a str,
-    thread_name: &'a str,
-    action: &'a str,
-    source_threads: &'a [String],
-    scheduled_skills: &'a [String],
-    timeout_secs: u64,
-}
-
-async fn run_worker(
-    runtime: &ToolRuntime,
-    client: &ModelClient,
-    invocation: WorkerInvocation<'_>,
-) -> std::io::Result<WorkerRun> {
-    let executable = runtime.worker_executable.clone().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "worker executable path was not configured; cannot spawn managed worker",
-        )
-    })?;
-    let mut command = Command::new(executable);
-    if runtime.backend.workspace_cwd_is_local() {
-        command.current_dir(&runtime.workspace_cwd);
-    }
-    command
-        .arg("__worker")
-        .arg("--session-id")
-        .arg(invocation.session_id)
-        .arg("--thread-name")
-        .arg(invocation.thread_name)
-        .arg("--action")
-        .arg(invocation.action)
-        .arg("--api-model")
-        .arg(client.model.as_str())
-        .arg("--api-base-url")
-        .arg(client.base_url())
-        .arg("--backend")
-        .arg(client.backend().as_str())
-        .arg("--store-path")
-        .arg(runtime.store_path.as_os_str())
-        .arg("--workspace-cwd")
-        .arg(runtime.workspace_cwd.as_os_str());
-
-    if !runtime.backend.workspace_cwd_is_local() || runtime.config_cwd != runtime.workspace_cwd {
-        command
-            .arg("--config-cwd")
-            .arg(runtime.config_cwd.as_os_str());
-    }
-
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    if let Some(reasoning_effort) = client.reasoning_effort() {
-        command.arg("--effort").arg(reasoning_effort.as_str());
-    }
-
-    if let Some(api_key_env) = client.api_key_env() {
-        command.arg("--api-key-env").arg(api_key_env);
-    }
-
-    // Always pass --extra-headers, even when empty, so the worker uses the
-    // session's headers (possibly {}) instead of falling back to config.toml.
-    if let Ok(json) = serde_json::to_string(client.extra_headers()) {
-        command.arg("--extra-headers").arg(json);
-    }
-
-    for source_thread in invocation.source_threads {
-        command.arg("--source-thread").arg(source_thread);
-    }
-    for skill in invocation.scheduled_skills {
-        command.arg("--skill").arg(skill);
-    }
-    command.args(runtime.backend.worker_cli_args());
-    isolate_process_group(&mut command);
-    command.kill_on_drop(true);
-
-    let mut child = command.spawn()?;
-
-    let timeout_trace = Arc::new(Mutex::new(WorkerTimeoutTrace::default()));
-    let stderr = child.stderr.take().unwrap();
-    let event_sink = runtime.event_sink.clone();
-    let thread_name_for_logs = invocation.thread_name.to_string();
-    let timeout_trace_for_logs = timeout_trace.clone();
-    let stderr_handle = tokio::spawn(async move {
-        let reader = BufReader::new(stderr);
-        let mut lines = reader.lines();
-        let mut output = String::new();
-        let mut worker_usage = TokenUsage::default();
-        while let Ok(Some(line)) = lines.next_line().await {
-            if let Some(event) = decode_stderr_event(&line) {
-                timeout_trace_for_logs.lock().await.observe(&event);
-                if let AgentEvent::AssistantMessage {
-                    usage: Some(usage), ..
-                } = &event
-                {
-                    worker_usage += usage.clone();
-                }
-                event_sink.emit(event);
-            } else {
-                event_sink.emit(AgentEvent::ThreadLog {
-                    name: thread_name_for_logs.clone(),
-                    line: line.clone(),
-                });
-                if !output.is_empty() {
-                    output.push('\n');
-                }
-                output.push_str(&line);
-            }
-        }
-        let usage = if worker_usage.input_tokens == 0
-            && worker_usage.output_tokens == 0
-            && worker_usage.cache_read_tokens == 0
-            && worker_usage.cache_write_tokens == 0
-        {
-            None
-        } else {
-            Some(worker_usage)
-        };
-        (output, usage)
-    });
-
-    let stdout = child.stdout.take().unwrap();
-    let stdout_handle = tokio::spawn(async move {
-        let reader = BufReader::new(stdout);
-        let mut lines = reader.lines();
-        let mut output = String::new();
-        while let Ok(Some(line)) = lines.next_line().await {
-            if !output.is_empty() {
-                output.push('\n');
-            }
-            output.push_str(&line);
-        }
-        output
-    });
-
-    let status = timeout(Duration::from_secs(invocation.timeout_secs), child.wait()).await;
-    let timed_out = status.is_err();
-    if timed_out {
-        terminate_child_tree(&mut child).await;
-    }
-
-    let (stderr, worker_usage) = stderr_handle.await.unwrap_or_default();
-    let stdout = stdout_handle.await.unwrap_or_default();
-    let timeout_reason = if timed_out {
-        Some(timeout_trace.lock().await.timeout_reason())
-    } else {
-        None
-    };
-    let exit_code = match status {
-        Ok(wait_result) => wait_result?.code().unwrap_or(-1),
-        Err(_) => -1,
-    };
-
-    Ok(WorkerRun {
-        stdout,
-        stderr,
-        exit_code,
-        timed_out,
-        timeout_reason,
-        usage: worker_usage,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::EventSink;
+    use crate::tools::test_runtime;
     use serde_json::json;
     use std::collections::HashSet;
-    use std::path::PathBuf;
     use std::sync::Arc;
 
     fn skill_record(
@@ -809,26 +514,6 @@ mod tests {
             skill_record("lint", "Run linting workflows.", None),
             skill_record("review", "Review code quality.", Some("Rust")),
         ])
-    }
-
-    fn test_runtime() -> ToolRuntime {
-        let workspace_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let backend = crate::sandbox::execution_backend_from_sandbox(None, &workspace_cwd);
-        ToolRuntime {
-            config_cwd: workspace_cwd.clone(),
-            workspace_cwd,
-            store_path: PathBuf::new(),
-            session_id: Some("test-session".to_string()),
-            worker_executable: None,
-            active_threads: Arc::new(Mutex::new(HashSet::new())),
-            event_sink: EventSink::none(),
-            backend,
-            mcp: None,
-            skills: None,
-            terminal_manager: crate::terminal::TerminalManager::new(),
-            thread_timeout_secs: DEFAULT_THREAD_TIMEOUT_SECS,
-            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
-        }
     }
 
     fn test_runtime_with_skills() -> ToolRuntime {
@@ -902,40 +587,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn timeout_trace_reports_model_api_location() {
-        let mut trace = WorkerTimeoutTrace::default();
-        trace.observe(&AgentEvent::ModelCallStarted {
-            thread_name: Some("impl/auth".to_string()),
-            iteration: 2,
-        });
-
-        assert_eq!(
-            trace.timeout_reason(),
-            "The thread timed out at a call to the model API.\nModel call: iteration 2"
-        );
-    }
-
-    #[test]
-    fn timeout_trace_reports_active_tool_call_details() {
-        let mut trace = WorkerTimeoutTrace::default();
-        trace.observe(&AgentEvent::ToolCallStarted {
-            thread_name: Some("impl/auth".to_string()),
-            call_id: "call_123".to_string(),
-            name: "exec_command".to_string(),
-            args_preview: "cargo test -p nac-core".to_string(),
-            args_detail: Some(
-                r#"{"cmd":"cargo test -p nac-core","tty":false,"yield_time_ms":300000}"#
-                    .to_string(),
-            ),
-        });
-
-        assert_eq!(
-            trace.timeout_reason(),
-            "The thread timed out at a tool call.\nTool call: exec_command call_123\narguments: {\"cmd\":\"cargo test -p nac-core\",\"tty\":false,\"yield_time_ms\":300000}"
-        );
-    }
-
     // ------------------------------------------------------------------
     // parse_dispatch_args
     // ------------------------------------------------------------------
@@ -1005,5 +656,87 @@ mod tests {
 
         let params = parse_dispatch_args(&args, &runtime).unwrap();
         assert_eq!(params.timeout_secs, DEFAULT_THREAD_TIMEOUT_SECS);
+    }
+
+    // ------------------------------------------------------------------
+    // Active threads lifecycle tests
+    // ------------------------------------------------------------------
+
+    /// Verify the basic mark/unmark lifecycle: marking a new thread succeeds,
+    /// marking it again fails, and unmarking removes it.
+    #[tokio::test]
+    async fn test_active_threads_lifecycle() {
+        let runtime = test_runtime();
+        let active = runtime.active_threads.clone();
+
+        // Initially no threads are active.
+        assert!(active.lock().await.is_empty());
+
+        // Mark thread A → succeeds (returns true).
+        assert!(mark_thread_active(&runtime, "A").await);
+        assert!(active.lock().await.contains("A"));
+
+        // Mark thread A again → fails (returns false, already active).
+        assert!(!mark_thread_active(&runtime, "A").await);
+
+        // Mark thread B → succeeds.
+        assert!(mark_thread_active(&runtime, "B").await);
+        assert!(active.lock().await.contains("B"));
+
+        // Unmark thread A → removes only A.
+        unmark_thread_active(&runtime, "A").await;
+        assert!(!active.lock().await.contains("A"));
+        assert!(active.lock().await.contains("B"), "B should still be active");
+
+        // Unmark thread B.
+        unmark_thread_active(&runtime, "B").await;
+        assert!(active.lock().await.is_empty());
+    }
+
+    /// Simulate the `marked_by_us` pattern from `execute_with_dag`: a
+    /// pre-existing thread that was already active should NOT be unmarked
+    /// by us, because `mark_thread_active` returns false for it and it
+    /// never enters the `marked_by_us` set.
+    #[tokio::test]
+    async fn test_marked_by_us_prevents_clobbering_preexisting_threads() {
+        let runtime = test_runtime();
+        let active = runtime.active_threads.clone();
+
+        // Pre-existing thread "preexisting" is already active.
+        active.lock().await.insert("preexisting".to_string());
+
+        // Simulate execute_with_dag's marking phase.
+        let mut marked_by_us: HashSet<String> = HashSet::new();
+
+        // Try to mark "preexisting" → returns false, not added to marked_by_us.
+        if mark_thread_active(&runtime, "preexisting").await {
+            marked_by_us.insert("preexisting".to_string());
+        }
+        assert!(
+            !marked_by_us.contains("preexisting"),
+            "pre-existing thread should not be in marked_by_us"
+        );
+
+        // Mark a new thread "new_thread" → returns true, added to marked_by_us.
+        if mark_thread_active(&runtime, "new_thread").await {
+            marked_by_us.insert("new_thread".to_string());
+        }
+        assert!(marked_by_us.contains("new_thread"));
+
+        // Simulate the unmarking phase: only unmark threads we marked.
+        for name in &marked_by_us {
+            unmark_thread_active(&runtime, name).await;
+        }
+
+        // "preexisting" should still be active (we didn't unmark it).
+        assert!(
+            active.lock().await.contains("preexisting"),
+            "pre-existing thread should not be clobbered"
+        );
+        // "new_thread" should be unmarked.
+        assert!(
+            !active.lock().await.contains("new_thread"),
+            "our thread should be unmarked"
+        );
     }
 }

--- a/crates/nac-core/src/tools/thread/worker.rs
+++ b/crates/nac-core/src/tools/thread/worker.rs
@@ -1,0 +1,340 @@
+use std::collections::BTreeMap;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::time::timeout;
+
+use crate::events::{decode_stderr_event, AgentEvent};
+use crate::model::{ModelClient, TokenUsage};
+use crate::process::{isolate_process_group, terminate_child_tree};
+use crate::tools::ToolRuntime;
+
+pub(super) struct WorkerRun {
+    pub(super) stdout: String,
+    pub(super) stderr: String,
+    pub(super) exit_code: i32,
+    pub(super) timed_out: bool,
+    pub(super) timeout_reason: Option<String>,
+    pub(super) usage: Option<TokenUsage>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActiveToolCallTrace {
+    name: String,
+    args_detail: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+enum TimeoutLocation {
+    #[default]
+    Startup,
+    ModelApi {
+        iteration: usize,
+    },
+    ToolCall,
+    BetweenToolAndModel,
+    Finalizing,
+}
+
+#[derive(Default)]
+struct WorkerTimeoutTrace {
+    location: TimeoutLocation,
+    active_tool_calls: BTreeMap<String, ActiveToolCallTrace>,
+}
+
+impl WorkerTimeoutTrace {
+    fn observe(&mut self, event: &AgentEvent) {
+        match event {
+            AgentEvent::RunStarted { .. } => {
+                self.location = TimeoutLocation::Startup;
+                self.active_tool_calls.clear();
+            }
+            AgentEvent::ModelCallStarted { iteration, .. } => {
+                self.location = TimeoutLocation::ModelApi {
+                    iteration: *iteration,
+                };
+                self.active_tool_calls.clear();
+            }
+            AgentEvent::ToolCallStarted {
+                call_id,
+                name,
+                args_detail,
+                ..
+            } => {
+                self.location = TimeoutLocation::ToolCall;
+                self.active_tool_calls.insert(
+                    call_id.clone(),
+                    ActiveToolCallTrace {
+                        name: name.clone(),
+                        args_detail: args_detail.clone(),
+                    },
+                );
+            }
+            AgentEvent::ToolCallFinished { call_id, .. } => {
+                self.active_tool_calls.remove(call_id);
+                if self.active_tool_calls.is_empty() {
+                    self.location = TimeoutLocation::BetweenToolAndModel;
+                } else {
+                    self.location = TimeoutLocation::ToolCall;
+                }
+            }
+            AgentEvent::AssistantMessage { .. } | AgentEvent::RunFinished { .. } => {
+                self.location = TimeoutLocation::Finalizing;
+                self.active_tool_calls.clear();
+            }
+            AgentEvent::Error { .. } | AgentEvent::ThreadLog { .. } => {}
+            AgentEvent::ThreadStarted { .. } | AgentEvent::ThreadFinished { .. } => {}
+        }
+    }
+
+    fn timeout_reason(&self) -> String {
+        match &self.location {
+            TimeoutLocation::ModelApi { iteration } => format!(
+                "The thread timed out at a call to the model API.\nModel call: iteration {}",
+                iteration
+            ),
+            TimeoutLocation::ToolCall if !self.active_tool_calls.is_empty() => {
+                if self.active_tool_calls.len() == 1 {
+                    let (call_id, call) = self.active_tool_calls.iter().next().unwrap();
+                    return format!(
+                        "The thread timed out at a tool call.\nTool call: {} {}\narguments: {}",
+                        call.name,
+                        call_id,
+                        call.args_detail.as_deref().unwrap_or("<not captured>")
+                    );
+                }
+
+                let mut reason = String::from("The thread timed out at tool calls:");
+                for (call_id, call) in &self.active_tool_calls {
+                    reason.push_str(&format!("\n- {} {}", call.name, call_id));
+                    match call.args_detail.as_deref() {
+                        Some(args_detail) => {
+                            reason.push_str(&format!("\n  arguments: {}", args_detail));
+                        }
+                        None => reason.push_str("\n  arguments: <not captured>"),
+                    }
+                }
+                reason
+            }
+            TimeoutLocation::BetweenToolAndModel => {
+                "The thread timed out after tool call completion while preparing the next model API call."
+                    .to_string()
+            }
+            TimeoutLocation::Finalizing => {
+                "The thread timed out after producing a final response while the worker was exiting."
+                    .to_string()
+            }
+            TimeoutLocation::Startup | TimeoutLocation::ToolCall => {
+                "The thread timed out before entering a model API call or tool call.".to_string()
+            }
+        }
+    }
+}
+
+pub(super) struct WorkerInvocation<'a> {
+    pub(super) session_id: &'a str,
+    pub(super) thread_name: &'a str,
+    pub(super) action: &'a str,
+    pub(super) source_threads: &'a [String],
+    pub(super) scheduled_skills: &'a [String],
+    pub(super) timeout_secs: u64,
+}
+
+pub(super) async fn run_worker(
+    runtime: &ToolRuntime,
+    client: &ModelClient,
+    invocation: WorkerInvocation<'_>,
+) -> std::io::Result<WorkerRun> {
+    let executable = runtime.worker_executable.clone().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "worker executable path was not configured; cannot spawn managed worker",
+        )
+    })?;
+    let mut command = Command::new(executable);
+    if runtime.backend.workspace_cwd_is_local() {
+        command.current_dir(&runtime.workspace_cwd);
+    }
+    command
+        .arg("__worker")
+        .arg("--session-id")
+        .arg(invocation.session_id)
+        .arg("--thread-name")
+        .arg(invocation.thread_name)
+        .arg("--action")
+        .arg(invocation.action)
+        .arg("--api-model")
+        .arg(client.model.as_str())
+        .arg("--api-base-url")
+        .arg(client.base_url())
+        .arg("--backend")
+        .arg(client.backend().as_str())
+        .arg("--store-path")
+        .arg(runtime.store_path.as_os_str())
+        .arg("--workspace-cwd")
+        .arg(runtime.workspace_cwd.as_os_str());
+
+    if !runtime.backend.workspace_cwd_is_local() || runtime.config_cwd != runtime.workspace_cwd {
+        command
+            .arg("--config-cwd")
+            .arg(runtime.config_cwd.as_os_str());
+    }
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(reasoning_effort) = client.reasoning_effort() {
+        command.arg("--effort").arg(reasoning_effort.as_str());
+    }
+
+    if let Some(api_key_env) = client.api_key_env() {
+        command.arg("--api-key-env").arg(api_key_env);
+    }
+
+    // Always pass --extra-headers, even when empty, so the worker uses the
+    // session's headers (possibly {}) instead of falling back to config.toml.
+    if let Ok(json) = serde_json::to_string(client.extra_headers()) {
+        command.arg("--extra-headers").arg(json);
+    }
+
+    for source_thread in invocation.source_threads {
+        command.arg("--source-thread").arg(source_thread);
+    }
+    for skill in invocation.scheduled_skills {
+        command.arg("--skill").arg(skill);
+    }
+    command.args(runtime.backend.worker_cli_args());
+    isolate_process_group(&mut command);
+    command.kill_on_drop(true);
+
+    let mut child = command.spawn()?;
+
+    let timeout_trace = Arc::new(Mutex::new(WorkerTimeoutTrace::default()));
+    let stderr = child.stderr.take().unwrap();
+    let event_sink = runtime.event_sink.clone();
+    let thread_name_for_logs = invocation.thread_name.to_string();
+    let timeout_trace_for_logs = timeout_trace.clone();
+    let stderr_handle = tokio::spawn(async move {
+        let reader = BufReader::new(stderr);
+        let mut lines = reader.lines();
+        let mut output = String::new();
+        let mut worker_usage = TokenUsage::default();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Some(event) = decode_stderr_event(&line) {
+                timeout_trace_for_logs.lock().await.observe(&event);
+                if let AgentEvent::AssistantMessage {
+                    usage: Some(usage), ..
+                } = &event
+                {
+                    worker_usage += usage.clone();
+                }
+                event_sink.emit(event);
+            } else {
+                event_sink.emit(AgentEvent::ThreadLog {
+                    name: thread_name_for_logs.clone(),
+                    line: line.clone(),
+                });
+                if !output.is_empty() {
+                    output.push('\n');
+                }
+                output.push_str(&line);
+            }
+        }
+        let usage = if worker_usage.input_tokens == 0
+            && worker_usage.output_tokens == 0
+            && worker_usage.cache_read_tokens == 0
+            && worker_usage.cache_write_tokens == 0
+        {
+            None
+        } else {
+            Some(worker_usage)
+        };
+        (output, usage)
+    });
+
+    let stdout = child.stdout.take().unwrap();
+    let stdout_handle = tokio::spawn(async move {
+        let reader = BufReader::new(stdout);
+        let mut lines = reader.lines();
+        let mut output = String::new();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&line);
+        }
+        output
+    });
+
+    let status = timeout(Duration::from_secs(invocation.timeout_secs), child.wait()).await;
+    let timed_out = status.is_err();
+    if timed_out {
+        terminate_child_tree(&mut child).await;
+    }
+
+    let (stderr, worker_usage) = stderr_handle.await.unwrap_or_default();
+    let stdout = stdout_handle.await.unwrap_or_default();
+    let timeout_reason = if timed_out {
+        Some(timeout_trace.lock().await.timeout_reason())
+    } else {
+        None
+    };
+    let exit_code = match status {
+        Ok(wait_result) => wait_result?.code().unwrap_or(-1),
+        Err(_) => -1,
+    };
+
+    Ok(WorkerRun {
+        stdout,
+        stderr,
+        exit_code,
+        timed_out,
+        timeout_reason,
+        usage: worker_usage,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_trace_reports_model_api_location() {
+        let mut trace = WorkerTimeoutTrace::default();
+        trace.observe(&AgentEvent::ModelCallStarted {
+            thread_name: Some("impl/auth".to_string()),
+            iteration: 2,
+        });
+
+        assert_eq!(
+            trace.timeout_reason(),
+            "The thread timed out at a call to the model API.\nModel call: iteration 2"
+        );
+    }
+
+    #[test]
+    fn timeout_trace_reports_active_tool_call_details() {
+        let mut trace = WorkerTimeoutTrace::default();
+        trace.observe(&AgentEvent::ToolCallStarted {
+            thread_name: Some("impl/auth".to_string()),
+            call_id: "call_123".to_string(),
+            name: "exec_command".to_string(),
+            args_preview: "cargo test -p nac-core".to_string(),
+            args_detail: Some(
+                r#"{"cmd":"cargo test -p nac-core","tty":false,"yield_time_ms":300000}"#
+                    .to_string(),
+            ),
+        });
+
+        assert_eq!(
+            trace.timeout_reason(),
+            "The thread timed out at a tool call.\nTool call: exec_command call_123\narguments: {\"cmd\":\"cargo test -p nac-core\",\"tty\":false,\"yield_time_ms\":300000}"
+        );
+    }
+}


### PR DESCRIPTION
allows threads to be dispatched in parallel like before, but with inter-dependencies in the same batch. they're parsed into a DAG at dispatch time and are run in waves.

here's an example of how this could enable a best-of-N in one dispatch:
```
thread("explore/xyz/1", "Get a detailed overview of xyz feature's wiring", [], [], 3600)
thread("explore/xyz/2", "Get a detailed overview of xyz feature's wiring", [], [], 3600)
thread("explore/xyz/3", "Get a detailed overview of xyz feature's wiring", [], [], 3600)
thread("explore/xyz/4", "Get a detailed overview of xyz feature's wiring", [], [], 3600)

thread( "explore/xyz/synthesize", "You've been given many attempts at the same task, getting an overview of xyz feature's wiring. Your task is to synthesize details from all these into one final output.", [], ["explore/xyz/1, explore/xyz/2, explore/xyz/3, explore/xyz/4"], 3600) 
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestrator tool execution, concurrency, and thread mutual-exclusion; incorrect DAG or active_threads handling could skip work or allow overlapping dispatches, though behavior is heavily unit-tested.
> 
> **Overview**
> **Parallel `thread` tool calls in one model turn are now ordered by a dependency DAG** instead of all spawning at once with no cross-batch ordering.
> 
> The orchestrator can dispatch multiple threads in a single response; **in-batch `threads` source names** become edges (Kahn waves). Independent threads run concurrently; dependents wait until their sources finish. **Pre-existing thread names** in `threads` do not affect wave order—workers load them as before.
> 
> `execute_tools_parallel` **partitions** calls into thread dispatches, other tools, and parse errors, then either keeps the **old all-parallel path** when there are no thread calls or runs **`execute_with_dag`**. Cycles and duplicate names in one batch fail DAG build and return errors for all thread calls while **non-thread tools still run**. Failed or skipped threads **propagate** to dependents; **`active_threads`** is pre-marked for the batch with a `marked_by_us` guard so cancel/panic does not clobber threads active from elsewhere. **Cancel** and **new `send()`** clear stale `active_threads`.
> 
> Thread dispatch is split into **`parse_dispatch_args` / `execute_parsed_dispatch`** (DAG owns marking); worker spawning moves to **`tools/thread/worker.rs`**. Orchestrator system prompt documents best-of-N style patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b757813d834957bb44abcd1fddfc9aaf5908a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->