### PR TITLE
make nac-web flat

### DIFF
--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -566,7 +566,7 @@ button.session-card {
 .session-card:focus-visible {
   border-color: var(--focus-border);
   outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
+  outline-offset: -3px;
 }
 
 .session-card.mode-sandbox:not(.errorish) {
@@ -623,7 +623,7 @@ button.session-card {
 .session-card.selected.mode-sandbox:not(.errorish):focus-visible {
   border-color: var(--focus-border);
   outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
+  outline-offset: -3px;
 }
 
 .session-card.pinned {

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -1,27 +1,50 @@
 :root {
   color-scheme: dark;
   --bg: #080809;
-  --bg-raised: #18181b;
   --bg-sunken: #0d0d0f;
   --panel: #121214;
   --panel-2: #19191c;
   --line: #34343a;
   --line-soft: #28282d;
+  --line-strong: #4a4a52;
   --text: #eeeeef;
   --muted: #b0b0b5;
   --faint: #76767e;
   --highlight: rgba(255, 255, 255, 0.84);
+  --focus-border: rgba(255, 255, 255, 0.82);
+  --focus-ring: rgba(255, 255, 255, 0.24);
+  --surface-hover: #202024;
+  --surface-active: #0f0f12;
+  --surface-selected: #242428;
+  --surface-selected-border: rgba(255, 255, 255, 0.72);
+  --control-bg: #151518;
+  --control-bg-hover: #1d1d21;
+  --control-border: var(--line);
+  --control-border-hover: var(--line-strong);
+  --button-bg: #18181b;
+  --button-bg-hover: #212126;
+  --button-bg-active: #101012;
+  --button-border: var(--line);
+  --button-border-hover: var(--line-strong);
+  --button-border-active: var(--focus-border);
   --teal: #4fd2a8;
   --amber: #e8a838;
   --rose: #d0d0d4;
   --blue: #6ea8ff;
   --green: #8a8a90;
+  --code-amber: #f0c674;
   --danger-panel: #231315;
+  --danger-panel-hover: #2b171a;
   --danger-text: #f0d6d8;
-  --danger-ring: rgba(220, 118, 126, 0.28);
-  --danger-ring-strong: rgba(238, 160, 168, 0.48);
-  --shadow-dark: rgba(0, 0, 0, 0.82);
-  --shadow-light: rgba(255, 255, 255, 0.07);
+  --danger-border: rgba(238, 160, 168, 0.42);
+  --danger-border-strong: rgba(238, 160, 168, 0.7);
+  --danger-ring: var(--danger-border);
+  --danger-ring-strong: var(--danger-border-strong);
+  --status-neutral: var(--faint);
+  --status-info: var(--blue);
+  --status-success: var(--teal);
+  --status-warning: var(--amber);
+  --status-danger: var(--danger-text);
   --type-label: 9px;
   --type-meta: 10px;
   --type-body: 11px;
@@ -37,23 +60,15 @@
   --space-lg: 10px;
   --space-xl: 12px;
   --space-2xl: 18px;
-  --radius-sm: 10px;
-  --radius-md: 12px;
-  --radius-lg: 14px;
-  --radius-xl: 16px;
-  --radius-2xl: 18px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 10px;
+  --radius-2xl: 12px;
   --radius-pill: 999px;
   --radius: var(--radius-lg);
   --button-size: 34px;
   --button-size-compact: 30px;
-  --neu-raised: 9px 9px 18px rgba(0, 0, 0, 0.62), -5px -5px 12px rgba(255, 255, 255, 0.055);
-  --neu-raised-small: 6px 6px 12px rgba(0, 0, 0, 0.58), -4px -4px 10px rgba(255, 255, 255, 0.052);
-  --neu-pressed: inset 6px 6px 13px rgba(0, 0, 0, 0.6), inset -4px -4px 10px rgba(255, 255, 255, 0.04);
-  --neu-sunken: var(--neu-pressed), 0 0 0 1px rgba(255, 255, 255, 0.045);
-  --neu-sunken-soft: var(--neu-pressed), 0 0 0 1px rgba(255, 255, 255, 0.04);
-  --neu-panel: 0 0 0 1px rgba(255, 255, 255, 0.055), 14px 14px 30px rgba(0, 0, 0, 0.72), -7px -7px 18px rgba(255, 255, 255, 0.035);
-  --neu-dialog: 18px 18px 40px rgba(0, 0, 0, 0.78), -7px -7px 18px rgba(255, 255, 255, 0.04);
-  --neu-selected: 0 0 0 1px rgba(255, 255, 255, 0.82), 9px 9px 18px rgba(0, 0, 0, 0.62), -5px -5px 12px rgba(255, 255, 255, 0.06);
   --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -81,30 +96,59 @@ button,
 input,
 select,
 textarea {
-  font: inherit;
-}
-
-button,
-input,
-select,
-textarea {
-  background: var(--panel);
-  border: 0;
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
   border-radius: var(--radius-md);
   color: var(--text);
+  font: inherit;
   outline: none;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
 }
 
 button {
+  background: var(--button-bg);
+  border-color: var(--button-border);
   cursor: pointer;
-  box-shadow: var(--neu-raised-small);
+  box-shadow: none;
 }
 
-button:hover,
+input:hover:not(:disabled),
+select:hover:not(:disabled),
+textarea:hover:not(:disabled) {
+  border-color: var(--control-border-hover);
+}
+
+button:hover:not(:disabled) {
+  background: var(--button-bg-hover);
+  border-color: var(--button-border-hover);
+}
+
+button:active:not(:disabled) {
+  background: var(--button-bg-active);
+  border-color: var(--button-border-active);
+}
+
 input:focus,
 select:focus,
 textarea:focus {
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--highlight);
+  border-color: var(--focus-border);
+}
+
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  border-color: var(--focus-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  cursor: default;
+  opacity: 0.52;
 }
 
 textarea {
@@ -123,9 +167,10 @@ textarea {
 .inspector {
   min-width: 0;
   min-height: 0;
+  border: 1px solid var(--line);
   border-radius: var(--radius-2xl);
   background: var(--panel);
-  box-shadow: var(--neu-panel);
+  box-shadow: none;
 }
 
 .inspector {
@@ -153,16 +198,17 @@ textarea {
 .launch-form input,
 .launch-form select,
 .launch-form textarea {
-  background: var(--panel-2);
-  border: 1px solid rgba(255, 255, 255, 0.055);
-  box-shadow: var(--neu-raised-small);
+  background: var(--control-bg);
+  border-color: var(--control-border);
+  box-shadow: none;
   font-family: var(--mono);
 }
 
 .launch-form input:focus,
 .launch-form select:focus,
 .launch-form textarea:focus {
-  box-shadow: var(--neu-raised-small), 0 0 0 1px var(--highlight);
+  border-color: var(--focus-border);
+  box-shadow: none;
 }
 
 .section-heading,
@@ -217,24 +263,36 @@ textarea {
   gap: var(--space-sm) !important;
   padding: var(--space-sm) var(--space-md);
   border-radius: var(--radius-md);
-  border: 1px solid rgba(255, 255, 255, 0.055);
-  background: var(--panel-2);
-  box-shadow: var(--neu-raised-small);
+  border: 1px solid var(--control-border);
+  background: var(--control-bg);
+  box-shadow: none;
+}
+
+.toggle:hover {
+  border-color: var(--control-border-hover);
+  background: var(--control-bg-hover);
+}
+
+.toggle:focus-within {
+  border-color: var(--focus-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .toggle input {
   width: auto;
+  accent-color: var(--highlight);
 }
 
 .primary-action {
   display: inline-grid;
   place-items: center;
-  background: var(--panel);
-  border: 0;
+  background: var(--button-bg);
+  border: 1px solid var(--button-border);
   color: #f1f1f1;
   font-weight: var(--type-weight-strong);
   padding: var(--space-md) var(--space-xl);
-  box-shadow: var(--neu-raised-small);
+  box-shadow: none;
 }
 
 .icon-button {
@@ -243,10 +301,10 @@ textarea {
   width: var(--button-size);
   height: var(--button-size);
   padding: 0;
-  border: 0;
+  border: 1px solid var(--button-border);
   border-radius: var(--radius-md);
-  background: var(--panel);
-  box-shadow: var(--neu-raised-small);
+  background: var(--button-bg);
+  box-shadow: none;
   color: var(--text);
   font-family: var(--mono);
   font-size: var(--type-ui);
@@ -266,21 +324,21 @@ textarea {
 
 .icon-button-destructive {
   background: var(--danger-panel);
+  border-color: var(--danger-border);
   color: var(--danger-text);
-  box-shadow: var(--neu-raised-small), 0 0 0 1px var(--danger-ring);
+  box-shadow: none;
 }
 
-.icon-button-destructive:hover {
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--danger-ring-strong);
+.icon-button-destructive:hover:not(:disabled) {
+  background: var(--danger-panel-hover);
+  border-color: var(--danger-border-strong);
+  box-shadow: none;
 }
 
-.primary-action:active,
-.icon-button:active {
-  box-shadow: var(--neu-pressed);
-}
-
-.icon-button-destructive:active {
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--danger-ring);
+.icon-button-destructive:active:not(:disabled) {
+  background: var(--danger-panel);
+  border-color: var(--danger-border);
+  box-shadow: none;
 }
 
 .icon-button:disabled {
@@ -307,35 +365,37 @@ textarea {
 }
 
 .form-status.error {
-  color: var(--text);
+  color: var(--danger-text);
+  font-weight: var(--type-weight-strong);
 }
 
 .status-dot {
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius-pill);
-  background: var(--faint);
-  box-shadow: 0 0 10px currentColor;
+  background: var(--status-neutral);
+  box-shadow: none;
 }
 
 .status-dot.active {
-  color: var(--teal);
-  background: var(--teal);
+  border-color: var(--status-success);
+  background: var(--status-success);
 }
 
 .status-dot.attention {
-  color: var(--blue);
-  background: var(--blue);
+  border-color: var(--status-info);
+  background: var(--status-info);
 }
 
 .status-dot.sandbox {
-  color: var(--faint);
-  background: var(--faint);
+  border-color: var(--status-warning);
+  background: var(--status-warning);
 }
 
 .status-dot.idle {
-  color: var(--faint);
-  background: var(--faint);
+  border-color: var(--line-strong);
+  background: var(--status-neutral);
 }
 
 .session-id {
@@ -364,10 +424,11 @@ textarea {
 .strip-cell,
 .summary-grid div {
   min-width: 0;
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-md);
   padding: var(--space-md) var(--space-lg);
   background: var(--bg-sunken);
-  box-shadow: var(--neu-sunken);
+  box-shadow: none;
 }
 
 .strip-cell span,
@@ -429,13 +490,16 @@ textarea {
 }
 
 .session-card {
+  position: relative;
   min-width: 0;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius);
   background: var(--panel-2);
-  box-shadow: var(--neu-raised);
+  box-shadow: none;
   cursor: pointer;
   padding: var(--space-md);
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease, outline-color 120ms ease;
 }
 
 button.session-card {
@@ -474,20 +538,83 @@ button.session-card {
   place-items: center;
   width: var(--button-size);
   height: var(--button-size);
+  border: 1px solid var(--button-border);
   border-radius: var(--radius-md);
-  background: var(--bg-sunken);
-  box-shadow: var(--neu-pressed);
+  background: var(--button-bg);
+  box-shadow: none;
+  color: var(--text);
   font-family: var(--mono);
 }
 
+.session-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: transparent;
+}
+
+.session-card:hover {
+  border-color: var(--line-strong);
+  background: var(--surface-hover);
+  box-shadow: none;
+}
+
+.session-card.warn {
+  border-color: rgba(232, 168, 56, 0.52);
+  background: #1f1a10;
+}
+
+.session-card.warn::before {
+  background: var(--status-warning);
+}
+
 .session-card.errorish {
-  border-color: rgba(208, 208, 212, 0.16);
-  box-shadow: var(--neu-raised), 0 0 0 1px rgba(208, 208, 212, 0.06);
+  border-color: var(--danger-border-strong);
+  background: var(--danger-panel);
+  box-shadow: none;
+}
+
+.session-card.errorish::before {
+  background: var(--danger-border-strong);
+}
+
+.session-card.selected,
+.session-card.selected.errorish,
+.tabs button.active {
+  border-color: var(--surface-selected-border);
+  background: var(--surface-selected);
+  box-shadow: none;
 }
 
 .session-card.selected,
 .session-card.selected.errorish {
-  box-shadow: var(--neu-selected);
+  outline: 1px solid var(--surface-selected-border);
+  outline-offset: -2px;
+}
+
+.session-card.selected.warn {
+  border-color: rgba(232, 168, 56, 0.72);
+}
+
+.session-card.selected.errorish {
+  border-color: var(--danger-border-strong);
+}
+
+.session-card.pinned {
+  border-top-color: var(--status-info);
+}
+
+.session-card.pinned::after {
+  content: "PIN";
+  position: absolute;
+  top: var(--space-sm);
+  right: calc(var(--space-md) + 14px);
+  color: var(--status-info);
+  font-family: var(--mono);
+  font-size: var(--type-label);
+  font-weight: var(--type-weight-strong);
+  letter-spacing: 0.04em;
 }
 
 .pinned-section-label {
@@ -506,9 +633,6 @@ button.session-card {
   background: var(--line-soft);
 }
 
-.session-card {
-  position: relative;
-}
 
 .session-card-head {
   display: grid;
@@ -547,10 +671,10 @@ button.session-card {
   width: 12px;
   height: 12px;
   vertical-align: -0.1em;
-  color: var(--text);
+  color: var(--status-warning);
   stroke-width: 1.5;
-  opacity: 0.8;
-  filter: drop-shadow(0 0 3px var(--text));
+  opacity: 1;
+  filter: none;
 }
 
 .ssh-icon {
@@ -558,10 +682,10 @@ button.session-card {
   width: 12px;
   height: 12px;
   vertical-align: -0.1em;
-  color: var(--text);
+  color: var(--status-info);
   stroke-width: 1.5;
-  opacity: 0.8;
-  filter: drop-shadow(0 0 3px var(--text));
+  opacity: 1;
+  filter: none;
 }
 
 .telemetry-grid {
@@ -573,10 +697,11 @@ button.session-card {
 
 .telemetry-grid div {
   min-width: 0;
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   padding: var(--space-sm);
   background: var(--bg-sunken);
-  box-shadow: var(--neu-sunken-soft);
+  box-shadow: none;
 }
 
 .telemetry-grid span {
@@ -602,7 +727,12 @@ button.session-card {
 }
 
 .run-tile-active {
-  color: #4fd2a8;
+  color: var(--status-success);
+  font-weight: var(--type-weight-strong);
+}
+
+.run-tile-active::before {
+  content: "● ";
 }
 
 .last-prompt {
@@ -619,12 +749,13 @@ button.session-card {
 }
 
 .empty-state {
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius);
   color: var(--muted);
   font-family: var(--mono);
   padding: var(--space-2xl);
-  background: var(--panel);
-  box-shadow: var(--neu-pressed);
+  background: var(--panel-2);
+  box-shadow: none;
 }
 
 .matrix-empty {
@@ -668,14 +799,17 @@ button.session-card {
 
 .tabs button {
   padding: var(--space-sm) var(--space-xs);
+  border-color: var(--button-border);
+  background: var(--button-bg);
   color: var(--muted);
   font-family: var(--mono);
   font-size: var(--type-meta);
+  box-shadow: none;
 }
 
+.tabs button:hover:not(:disabled),
 .tabs button.active {
   color: var(--text);
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--highlight);
 }
 
 .summary-grid {
@@ -704,10 +838,10 @@ button.session-card {
 .dense-list {
   min-height: 0;
   overflow: auto;
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius);
-  background: var(--bg-sunken);
+  background: var(--surface-active);
   padding: var(--space-md);
-  box-shadow: var(--neu-sunken);
 }
 
 .transcript {
@@ -717,12 +851,21 @@ button.session-card {
 .message-row {
   display: grid;
   gap: var(--space-xs);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.035);
-  padding: var(--space-md) 0;
+  border-bottom: 1px solid var(--line-soft);
+  border-left: 2px solid transparent;
+  padding: var(--space-md) 0 var(--space-md) var(--space-sm);
 }
 
 .message-row:first-child {
   padding-top: 0;
+}
+
+.message-row:last-child {
+  border-bottom: 0;
+}
+
+.message-row.pending {
+  border-left-color: var(--status-info);
 }
 
 .message-row.pending .message-meta {
@@ -792,24 +935,29 @@ button.session-card {
   max-width: 100%;
   gap: var(--space-sm);
   overflow: hidden;
-  border: 1px solid rgba(79, 210, 168, 0.16);
+  border: 1px solid var(--line-soft);
+  border-left: 3px solid var(--status-info);
   border-radius: var(--radius-md);
-  background: linear-gradient(135deg, rgba(79, 210, 168, 0.08), rgba(110, 168, 255, 0.05)), var(--bg-sunken);
-  box-shadow: var(--neu-sunken-soft);
+  background: var(--surface-active);
+  box-shadow: none;
   padding: var(--space-sm);
   white-space: normal;
 }
 
 .life-waiting-canvas {
+  --waiting-life-dead: rgba(110, 168, 255, 0.16);
+  --waiting-life-alive: rgba(238, 238, 239, 0.72);
+  --waiting-life-born: rgba(79, 210, 168, 0.82);
   display: block;
   width: 100%;
   max-width: 100%;
   min-width: 0;
   height: 96px;
   min-height: 72px;
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
-  background: var(--bg-sunken);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.045), 0 0 24px rgba(79, 210, 168, 0.08);
+  background: var(--bg);
+  box-shadow: none;
 }
 
 .life-waiting-label {
@@ -826,9 +974,10 @@ button.session-card {
   flex: 0 0 auto;
   width: 7px;
   height: 7px;
+  border: 1px solid rgba(79, 210, 168, 0.55);
   border-radius: var(--radius-pill);
   background: var(--teal);
-  box-shadow: 0 0 10px rgba(79, 210, 168, 0.48), 0 0 16px rgba(110, 168, 255, 0.18);
+  box-shadow: none;
 }
 
 .message-row,
@@ -890,9 +1039,11 @@ button.session-card {
 }
 
 .message-body.markdown blockquote {
-  border-left: 2px solid var(--line);
+  border-left: 3px solid var(--line-strong);
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: rgba(255, 255, 255, 0.025);
   color: var(--muted);
-  padding-left: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
 }
 
 .message-body.markdown blockquote > * + * {
@@ -931,9 +1082,9 @@ button.session-card {
 .message-body.markdown code {
   max-width: 100%;
   overflow-wrap: anywhere;
-  border: 1px solid rgba(255, 255, 255, 0.075);
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.055);
+  background: var(--control-bg);
   color: var(--code-amber);
   padding: 0 3px;
   white-space: break-spaces;
@@ -944,9 +1095,9 @@ button.session-card {
   max-width: 100%;
   overflow-x: hidden;
   overflow-wrap: anywhere;
-  border: 1px solid rgba(255, 255, 255, 0.065);
+  border: 1px solid var(--line);
   border-radius: var(--radius-md);
-  background: rgba(0, 0, 0, 0.22);
+  background: var(--bg);
   padding: var(--space-md);
   white-space: pre-wrap;
   word-break: break-word;
@@ -1000,8 +1151,8 @@ button.session-card {
 }
 
 .message-body.markdown th {
-  background: rgba(255, 255, 255, 0.045);
-  color: var(--muted);
+  background: var(--panel-2);
+  color: var(--text);
   font-weight: var(--type-weight-strong);
 }
 
@@ -1018,14 +1169,18 @@ button.session-card {
   --prompt-life-padding-block: var(--space-sm);
   --prompt-life-padding-inline: var(--space-xs);
   display: grid;
-  border-radius: var(--radius-xl);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
   background: var(--panel);
-  box-shadow: var(--neu-pressed);
+  box-shadow: none;
   padding: var(--space-xs);
 }
 
 .prompt-form:focus-within {
-  box-shadow: var(--neu-pressed);
+  border-color: var(--focus-border);
+  box-shadow: none;
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .prompt-submit {
@@ -1071,9 +1226,10 @@ button.session-card {
   height: var(--prompt-life-height);
   min-height: var(--prompt-life-height);
   max-height: var(--prompt-life-height);
-  border: 0;
+  border: 1px solid var(--line-soft);
+  border-left: 3px solid var(--status-info);
   border-radius: var(--radius-md);
-  background: transparent;
+  background: var(--surface-active);
   box-shadow: none;
   padding: var(--prompt-life-padding-block) var(--prompt-life-padding-inline);
 }
@@ -1083,8 +1239,9 @@ button.session-card {
   height: calc(var(--prompt-life-height) - var(--prompt-life-padding-block) - var(--prompt-life-padding-block));
   min-height: calc(var(--prompt-life-height) - var(--prompt-life-padding-block) - var(--prompt-life-padding-block));
   max-height: calc(var(--prompt-life-height) - var(--prompt-life-padding-block) - var(--prompt-life-padding-block));
-  border-radius: 0;
-  background: transparent;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
   box-shadow: none;
 }
 
@@ -1109,7 +1266,8 @@ button.session-card {
 .prompt-form.busy {
   grid-template-columns: minmax(0, 1fr);
   gap: var(--space-sm);
-  box-shadow: var(--neu-pressed);
+  border-color: var(--line-strong);
+  box-shadow: none;
 }
 
 .prompt-form.busy::after {
@@ -1137,7 +1295,7 @@ button.session-card {
 }
 
 .prompt-form.busy textarea:disabled {
-  background: rgba(255, 255, 255, 0.018);
+  background: var(--surface-active);
 }
 
 .prompt-form.busy .prompt-submit {
@@ -1149,9 +1307,10 @@ button.session-card {
 .prompt-form .prompt-submit[aria-disabled="true"] {
   cursor: not-allowed;
   color: var(--faint);
+  border-color: var(--line-soft);
   opacity: 0.42;
-  background: var(--bg-sunken);
-  box-shadow: var(--neu-pressed);
+  background: var(--surface-active);
+  box-shadow: none;
 }
 
 .event-log,
@@ -1163,15 +1322,28 @@ button.session-card {
 
 .event-item,
 .dense-item {
-  border: 1px solid rgba(255, 255, 255, 0.055);
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-md);
   padding: var(--space-md);
   background: var(--panel-2);
-  box-shadow: var(--neu-raised-small);
 }
 
 .event-kind {
   color: var(--text);
+}
+
+.event-item.event-tool-start {
+  border-left: 3px solid var(--status-info);
+}
+
+.event-item.event-tool-finish {
+  border-left: 3px solid var(--status-success);
+}
+
+.event-item.event-tool-error {
+  border-color: var(--danger-border);
+  border-left: 3px solid var(--status-danger);
+  background: var(--danger-panel);
 }
 
 .dense-title {
@@ -1197,7 +1369,9 @@ button.session-card {
 }
 
 .thread-row.thread-active {
-  box-shadow: var(--neu-selected);
+  border-color: var(--surface-selected-border);
+  border-left: 3px solid var(--status-success);
+  background: var(--surface-selected);
 }
 
 .thread-block {
@@ -1215,18 +1389,30 @@ button.session-card {
 }
 
 .thread-row:hover,
-.thread-row:focus-visible {
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--highlight);
+.workspace-file:hover {
+  border-color: var(--button-border-hover);
+  background: var(--surface-hover);
+}
+
+.thread-row:focus-visible,
+.workspace-file:focus-visible {
+  border-color: var(--focus-border);
+  background: var(--surface-hover);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
 }
 
 .thread-row.expanded {
-  border-color: rgba(255, 255, 255, 0.28);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018)), var(--panel-2);
-  box-shadow: var(--neu-selected);
+  border-color: var(--line-strong);
+  border-bottom-color: var(--line-soft);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+  background: var(--surface-selected);
 }
 
 .thread-row.thread-active.expanded {
-  box-shadow: var(--neu-selected);
+  border-color: var(--surface-selected-border);
+  border-left-color: var(--status-success);
+  background: var(--surface-selected);
 }
 
 .thread-detail {
@@ -1234,15 +1420,14 @@ button.session-card {
   gap: var(--space-sm);
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--line-soft);
   border-top: 0;
   border-radius: 0 0 var(--radius-md) var(--radius-md);
-  background: var(--bg-sunken);
+  background: var(--surface-active);
   padding: var(--space-sm);
-  box-shadow: var(--neu-sunken-soft);
 }
 
-/* Nested episode panels inside thread-detail — raised from the sunken background */
+/* Nested episode panels inside thread-detail */
 .thread-detail .dense-section-title {
   margin-top: var(--space-md);
 }
@@ -1253,10 +1438,9 @@ button.session-card {
 
 .thread-detail .dense-subitem {
   background: var(--panel);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   padding: var(--space-sm);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
 .thread-detail .dense-subitem .dense-detail-grid {
@@ -1322,14 +1506,24 @@ button.session-card {
 }
 
 .dense-subitem {
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
-  background: var(--bg-sunken);
+  background: var(--surface-active);
   padding: var(--space-sm);
 }
 
 .dense-subitem .dense-detail-grid,
 .dense-subitem .dense-body {
   margin-top: var(--space-xs);
+}
+
+.workset-row,
+.workspace-summary {
+  border-left: 3px solid var(--line-strong);
+}
+
+.workspace-summary {
+  border-left-color: var(--status-info);
 }
 
 .workspace-file-block {
@@ -1345,23 +1539,19 @@ button.session-card {
   font: inherit;
 }
 
-.workspace-file:hover,
-.workspace-file:focus-visible {
-  box-shadow: var(--neu-pressed), 0 0 0 1px var(--highlight);
-}
-
 .workspace-file.selected {
-  border-color: rgba(255, 255, 255, 0.28);
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.018)), var(--panel-2);
-  box-shadow: var(--neu-selected);
+  border-color: var(--surface-selected-border);
+  border-left: 3px solid var(--status-info);
+  background: var(--surface-selected);
 }
 
 .workspace-file.unsupported,
 .workspace-file.unsupported:hover,
 .workspace-file.unsupported:focus-visible {
   cursor: not-allowed;
+  border-color: var(--line-soft);
+  background: var(--surface-active);
   opacity: 0.68;
-  box-shadow: var(--neu-sunken-soft);
 }
 
 .workspace-file-affordance {
@@ -1380,11 +1570,10 @@ button.session-card {
   gap: var(--space-sm);
   min-width: 0;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-md);
-  background: var(--bg-sunken);
+  background: var(--surface-active);
   padding: var(--space-sm);
-  box-shadow: var(--neu-sunken-soft);
 }
 
 .diff-viewer-title,
@@ -1421,7 +1610,7 @@ button.session-card {
 }
 
 .diff-section + .diff-section {
-  border-top: 1px solid rgba(255, 255, 255, 0.055);
+  border-top: 1px solid var(--line-soft);
   padding-top: var(--space-sm);
 }
 
@@ -1441,9 +1630,9 @@ button.session-card {
 .diff-table-wrap {
   min-width: 0;
   overflow: auto;
-  border: 1px solid rgba(255, 255, 255, 0.055);
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--bg);
 }
 
 .diff-table {
@@ -1471,7 +1660,7 @@ button.session-card {
 
 .diff-table th,
 .diff-table td {
-  border-top: 1px solid rgba(255, 255, 255, 0.035);
+  border-top: 1px solid var(--line-soft);
   padding: var(--space-2xs) var(--space-sm);
   vertical-align: top;
 }
@@ -1483,7 +1672,7 @@ button.session-card {
   text-align: right;
   user-select: none;
   white-space: nowrap;
-  background: rgba(255, 255, 255, 0.022);
+  background: var(--panel);
 }
 
 .diff-marker {
@@ -1501,32 +1690,38 @@ button.session-card {
 }
 
 .diff-line.add > td {
-  background: rgba(79, 210, 168, 0.08);
+  border-top-color: rgba(79, 210, 168, 0.22);
+  background: rgba(79, 210, 168, 0.1);
 }
 
+.diff-line.add .diff-gutter,
 .diff-line.add .diff-marker {
   color: var(--teal);
 }
 
 .diff-line.del > td {
-  background: rgba(220, 118, 126, 0.1);
+  border-top-color: var(--danger-border);
+  background: rgba(240, 214, 216, 0.1);
 }
 
+.diff-line.del .diff-gutter,
 .diff-line.del .diff-marker {
   color: var(--danger-text);
 }
 
 .diff-line.hunk > td {
+  border-top-color: rgba(110, 168, 255, 0.28);
   color: var(--blue);
-  background: rgba(110, 168, 255, 0.11);
+  background: rgba(110, 168, 255, 0.12);
   font-weight: var(--type-weight-strong);
 }
 
 .diff-warning,
 .diff-state {
+  border: 1px solid var(--line-soft);
   border-radius: var(--radius-sm);
   padding: var(--space-sm) var(--space-md);
-  background: rgba(255, 255, 255, 0.035);
+  background: var(--panel-2);
   color: var(--muted);
   font-family: var(--mono);
   font-size: var(--type-meta);
@@ -1534,7 +1729,8 @@ button.session-card {
 
 .diff-warning {
   color: var(--text);
-  border: 1px solid rgba(189, 189, 194, 0.18);
+  border-color: rgba(232, 168, 56, 0.45);
+  background: rgba(232, 168, 56, 0.1);
 }
 
 .diff-state.error {
@@ -1559,8 +1755,7 @@ button.session-card {
   display: grid;
   place-items: center;
   padding: 14px;
-  background: rgba(0, 0, 0, 0.52);
-  backdrop-filter: blur(8px);
+  background: rgba(8, 8, 9, 0.86);
 }
 
 .launch-overlay[hidden] {
@@ -1571,10 +1766,10 @@ button.session-card {
   width: min(620px, 100%);
   max-height: min(720px, calc(100vh - 28px));
   overflow: auto;
-  border: 1px solid rgba(255, 255, 255, 0.06);
-  border-radius: var(--radius-xl);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-lg);
   background: var(--panel);
-  box-shadow: var(--neu-dialog);
+  box-shadow: none;
   padding: var(--space-lg);
 }
 
@@ -1693,9 +1888,6 @@ button.session-card {
     height: var(--button-size-compact);
     padding: 0 var(--space-md);
     border-radius: var(--radius-pill);
-    background: var(--panel-2);
-    box-shadow: var(--neu-raised-small);
-    color: var(--text);
     font-family: var(--mono);
     font-size: var(--type-meta);
     font-weight: var(--type-weight-strong);

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -569,15 +569,6 @@ button.session-card {
   outline-offset: 2px;
 }
 
-.session-card.warn {
-  border-color: rgba(232, 168, 56, 0.52);
-  background: #1f1a10;
-}
-
-.session-card.warn::before {
-  background: var(--status-warning);
-}
-
 .session-card.mode-sandbox:not(.errorish) {
   border-color: var(--sandbox-border);
 }
@@ -617,10 +608,6 @@ button.session-card {
 .session-card.selected.errorish {
   outline: 1px solid var(--surface-selected-border);
   outline-offset: -2px;
-}
-
-.session-card.selected.warn {
-  border-color: rgba(232, 168, 56, 0.72);
 }
 
 .session-card.selected.mode-sandbox:not(.errorish) {

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -631,6 +631,14 @@ button.session-card {
   border-color: var(--danger-border-strong);
 }
 
+.session-card.selected:focus-visible,
+.session-card.selected.errorish:focus-visible,
+.session-card.selected.mode-sandbox:not(.errorish):focus-visible {
+  border-color: var(--focus-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .session-card.pinned {
   border-top-color: var(--status-info);
 }

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -42,9 +42,12 @@
   --danger-ring-strong: var(--danger-border-strong);
   --status-neutral: var(--faint);
   --status-info: var(--blue);
+  --status-sandbox: var(--status-info);
   --status-success: var(--teal);
   --status-warning: var(--amber);
   --status-danger: var(--danger-text);
+  --sandbox-border: rgba(110, 168, 255, 0.38);
+  --sandbox-border-strong: rgba(110, 168, 255, 0.58);
   --type-label: 9px;
   --type-meta: 10px;
   --type-body: 11px;
@@ -389,8 +392,8 @@ textarea {
 }
 
 .status-dot.sandbox {
-  border-color: var(--status-warning);
-  background: var(--status-warning);
+  border-color: var(--status-sandbox);
+  background: var(--status-sandbox);
 }
 
 .status-dot.idle {
@@ -560,6 +563,12 @@ button.session-card {
   box-shadow: none;
 }
 
+.session-card:focus-visible {
+  border-color: var(--focus-border);
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 .session-card.warn {
   border-color: rgba(232, 168, 56, 0.52);
   background: #1f1a10;
@@ -567,6 +576,18 @@ button.session-card {
 
 .session-card.warn::before {
   background: var(--status-warning);
+}
+
+.session-card.mode-sandbox:not(.errorish) {
+  border-color: var(--sandbox-border);
+}
+
+.session-card.mode-sandbox:not(.errorish):not(.selected):hover {
+  border-color: var(--sandbox-border-strong);
+}
+
+.session-card.mode-sandbox:not(.errorish)::before {
+  background: var(--status-sandbox);
 }
 
 .session-card.errorish {
@@ -580,7 +601,12 @@ button.session-card {
 }
 
 .session-card.selected,
-.session-card.selected.errorish,
+.session-card.selected.errorish {
+  border-color: var(--surface-selected-border);
+  background: var(--surface-selected);
+  box-shadow: none;
+}
+
 .tabs button.active {
   border-color: var(--surface-selected-border);
   background: var(--surface-selected);
@@ -595,6 +621,10 @@ button.session-card {
 
 .session-card.selected.warn {
   border-color: rgba(232, 168, 56, 0.72);
+}
+
+.session-card.selected.mode-sandbox:not(.errorish) {
+  border-color: var(--surface-selected-border);
 }
 
 .session-card.selected.errorish {
@@ -671,7 +701,7 @@ button.session-card {
   width: 12px;
   height: 12px;
   vertical-align: -0.1em;
-  color: var(--status-warning);
+  color: var(--status-sandbox);
   stroke-width: 1.5;
   opacity: 1;
   filter: none;
@@ -945,9 +975,6 @@ button.session-card {
 }
 
 .life-waiting-canvas {
-  --waiting-life-dead: rgba(110, 168, 255, 0.16);
-  --waiting-life-alive: rgba(238, 238, 239, 0.72);
-  --waiting-life-born: rgba(79, 210, 168, 0.82);
   display: block;
   width: 100%;
   max-width: 100%;

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -1159,7 +1159,7 @@ function renderNewSessionCard() {
 function renderSessionCard(card) {
   if (!card) return "";
   return `
-    <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
+    <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" aria-label="${escapeAttr(sessionCardAriaLabel(card))}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
       <div class="session-card-head">
         <div>
           <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}${card.sshHost ? ` <svg class="icon ssh-icon" viewBox="0 0 24 24" aria-hidden="true" title="ssh: ${escapeAttr(card.sshHost)}"><rect x="4" y="5" width="16" height="14" rx="2"></rect><path d="M7 10l3 2-3 2"></path><path d="M13 14h4"></path></svg>` : ""}</h2>
@@ -1168,12 +1168,27 @@ function renderSessionCard(card) {
         <span class="status-dot ${card.statusClass}"></span>
       </div>
       <div class="telemetry-grid">
-        <div><span>run</span><strong data-run-timer="${escapeAttr(card.sessionId)}" class="run-tile${card.runActive ? " run-tile-active" : ""}">${card.runDisplay}</strong></div>
+        <div><span>run</span><strong data-run-timer="${escapeAttr(card.sessionId)}" class="run-tile${card.runActive ? " run-tile-active" : ""}" aria-label="${escapeAttr(runTileAriaLabel(card))}">${card.runDisplay}</strong></div>
         <div><span>add</span><strong>${escapeHtml(card.additions)}</strong></div>
         <div><span>del</span><strong>${escapeHtml(card.deletions)}</strong></div>
       </div>
       <div class="last-prompt">${escapeHtml(card.promptPreview)}</div>
     </article>`;
+}
+
+function sessionCardAriaLabel(card) {
+  const states = [];
+  if (card?.pinned) states.push("pinned");
+  if (card?.selected) states.push("selected");
+  if (card?.runActive) states.push("run active");
+  const stateText = states.length ? `, ${states.join(", ")}` : "";
+  return `Session ${card?.shortId || shortId(card?.sessionId) || "unknown"}${stateText}`;
+}
+
+function runTileAriaLabel(card) {
+  if (card?.runActive) return `Run active, elapsed ${card.runDisplay}`;
+  if (card?.runDisplay && card.runDisplay !== "--:--:--") return `Last run duration ${card.runDisplay}`;
+  return "No run duration";
 }
 
 function renderInspector() {
@@ -1373,12 +1388,15 @@ const SUBMITTING_RUN_GRACE_MS = 15000;
 const WAITING_LIFE_TICK_MS = 75;
 const WAITING_LIFE_MAX_CATCHUP_STEPS = 2;
 const WAITING_LIFE_SIZE_CHECK_MS = 500;
-const WAITING_LIFE_SQUARE_SCALE = 0.29;
-const WAITING_LIFE_LED_BLOOM_SCALE = 2.6;
-const WAITING_LIFE_LED_AFTERIMAGE_SCALE = 1.7;
-const WAITING_LIFE_LED_BLOOM_FILL = "rgba(145, 205, 255, 0.08)";
-const WAITING_LIFE_LED_BORN_BLOOM_FILL = "rgba(215, 240, 255, 0.12)";
-const WAITING_LIFE_LED_AFTERIMAGE_FILL = "rgba(80, 155, 230, 0.045)";
+const WAITING_LIFE_SQUARE_SCALE = 0.38;
+const WAITING_LIFE_DEAD_FILL = "rgba(110, 168, 255, 0.16)";
+const WAITING_LIFE_ALIVE_FILL = "rgba(238, 238, 239, 0.72)";
+const WAITING_LIFE_BORN_FILL = "rgba(79, 210, 168, 0.82)";
+const WAITING_LIFE_DEFAULT_FILLS = Object.freeze({
+  dead: WAITING_LIFE_DEAD_FILL,
+  alive: WAITING_LIFE_ALIVE_FILL,
+  born: WAITING_LIFE_BORN_FILL,
+});
 const WAITING_LIFE_MOBILE_QUERY = "(max-width: 1179px)";
 const WAITING_LIFE_PATTERNS = [
   {
@@ -1503,8 +1521,13 @@ function createWaitingLife(canvas, sessionId, seedKey) {
     postLayoutRafId: null,
     sizeDirty: true,
     lastSizeCheck: 0,
+    fills: WAITING_LIFE_DEFAULT_FILLS,
+    fillsDirty: true,
     resizeObserver: null,
+    styleObserver: null,
   };
+
+  refreshWaitingLifeFills(life);
 
   if (typeof ResizeObserver === "function") {
     try {
@@ -1515,12 +1538,28 @@ function createWaitingLife(canvas, sessionId, seedKey) {
     }
   }
 
+  if (typeof MutationObserver === "function") {
+    try {
+      life.styleObserver = new MutationObserver(() => markWaitingLifeFillsDirty(life));
+      life.styleObserver.observe(canvas, { attributes: true, attributeFilter: ["class", "style"] });
+    } catch (_) {
+      life.styleObserver = null;
+    }
+  }
+
   return life;
 }
 
 function markWaitingLifeSizeDirty(life) {
   if (!life || state.waitingLife !== life) return;
   life.sizeDirty = true;
+  life.fillsDirty = true;
+  scheduleWaitingLifePostLayoutDraw(life);
+}
+
+function markWaitingLifeFillsDirty(life) {
+  if (!life || state.waitingLife !== life) return;
+  life.fillsDirty = true;
   scheduleWaitingLifePostLayoutDraw(life);
 }
 
@@ -1529,6 +1568,7 @@ function stopWaitingLife() {
   if (life?.rafId && typeof cancelAnimationFrame === "function") cancelAnimationFrame(life.rafId);
   if (life?.postLayoutRafId && typeof cancelAnimationFrame === "function") cancelAnimationFrame(life.postLayoutRafId);
   if (life?.resizeObserver) life.resizeObserver.disconnect();
+  if (life?.styleObserver) life.styleObserver.disconnect();
   state.waitingLife = null;
 }
 
@@ -1542,7 +1582,7 @@ function scheduleWaitingLifePostLayoutDraw(life) {
       return;
     }
     const resized = ensureWaitingLifeSize(life);
-    if (resized) drawLifeField(life);
+    if (resized || life.fillsDirty) drawLifeField(life);
   });
 }
 
@@ -1581,7 +1621,7 @@ function tickWaitingLife(time) {
   }
   if (life.accumulator >= tickMs) life.accumulator %= tickMs;
 
-  if (stepped || resized) drawLifeField(life);
+  if (stepped || resized || life.fillsDirty) drawLifeField(life);
   life.rafId = requestAnimationFrame(tickWaitingLife);
 }
 
@@ -1616,6 +1656,7 @@ function ensureWaitingLifeSize(life, now = performanceNow()) {
   life.field = createLifeField(cols, rows, `${life.seedKey}|${cols}x${rows}`);
   life.accumulator = 0;
   life.sizeDirty = false;
+  life.fillsDirty = true;
   return true;
 }
 
@@ -1766,18 +1807,9 @@ function drawLifeField(life) {
   const cellSize = Math.max(1, Math.max(life.pixelWidth / field.cols, life.pixelHeight / field.rows));
   const squareSize = Math.max(0.5, cellSize * WAITING_LIFE_SQUARE_SCALE);
   const inset = (cellSize - squareSize) / 2;
-  const bloomSquareSize = Math.max(
-    squareSize,
-    Math.min(cellSize, squareSize * WAITING_LIFE_LED_BLOOM_SCALE),
-  );
-  const bloomInset = (cellSize - bloomSquareSize) / 2;
-  const afterimageSquareSize = Math.max(
-    squareSize,
-    Math.min(cellSize, squareSize * WAITING_LIFE_LED_AFTERIMAGE_SCALE),
-  );
-  const afterimageInset = (cellSize - afterimageSquareSize) / 2;
   const offsetX = Math.min(0, (life.pixelWidth - cellSize * field.cols) / 2);
   const offsetY = Math.min(0, (life.pixelHeight - cellSize * field.rows) / 2);
+  const fills = waitingLifeFills(life);
 
   context.save();
   context.clearRect(0, 0, life.pixelWidth, life.pixelHeight);
@@ -1786,17 +1818,39 @@ function drawLifeField(life) {
   context.globalCompositeOperation = "source-over";
   context.imageSmoothingEnabled = false;
 
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, afterimageSquareSize, afterimageInset, "dead", WAITING_LIFE_LED_AFTERIMAGE_FILL);
-  context.globalCompositeOperation = "lighter";
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, bloomSquareSize, bloomInset, "alive", WAITING_LIFE_LED_BLOOM_FILL);
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, bloomSquareSize, bloomInset, "born", WAITING_LIFE_LED_BORN_BLOOM_FILL);
-  context.globalCompositeOperation = "source-over";
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "dead", "rgba(80, 150, 215, 0.055)");
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "alive", "rgba(255, 255, 255, 0.68)");
-  context.globalCompositeOperation = "lighter";
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "born", "rgba(255, 255, 255, 0.34)");
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "dead", fills.dead);
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "alive", fills.alive);
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "born", fills.born);
 
   context.restore();
+}
+
+function waitingLifeFills(life) {
+  if (!life) return WAITING_LIFE_DEFAULT_FILLS;
+  if (!life.fills || life.fillsDirty) refreshWaitingLifeFills(life);
+  return life.fills || WAITING_LIFE_DEFAULT_FILLS;
+}
+
+function refreshWaitingLifeFills(life) {
+  if (!life) return;
+  life.fills = life.canvas ? waitingLifeCanvasFills(life.canvas) : WAITING_LIFE_DEFAULT_FILLS;
+  life.fillsDirty = false;
+}
+
+function waitingLifeCanvasFills(canvas) {
+  const styles = typeof getComputedStyle === "function" && canvas
+    ? getComputedStyle(canvas)
+    : null;
+  return {
+    dead: waitingLifeCssValue(styles, "--waiting-life-dead", WAITING_LIFE_DEAD_FILL),
+    alive: waitingLifeCssValue(styles, "--waiting-life-alive", WAITING_LIFE_ALIVE_FILL),
+    born: waitingLifeCssValue(styles, "--waiting-life-born", WAITING_LIFE_BORN_FILL),
+  };
+}
+
+function waitingLifeCssValue(styles, name, fallback) {
+  const value = styles?.getPropertyValue(name).trim();
+  return value || fallback;
 }
 
 function drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, mode, fillStyle) {
@@ -2597,7 +2651,7 @@ function ensurePromptLifeElement() {
     promptLife.setAttribute("aria-atomic", promptLife.getAttribute("aria-atomic") || "true");
   }
 
-  promptLife.style.background = "transparent";
+  promptLife.style.removeProperty("background");
 
   let canvas = promptLife.querySelector(".prompt-life-canvas");
   if (!canvas) {
@@ -2609,7 +2663,7 @@ function ensurePromptLifeElement() {
     canvas.classList.add("prompt-life-canvas", "life-waiting-canvas");
     canvas.setAttribute("aria-hidden", "true");
   }
-  canvas.style.background = "transparent";
+  canvas.style.removeProperty("background");
 
   let label = promptLife.querySelector(".prompt-life-label");
   if (!label) {
@@ -2996,7 +3050,9 @@ function startLiveTimer() {
       if (!sid) return;
       const startedAt = state.runStartedAtBySession.get(sid);
       if (startedAt) {
-        tile.textContent = formatRuntime(now - startedAt);
+        const display = formatRuntime(now - startedAt);
+        tile.textContent = display;
+        tile.setAttribute("aria-label", `Run active, elapsed ${display}`);
       }
     });
   }, 200);

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -39,6 +39,7 @@ const state = {
   transcriptRenderedSignature: "",
   pendingDeleteSessionId: null,
   pinnedSessionIds: new Set(),
+  pendingSessionCardFocusId: null,
 };
 
 const el = {};
@@ -387,7 +388,6 @@ function sessionCardViewModel(entry) {
     active_run: snapshot?.active_run || entry.active_run,
     messages: snapshot?.messages || [],
   };
-  const pendingCount = effectivePendingMessages(sessionId, cardSnapshot).length;
   const promptPreview = latestPendingUserPrompt(sessionId, cardSnapshot)
     || displayPromptFromMessageText(summary.last_user_prompt)
     || "no prompt yet";
@@ -505,7 +505,7 @@ function selectSession(sessionId) {
   state.mobileDetailOpen = true;
   state.scrollChatToBottom = true;
   el.selectedId.textContent = shortId(sessionId);
-  requestRender({ inspector: true });
+  requestRender({ shell: false, sessions: true, inspector: true });
   openEventStream(sessionId);
   loadSnapshot(sessionId, false);
 }
@@ -1118,6 +1118,7 @@ function renderSessions() {
       activateSessionCard(card, event);
     });
   });
+  restorePendingSessionCardFocus();
   state.lastSessionsDigest = sessionCardListRenderDigest(cards);
   state.lastSelectedSessionDigest = sessionCardRenderDigest(cards.find((card) => card?.sessionId === state.selectedId));
 }
@@ -1129,12 +1130,24 @@ function sessionCardActivationKey(event) {
 function activateSessionCard(card, event) {
   const sessionId = card?.dataset?.sessionId;
   if (!sessionId) return;
+  if (event?.type === "keydown") {
+    state.pendingSessionCardFocusId = sessionId;
+  }
   if (event?.shiftKey) {
     event.preventDefault();
     toggleSessionPin(sessionId);
     return;
   }
   selectSession(sessionId);
+}
+
+function restorePendingSessionCardFocus() {
+  const sessionId = state.pendingSessionCardFocusId;
+  if (!sessionId) return;
+  state.pendingSessionCardFocusId = null;
+  const card = [...el.sessionGrid.querySelectorAll("[data-session-id]")]
+    .find((candidate) => candidate.dataset.sessionId === sessionId);
+  card?.focus({ preventScroll: true });
 }
 
 function toggleSessionPin(sessionId) {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -382,7 +382,6 @@ function sessionCardViewModel(entry) {
   const snapshot = state.snapshots.get(sessionId);
   const workspaceError = snapshot?.workspace?.error || "";
   const diffStats = workspaceDiffStats(snapshot, entry.workspace_diff);
-  const cardActive = activeRunCountsForSession(sessionId, entry.active_run);
   const cardSnapshot = {
     ...(snapshot || {}),
     active_run: snapshot?.active_run || entry.active_run,
@@ -409,7 +408,8 @@ function sessionCardViewModel(entry) {
     sandboxed: Boolean(summary.sandboxed),
     selected: sessionId === state.selectedId,
     pinned: state.pinnedSessionIds.has(sessionId),
-    tone: cardActive ? "" : summary.sandboxed ? "warn" : "",
+    tone: "",
+    modeClass: summary.sandboxed ? "mode-sandbox" : "",
     errorish: workspaceError && !workspaceError.includes("remote/sandbox-only") ? "errorish" : "",
     statusClass: sessionStatusClass(entry),
     runActive,
@@ -433,6 +433,7 @@ function sessionCardRenderDigest(card) {
     card.selected ? "1" : "0",
     card.pinned ? "1" : "0",
     card.tone,
+    card.modeClass,
     card.errorish,
     card.statusClass,
     card.runActive ? "1" : "0",
@@ -1112,17 +1113,30 @@ function renderSessions() {
   el.sessionGrid.innerHTML = sessionCards;
   el.sessionGrid.querySelector("[data-action='new-session']")?.addEventListener("click", showLaunchOverlay);
   el.sessionGrid.querySelectorAll("[data-session-id]").forEach((card) => {
-    card.addEventListener("click", (event) => {
-      if (event.shiftKey) {
-        event.preventDefault();
-        toggleSessionPin(card.dataset.sessionId);
-        return;
-      }
-      selectSession(card.dataset.sessionId);
+    card.addEventListener("click", (event) => activateSessionCard(card, event));
+    card.addEventListener("keydown", (event) => {
+      if (!sessionCardActivationKey(event)) return;
+      event.preventDefault();
+      activateSessionCard(card, event);
     });
   });
   state.lastSessionsDigest = sessionCardListRenderDigest(cards);
   state.lastSelectedSessionDigest = sessionCardRenderDigest(cards.find((card) => card?.sessionId === state.selectedId));
+}
+
+function sessionCardActivationKey(event) {
+  return event.key === "Enter" || event.key === " " || event.key === "Spacebar";
+}
+
+function activateSessionCard(card, event) {
+  const sessionId = card?.dataset?.sessionId;
+  if (!sessionId) return;
+  if (event?.shiftKey) {
+    event.preventDefault();
+    toggleSessionPin(sessionId);
+    return;
+  }
+  selectSession(sessionId);
 }
 
 function toggleSessionPin(sessionId) {
@@ -1159,7 +1173,7 @@ function renderNewSessionCard() {
 function renderSessionCard(card) {
   if (!card) return "";
   return `
-    <article class="session-card ${card.tone} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" aria-label="${escapeAttr(sessionCardAriaLabel(card))}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
+    <article class="session-card ${card.tone} ${card.modeClass} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" role="button" tabindex="0" aria-current="${card.selected ? "true" : "false"}" aria-label="${escapeAttr(sessionCardAriaLabel(card))}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
       <div class="session-card-head">
         <div>
           <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}${card.sshHost ? ` <svg class="icon ssh-icon" viewBox="0 0 24 24" aria-hidden="true" title="ssh: ${escapeAttr(card.sshHost)}"><rect x="4" y="5" width="16" height="14" rx="2"></rect><path d="M7 10l3 2-3 2"></path><path d="M13 14h4"></path></svg>` : ""}</h2>
@@ -1181,6 +1195,9 @@ function sessionCardAriaLabel(card) {
   if (card?.pinned) states.push("pinned");
   if (card?.selected) states.push("selected");
   if (card?.runActive) states.push("run active");
+  if (card?.statusClass === "attention") states.push("needs attention");
+  if (card?.errorish) states.push("workspace error");
+  if (card?.sandboxed) states.push("sandboxed");
   const stateText = states.length ? `, ${states.join(", ")}` : "";
   return `Session ${card?.shortId || shortId(card?.sessionId) || "unknown"}${stateText}`;
 }
@@ -1392,11 +1409,6 @@ const WAITING_LIFE_SQUARE_SCALE = 0.38;
 const WAITING_LIFE_DEAD_FILL = "rgba(110, 168, 255, 0.16)";
 const WAITING_LIFE_ALIVE_FILL = "rgba(238, 238, 239, 0.72)";
 const WAITING_LIFE_BORN_FILL = "rgba(79, 210, 168, 0.82)";
-const WAITING_LIFE_DEFAULT_FILLS = Object.freeze({
-  dead: WAITING_LIFE_DEAD_FILL,
-  alive: WAITING_LIFE_ALIVE_FILL,
-  born: WAITING_LIFE_BORN_FILL,
-});
 const WAITING_LIFE_MOBILE_QUERY = "(max-width: 1179px)";
 const WAITING_LIFE_PATTERNS = [
   {
@@ -1521,13 +1533,8 @@ function createWaitingLife(canvas, sessionId, seedKey) {
     postLayoutRafId: null,
     sizeDirty: true,
     lastSizeCheck: 0,
-    fills: WAITING_LIFE_DEFAULT_FILLS,
-    fillsDirty: true,
     resizeObserver: null,
-    styleObserver: null,
   };
-
-  refreshWaitingLifeFills(life);
 
   if (typeof ResizeObserver === "function") {
     try {
@@ -1538,28 +1545,12 @@ function createWaitingLife(canvas, sessionId, seedKey) {
     }
   }
 
-  if (typeof MutationObserver === "function") {
-    try {
-      life.styleObserver = new MutationObserver(() => markWaitingLifeFillsDirty(life));
-      life.styleObserver.observe(canvas, { attributes: true, attributeFilter: ["class", "style"] });
-    } catch (_) {
-      life.styleObserver = null;
-    }
-  }
-
   return life;
 }
 
 function markWaitingLifeSizeDirty(life) {
   if (!life || state.waitingLife !== life) return;
   life.sizeDirty = true;
-  life.fillsDirty = true;
-  scheduleWaitingLifePostLayoutDraw(life);
-}
-
-function markWaitingLifeFillsDirty(life) {
-  if (!life || state.waitingLife !== life) return;
-  life.fillsDirty = true;
   scheduleWaitingLifePostLayoutDraw(life);
 }
 
@@ -1568,7 +1559,6 @@ function stopWaitingLife() {
   if (life?.rafId && typeof cancelAnimationFrame === "function") cancelAnimationFrame(life.rafId);
   if (life?.postLayoutRafId && typeof cancelAnimationFrame === "function") cancelAnimationFrame(life.postLayoutRafId);
   if (life?.resizeObserver) life.resizeObserver.disconnect();
-  if (life?.styleObserver) life.styleObserver.disconnect();
   state.waitingLife = null;
 }
 
@@ -1582,7 +1572,7 @@ function scheduleWaitingLifePostLayoutDraw(life) {
       return;
     }
     const resized = ensureWaitingLifeSize(life);
-    if (resized || life.fillsDirty) drawLifeField(life);
+    if (resized) drawLifeField(life);
   });
 }
 
@@ -1621,7 +1611,7 @@ function tickWaitingLife(time) {
   }
   if (life.accumulator >= tickMs) life.accumulator %= tickMs;
 
-  if (stepped || resized || life.fillsDirty) drawLifeField(life);
+  if (stepped || resized) drawLifeField(life);
   life.rafId = requestAnimationFrame(tickWaitingLife);
 }
 
@@ -1656,7 +1646,6 @@ function ensureWaitingLifeSize(life, now = performanceNow()) {
   life.field = createLifeField(cols, rows, `${life.seedKey}|${cols}x${rows}`);
   life.accumulator = 0;
   life.sizeDirty = false;
-  life.fillsDirty = true;
   return true;
 }
 
@@ -1809,7 +1798,6 @@ function drawLifeField(life) {
   const inset = (cellSize - squareSize) / 2;
   const offsetX = Math.min(0, (life.pixelWidth - cellSize * field.cols) / 2);
   const offsetY = Math.min(0, (life.pixelHeight - cellSize * field.rows) / 2);
-  const fills = waitingLifeFills(life);
 
   context.save();
   context.clearRect(0, 0, life.pixelWidth, life.pixelHeight);
@@ -1818,39 +1806,11 @@ function drawLifeField(life) {
   context.globalCompositeOperation = "source-over";
   context.imageSmoothingEnabled = false;
 
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "dead", fills.dead);
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "alive", fills.alive);
-  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "born", fills.born);
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "dead", WAITING_LIFE_DEAD_FILL);
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "alive", WAITING_LIFE_ALIVE_FILL);
+  drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, "born", WAITING_LIFE_BORN_FILL);
 
   context.restore();
-}
-
-function waitingLifeFills(life) {
-  if (!life) return WAITING_LIFE_DEFAULT_FILLS;
-  if (!life.fills || life.fillsDirty) refreshWaitingLifeFills(life);
-  return life.fills || WAITING_LIFE_DEFAULT_FILLS;
-}
-
-function refreshWaitingLifeFills(life) {
-  if (!life) return;
-  life.fills = life.canvas ? waitingLifeCanvasFills(life.canvas) : WAITING_LIFE_DEFAULT_FILLS;
-  life.fillsDirty = false;
-}
-
-function waitingLifeCanvasFills(canvas) {
-  const styles = typeof getComputedStyle === "function" && canvas
-    ? getComputedStyle(canvas)
-    : null;
-  return {
-    dead: waitingLifeCssValue(styles, "--waiting-life-dead", WAITING_LIFE_DEAD_FILL),
-    alive: waitingLifeCssValue(styles, "--waiting-life-alive", WAITING_LIFE_ALIVE_FILL),
-    born: waitingLifeCssValue(styles, "--waiting-life-born", WAITING_LIFE_BORN_FILL),
-  };
-}
-
-function waitingLifeCssValue(styles, name, fallback) {
-  const value = styles?.getPropertyValue(name).trim();
-  return value || fallback;
 }
 
 function drawLifeSquares(context, field, offsetX, offsetY, cellSize, squareSize, inset, mode, fillStyle) {

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -408,7 +408,6 @@ function sessionCardViewModel(entry) {
     sandboxed: Boolean(summary.sandboxed),
     selected: sessionId === state.selectedId,
     pinned: state.pinnedSessionIds.has(sessionId),
-    tone: "",
     modeClass: summary.sandboxed ? "mode-sandbox" : "",
     errorish: workspaceError && !workspaceError.includes("remote/sandbox-only") ? "errorish" : "",
     statusClass: sessionStatusClass(entry),
@@ -432,7 +431,6 @@ function sessionCardRenderDigest(card) {
     card.sandboxed ? "1" : "0",
     card.selected ? "1" : "0",
     card.pinned ? "1" : "0",
-    card.tone,
     card.modeClass,
     card.errorish,
     card.statusClass,
@@ -1172,8 +1170,15 @@ function renderNewSessionCard() {
 
 function renderSessionCard(card) {
   if (!card) return "";
+  const className = [
+    "session-card",
+    card.modeClass,
+    card.errorish,
+    card.selected ? "selected" : "",
+    card.pinned ? "pinned" : "",
+  ].filter(Boolean).join(" ");
   return `
-    <article class="session-card ${card.tone} ${card.modeClass} ${card.errorish} ${card.selected ? "selected" : ""} ${card.pinned ? "pinned" : ""}" data-session-id="${escapeAttr(card.sessionId)}" role="button" tabindex="0" aria-current="${card.selected ? "true" : "false"}" aria-label="${escapeAttr(sessionCardAriaLabel(card))}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
+    <article class="${className}" data-session-id="${escapeAttr(card.sessionId)}" role="button" tabindex="0" aria-current="${card.selected ? "true" : "false"}" aria-label="${escapeAttr(sessionCardAriaLabel(card))}" title="${card.pinned ? "Shift-click to unpin" : "Shift-click to pin"}">
       <div class="session-card-head">
         <div>
           <h2>${escapeHtml(card.shortId)}${card.sandboxed ? ` <svg class="icon sandbox-icon" viewBox="0 0 24 24" aria-hidden="true" title="sandbox active"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M8 8h8"></path></svg>` : ""}${card.sshHost ? ` <svg class="icon ssh-icon" viewBox="0 0 24 24" aria-hidden="true" title="ssh: ${escapeAttr(card.sshHost)}"><rect x="4" y="5" width="16" height="14" rx="2"></rect><path d="M7 10l3 2-3 2"></path><path d="M13 14h4"></path></svg>` : ""}</h2>
@@ -1191,15 +1196,35 @@ function renderSessionCard(card) {
 }
 
 function sessionCardAriaLabel(card) {
-  const states = [];
-  if (card?.pinned) states.push("pinned");
-  if (card?.selected) states.push("selected");
-  if (card?.runActive) states.push("run active");
-  if (card?.statusClass === "attention") states.push("needs attention");
-  if (card?.errorish) states.push("workspace error");
-  if (card?.sandboxed) states.push("sandboxed");
-  const stateText = states.length ? `, ${states.join(", ")}` : "";
-  return `Session ${card?.shortId || shortId(card?.sessionId) || "unknown"}${stateText}`;
+  const details = [`Session ${card?.shortId || shortId(card?.sessionId) || "unknown"}`];
+  const status = sessionCardStatusLabel(card);
+  const cwd = compactAriaText(card?.cwd);
+  const prompt = compactAriaText(card?.promptPreview);
+  if (status) details.push(`status ${status}`);
+  if (cwd) details.push(`cwd ${cwd}`);
+  if (card?.sshHost) details.push(`ssh ${compactAriaText(card.sshHost)}`);
+  if (card?.sandboxed && status !== "sandboxed") details.push("sandboxed");
+  if (prompt && prompt !== "no prompt yet") details.push(`prompt ${prompt}`);
+  if (card?.additions && card.additions !== "--") details.push(`additions ${card.additions}`);
+  if (card?.deletions && card.deletions !== "--") details.push(`deletions ${card.deletions}`);
+  if (card?.pinned) details.push("pinned");
+  if (card?.selected) details.push("selected");
+  return details.join(", ");
+}
+
+function sessionCardStatusLabel(card) {
+  if (card?.errorish) return "workspace error";
+  if (card?.runActive || card?.statusClass === "active") return "active";
+  if (card?.statusClass === "attention") return "needs attention";
+  if (card?.statusClass === "sandbox") return "sandboxed";
+  if (card?.statusClass === "idle") return "idle";
+  return "";
+}
+
+function compactAriaText(value, limit = 120) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (!text || text.length <= limit) return text;
+  return `${text.slice(0, limit - 3)}...`;
 }
 
 function runTileAriaLabel(card) {


### PR DESCRIPTION
updates the nac-web dashboard to use a flatter visual design.

new vs main:
- removes the raised/neumorphic card and button styling
- uses flatter surfaces, borders, and tighter radii
- adds clearer hover, active, selected, and focus states
- keeps selected session cards visually stable
- makes session cards keyboard activatable
- simplifies the waiting canvas styling to match the flat UI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and client-side interaction only in static assets; no server APIs, auth, or data handling changes.
> 
> **Overview**
> **Flat visual system** for the nac-server web dashboard (`app.css`): neumorphic shadows and raised surfaces are removed in favor of borders, tighter radii, and shared tokens for controls, focus rings, hover/selected states, and status/sandbox/danger colors. Session cards, inspector panels, transcripts, diffs, and overlays are updated to match, including left-accent bars for sandbox/error/selection and clearer tool-event styling in the event log.
> 
> **Session grid behavior** (`app.js`): cards use `mode-sandbox` instead of a generic warn tone, expose `role="button"` with Enter/Space activation, richer `aria-label`s, and focus restoration after keyboard pin/select so re-renders do not drop focus. Selecting a session now triggers a session-grid re-render so selection styling stays in sync.
> 
> The **Conway “waiting” canvas** drops glow/bloom layers for simple flat cell colors and relies on CSS for backgrounds instead of inline transparent overrides. Live run timers refresh `aria-label` text as elapsed time updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe27cd8f1dd32726fe38de8cdc4d4ba3384459e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->