### PR TITLE
Background exec sessions: background exec_command, write_stdin polling, kill_shell

### DIFF
--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -755,79 +755,7 @@ mod tests {
         client
     }
 
-    /// Minimal fake chat-completions server: serves the given JSON bodies to
-    /// sequential requests. Before serving the last response it optionally
-    /// waits for `wait_file_before_last` to exist, so a background command
-    /// started by a tool call is guaranteed to be running when the turn ends.
-    fn spawn_fake_model_server(
-        responses: Vec<String>,
-        wait_file_before_last: Option<PathBuf>,
-    ) -> (String, std::thread::JoinHandle<()>) {
-        use std::io::{Read, Write};
-
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind fake model server");
-        let url = format!("http://{}", listener.local_addr().unwrap());
-        let handle = std::thread::spawn(move || {
-            let total = responses.len();
-            for (index, body) in responses.into_iter().enumerate() {
-                let Ok((mut stream, _)) = listener.accept() else {
-                    return;
-                };
-                let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(10)));
-
-                // Read the full request (headers + Content-Length body).
-                let mut buf = Vec::new();
-                let mut chunk = [0u8; 4096];
-                let mut header_end = None;
-                let mut content_length = 0usize;
-                loop {
-                    match stream.read(&mut chunk) {
-                        Ok(0) | Err(_) => break,
-                        Ok(read) => buf.extend_from_slice(&chunk[..read]),
-                    }
-                    if header_end.is_none() {
-                        if let Some(pos) = buf.windows(4).position(|window| window == b"\r\n\r\n")
-                        {
-                            header_end = Some(pos + 4);
-                            let headers = String::from_utf8_lossy(&buf[..pos]);
-                            content_length = headers
-                                .lines()
-                                .find_map(|line| {
-                                    let (name, value) = line.split_once(':')?;
-                                    name.eq_ignore_ascii_case("content-length")
-                                        .then(|| value.trim().parse::<usize>().ok())
-                                        .flatten()
-                                })
-                                .unwrap_or(0);
-                        }
-                    }
-                    if let Some(end) = header_end {
-                        if buf.len() >= end + content_length {
-                            break;
-                        }
-                    }
-                }
-
-                if index + 1 == total {
-                    if let Some(path) = &wait_file_before_last {
-                        let deadline =
-                            std::time::Instant::now() + std::time::Duration::from_secs(10);
-                        while !path.exists() && std::time::Instant::now() < deadline {
-                            std::thread::sleep(std::time::Duration::from_millis(50));
-                        }
-                    }
-                }
-
-                let response = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                    body.len(),
-                    body
-                );
-                let _ = stream.write_all(response.as_bytes());
-            }
-        });
-        (url, handle)
-    }
+    use crate::test_http::spawn_fake_model_server;
 
     /// Success path: a tool call starts a background session mid-turn; when
     /// the final assistant message ends the turn, the dispatch-end
@@ -925,7 +853,7 @@ mod tests {
             .terminal_manager
             .spawn_background(
                 "bg-error-path".to_string(),
-                Some(&cmd),
+                &cmd,
                 None,
                 120,
                 40,

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -119,7 +119,11 @@ impl Agent {
                      - yield_time_ms on exec_command and write_stdin can be up to 3600000 ms (1 hour). Prefer short polls (write_stdin with empty chars) for interactive flows; use a single long wait for known-long commands like builds and test suites, and keep waits well under your remaining task budget.\n\
                      - Persistent shells keep state (cwd, env vars, venvs, etc.) across calls. Use them for multi-step workflows.\n\
                      - Always prefer write_stdin with empty chars to poll for output from a running command before sending new input.\n\
-                     - Close sessions by sending exit<RET> or <C-d>. Sessions auto-cleanup when the worker finishes.",
+                     - Use exec_command with background=true to start long-running processes like dev servers or watchers: it returns immediately with a session_name while the command keeps running.\n\
+                     - Run-server-then-test flow: start the server with background=true, poll it with empty-chars write_stdin until it reports ready, run normal one-shot exec_command calls (curl, tests) against it, then kill_shell(session_id) to stop it.\n\
+                     - kill_shell is idempotent: it reports was_running plus a final output tail. If a background process dies on its own, the next empty-chars poll returns its exit_code.\n\
+                     - Kill background sessions with kill_shell as soon as you are done with them; live background sessions are never evicted automatically.\n\
+                     - Close sessions by sending exit<RET> or <C-d>. All sessions, including background ones, are cleaned up when the worker finishes — background servers do not survive past the end of this dispatch.",
                     cwd
                 ),
                 tools::worker_tool_definitions(),
@@ -681,6 +685,273 @@ mod tests {
     fn preview_truncates_on_utf8_boundary() {
         assert_eq!(preview("a┌b", 2), "a...");
         assert_eq!(preview("a┌b", 4), "a┌...");
+    }
+
+    #[cfg(unix)]
+    fn process_alive(pid: i32) -> bool {
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    fn unique_pidfile(label: &str) -> PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        std::env::temp_dir().join(format!("nac_agent_bg_{label}_{unique}.pid"))
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_pidfile(path: &PathBuf) -> i32 {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if let Ok(contents) = std::fs::read_to_string(path) {
+                if let Ok(pid) = contents.trim().parse::<i32>() {
+                    return pid;
+                }
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "background command never wrote pidfile {}",
+                path.display()
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    #[cfg(unix)]
+    async fn assert_process_dies(pid: i32) {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while process_alive(pid) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "background process {} still alive after Agent::send returned",
+                pid
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Build a model client pointed at `base_url` without touching real
+    /// provider credentials. Holds TEST_ENV_LOCK only for the duration of
+    /// client construction (no awaits while locked).
+    fn test_client_with_base_url(base_url: String) -> ModelClient {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("OPENAI_API_KEY");
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "test-dummy-key");
+        }
+        let client = ModelClient::from_env_with_overrides(crate::model::ClientOverrides {
+            base_url: Some(base_url),
+            model: Some("test-model".to_string()),
+            backend: Some(crate::model::BackendKind::DeepSeekChat),
+            ..Default::default()
+        })
+        .expect("test client must build");
+        match original {
+            Some(value) => unsafe { std::env::set_var("OPENAI_API_KEY", value) },
+            None => unsafe { std::env::remove_var("OPENAI_API_KEY") },
+        }
+        client
+    }
+
+    /// Minimal fake chat-completions server: serves the given JSON bodies to
+    /// sequential requests. Before serving the last response it optionally
+    /// waits for `wait_file_before_last` to exist, so a background command
+    /// started by a tool call is guaranteed to be running when the turn ends.
+    fn spawn_fake_model_server(
+        responses: Vec<String>,
+        wait_file_before_last: Option<PathBuf>,
+    ) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind fake model server");
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let handle = std::thread::spawn(move || {
+            let total = responses.len();
+            for (index, body) in responses.into_iter().enumerate() {
+                let Ok((mut stream, _)) = listener.accept() else {
+                    return;
+                };
+                let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(10)));
+
+                // Read the full request (headers + Content-Length body).
+                let mut buf = Vec::new();
+                let mut chunk = [0u8; 4096];
+                let mut header_end = None;
+                let mut content_length = 0usize;
+                loop {
+                    match stream.read(&mut chunk) {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => buf.extend_from_slice(&chunk[..read]),
+                    }
+                    if header_end.is_none() {
+                        if let Some(pos) = buf.windows(4).position(|window| window == b"\r\n\r\n")
+                        {
+                            header_end = Some(pos + 4);
+                            let headers = String::from_utf8_lossy(&buf[..pos]);
+                            content_length = headers
+                                .lines()
+                                .find_map(|line| {
+                                    let (name, value) = line.split_once(':')?;
+                                    name.eq_ignore_ascii_case("content-length")
+                                        .then(|| value.trim().parse::<usize>().ok())
+                                        .flatten()
+                                })
+                                .unwrap_or(0);
+                        }
+                    }
+                    if let Some(end) = header_end {
+                        if buf.len() >= end + content_length {
+                            break;
+                        }
+                    }
+                }
+
+                if index + 1 == total {
+                    if let Some(path) = &wait_file_before_last {
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_secs(10);
+                        while !path.exists() && std::time::Instant::now() < deadline {
+                            std::thread::sleep(std::time::Duration::from_millis(50));
+                        }
+                    }
+                }
+
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+        (url, handle)
+    }
+
+    /// Success path: a tool call starts a background session mid-turn; when
+    /// the final assistant message ends the turn, the dispatch-end
+    /// remove_all() must have killed and reaped the background process.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn background_session_started_during_turn_is_reaped_after_send_success() {
+        let pidfile = unique_pidfile("success");
+        let _ = std::fs::remove_file(&pidfile);
+
+        let args = serde_json::json!({
+            "cmd": format!("echo $$ > {}; exec sleep 300", pidfile.display()),
+            "background": true
+        })
+        .to_string();
+        let first = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "tool_calls": [{
+                        "id": "call_bg_1",
+                        "type": "function",
+                        "function": { "name": "exec_command", "arguments": args }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })
+        .to_string();
+        let second = serde_json::json!({
+            "choices": [{
+                "message": { "content": "done" },
+                "finish_reason": "stop"
+            }]
+        })
+        .to_string();
+
+        let (url, handle) = spawn_fake_model_server(vec![first, second], Some(pidfile.clone()));
+        let client = test_client_with_base_url(url);
+        let mut agent = Agent::default(client);
+
+        let result = agent.send("start a background server").await;
+        assert_eq!(result.expect("send should succeed"), "done");
+        handle.join().expect("fake model server thread panicked");
+
+        // The background command really started during the turn...
+        let pid = wait_for_pidfile(&pidfile).await;
+        // ...and its process is dead (killed + reaped) now that send returned.
+        assert_process_dies(pid).await;
+
+        // The session itself is gone from the terminal manager.
+        let session_name = agent
+            .messages
+            .iter()
+            .find_map(|message| match message {
+                Message::Tool { content, .. } => serde_json::from_str::<serde_json::Value>(content)
+                    .ok()?
+                    .get("session_name")?
+                    .as_str()
+                    .map(ToString::to_string),
+                _ => None,
+            })
+            .expect("tool result should include session_name");
+        assert!(
+            agent
+                .tool_runtime
+                .terminal_manager
+                .get(&session_name)
+                .await
+                .is_none(),
+            "background session should be removed after send returns"
+        );
+
+        let _ = std::fs::remove_file(&pidfile);
+    }
+
+    /// Error path: a live background session must also be killed and reaped
+    /// by the remove_all() on the model-error exit from Agent::send.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn background_session_is_reaped_after_send_model_error() {
+        // A connect-refused base URL makes send_turn fail immediately.
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let client = test_client_with_base_url(format!("http://127.0.0.1:{}", port));
+        let mut agent = Agent::default(client);
+
+        let pidfile = unique_pidfile("error");
+        let _ = std::fs::remove_file(&pidfile);
+        let cmd = format!("echo $$ > {}; exec sleep 300", pidfile.display());
+        agent
+            .tool_runtime
+            .terminal_manager
+            .spawn_background(
+                "bg-error-path".to_string(),
+                Some(&cmd),
+                None,
+                120,
+                40,
+                &agent.tool_runtime.backend,
+            )
+            .await
+            .expect("background session should spawn");
+
+        let pid = wait_for_pidfile(&pidfile).await;
+        assert!(process_alive(pid), "background process should be running");
+
+        let result = agent.send("hello").await;
+        assert!(result.is_err(), "send should fail with connect error");
+
+        assert!(
+            agent
+                .tool_runtime
+                .terminal_manager
+                .get("bg-error-path")
+                .await
+                .is_none(),
+            "background session should be removed on the error path"
+        );
+        assert_process_dies(pid).await;
+
+        let _ = std::fs::remove_file(&pidfile);
     }
 
     #[test]

--- a/crates/nac-core/src/lib.rs
+++ b/crates/nac-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod sessions;
 mod skills;
 mod store;
 mod terminal;
+#[cfg(test)]
+mod test_http;
 mod tools;
 pub mod types;
 pub mod upgrade;

--- a/crates/nac-core/src/mcp/mod.rs
+++ b/crates/nac-core/src/mcp/mod.rs
@@ -46,10 +46,10 @@ const MCP_TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
 #[cfg(test)]
 pub(crate) mod test_support {
+    use crate::test_http::{read_http_request, write_http_response};
     use serde_json::{json, Value};
     use std::env;
     use std::ffi::OsString;
-    use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::path::{Path, PathBuf};
     use std::thread;
@@ -103,67 +103,16 @@ pub(crate) mod test_support {
         (url, handle)
     }
 
-    struct FakeHttpRequest {
-        method: String,
-        body: Option<Value>,
-    }
-
-    fn read_fake_http_request(stream: &mut TcpStream) -> Option<FakeHttpRequest> {
-        stream.set_read_timeout(Some(Duration::from_secs(5))).ok()?;
-        let mut buf = Vec::new();
-        let mut chunk = [0u8; 1024];
-        loop {
-            let read = stream.read(&mut chunk).ok()?;
-            if read == 0 {
-                return None;
-            }
-            buf.extend_from_slice(&chunk[..read]);
-            let Some(header_end) = buf.windows(4).position(|window| window == b"\r\n\r\n") else {
-                continue;
-            };
-            let header_text = String::from_utf8_lossy(&buf[..header_end]);
-            let method = header_text
-                .lines()
-                .next()
-                .and_then(|line| line.split_whitespace().next())
-                .unwrap_or("")
-                .to_string();
-            let content_length = header_text
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse::<usize>().ok())
-                        .flatten()
-                })
-                .unwrap_or(0);
-            let body_start = header_end + 4;
-            while buf.len() < body_start + content_length {
-                let read = stream.read(&mut chunk).ok()?;
-                if read == 0 {
-                    return None;
-                }
-                buf.extend_from_slice(&chunk[..read]);
-            }
-            let body = if content_length == 0 {
-                None
-            } else {
-                serde_json::from_slice(&buf[body_start..body_start + content_length]).ok()
-            };
-            return Some(FakeHttpRequest { method, body });
-        }
-    }
-
     fn handle_fake_http_mcp_request(stream: &mut TcpStream) -> bool {
-        let Some(request) = read_fake_http_request(stream) else {
+        let Some(request) = read_http_request(stream) else {
             return false;
         };
         if request.method != "POST" {
-            write_fake_http_response(stream, "405 Method Not Allowed", None, "");
+            write_http_response(stream, "405 Method Not Allowed", None, "");
             return false;
         }
         let Some(body) = request.body else {
-            write_fake_http_response(stream, "400 Bad Request", None, "");
+            write_http_response(stream, "400 Bad Request", None, "");
             return false;
         };
         let method = body.get("method").and_then(Value::as_str).unwrap_or("");
@@ -179,7 +128,7 @@ pub(crate) mod test_support {
                         "serverInfo": { "name": "fake-http-mcp", "version": "0.1.0" }
                     }
                 });
-                write_fake_http_response(
+                write_http_response(
                     stream,
                     "200 OK",
                     Some("application/json"),
@@ -188,7 +137,7 @@ pub(crate) mod test_support {
                 false
             }
             "notifications/initialized" => {
-                write_fake_http_response(stream, "202 Accepted", None, "");
+                write_http_response(stream, "202 Accepted", None, "");
                 false
             }
             "tools/list" => {
@@ -203,7 +152,7 @@ pub(crate) mod test_support {
                         }]
                     }
                 });
-                write_fake_http_response(
+                write_http_response(
                     stream,
                     "200 OK",
                     Some("application/json"),
@@ -217,7 +166,7 @@ pub(crate) mod test_support {
                     "id": id,
                     "error": { "code": -32601, "message": "method not found" }
                 });
-                write_fake_http_response(
+                write_http_response(
                     stream,
                     "200 OK",
                     Some("application/json"),
@@ -226,23 +175,6 @@ pub(crate) mod test_support {
                 false
             }
         }
-    }
-
-    fn write_fake_http_response(
-        stream: &mut TcpStream,
-        status: &str,
-        content_type: Option<&str>,
-        body: &str,
-    ) {
-        let content_type = content_type
-            .map(|value| format!("Content-Type: {value}\r\n"))
-            .unwrap_or_default();
-        let response = format!(
-            "HTTP/1.1 {status}\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
-            body.len()
-        );
-        let _ = stream.write_all(response.as_bytes());
-        let _ = stream.flush();
     }
 }
 

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -68,9 +68,6 @@ impl TerminalManager {
     /// alive. The PTY child runs in its own session/process group (portable_pty
     /// calls setsid on spawn) and the command is built via the sandbox
     /// backend's `terminal_pty_command`, so podman/smolvm/ssh keep working.
-    // TODO(background-exec tool layer): remove this allow once the tool wires
-    // in background spawning.
-    #[allow(dead_code)]
     pub async fn spawn_background(
         &self,
         name: String,

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -167,9 +167,6 @@ impl TerminalManager {
     /// SIGTERM descendants + process group → 500ms grace → SIGKILL → reap).
     /// Returns `Ok(true)` if the process was still alive when the kill was
     /// issued, `Ok(false)` if it had already exited.
-    // TODO(background-exec tool layer): remove this allow once the tool wires
-    // in session killing.
-    #[allow(dead_code)]
     pub async fn kill_session(&self, name: &str) -> Result<bool> {
         let session = {
             let mut sessions = self.sessions.lock().await;

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -16,6 +16,11 @@ use super::keyparse::parse_keys;
 use super::session::{terminal_env_owned, TerminalSession};
 use super::{TerminalInfo, TerminalOutput};
 
+struct SpawnOpts<'a> {
+    background: bool,
+    command: Option<&'a str>,
+}
+
 #[derive(Clone)]
 pub struct TerminalManager {
     sessions: Arc<Mutex<HashMap<String, TerminalSession>>>,
@@ -24,9 +29,13 @@ pub struct TerminalManager {
 
 impl TerminalManager {
     pub fn new() -> Self {
+        Self::with_max_sessions(16)
+    }
+
+    pub fn with_max_sessions(max_sessions: usize) -> Self {
         TerminalManager {
             sessions: Arc::new(Mutex::new(HashMap::new())),
-            max_sessions: 16,
+            max_sessions,
         }
     }
 
@@ -38,6 +47,62 @@ impl TerminalManager {
         rows: u16,
         backend: &Arc<ExecutionBackend>,
     ) -> Result<TerminalInfo> {
+        self.create_inner(
+            name,
+            cwd,
+            cols,
+            rows,
+            backend,
+            SpawnOpts {
+                background: false,
+                command: None,
+            },
+        )
+        .await
+    }
+
+    /// Spawn a PTY session for a long-running background command and return
+    /// immediately — no initial output wait. The command (if any) is written
+    /// to the shell followed by a carriage return. The session is flagged as
+    /// background, which exempts it from LRU eviction while its process is
+    /// alive. The PTY child runs in its own session/process group (portable_pty
+    /// calls setsid on spawn) and the command is built via the sandbox
+    /// backend's `terminal_pty_command`, so podman/smolvm/ssh keep working.
+    // TODO(background-exec tool layer): remove this allow once the tool wires
+    // in background spawning.
+    #[allow(dead_code)]
+    pub async fn spawn_background(
+        &self,
+        name: String,
+        command: Option<&str>,
+        cwd: Option<PathBuf>,
+        cols: u16,
+        rows: u16,
+        backend: &Arc<ExecutionBackend>,
+    ) -> Result<TerminalInfo> {
+        self.create_inner(
+            name,
+            cwd,
+            cols,
+            rows,
+            backend,
+            SpawnOpts {
+                background: true,
+                command,
+            },
+        )
+        .await
+    }
+
+    async fn create_inner(
+        &self,
+        name: String,
+        cwd: Option<PathBuf>,
+        cols: u16,
+        rows: u16,
+        backend: &Arc<ExecutionBackend>,
+        opts: SpawnOpts<'_>,
+    ) -> Result<TerminalInfo> {
         let old = {
             let mut sessions = self.sessions.lock().await;
             sessions.remove(&name)
@@ -46,32 +111,76 @@ impl TerminalManager {
             let _ = old.kill().await;
         }
 
-        let evicted: Vec<TerminalSession> = {
-            let mut sessions = self.sessions.lock().await;
-            let mut evicted = Vec::new();
-            while sessions.len() >= self.max_sessions {
-                let oldest_key = sessions
-                    .iter()
-                    .min_by_key(|(_, s)| s.created_at)
-                    .map(|(k, _)| k.clone());
-                if let Some(key) = oldest_key {
-                    if let Some(s) = sessions.remove(&key) {
-                        evicted.push(s);
-                    }
-                } else {
-                    break;
-                }
-            }
-            evicted
-        };
+        let evicted = self.evict_for_capacity().await;
         for mut s in evicted {
             let _ = s.kill().await;
         }
 
-        let session = TerminalSession::spawn(name.clone(), cwd, cols, rows, backend)?;
+        let mut session = TerminalSession::spawn(name.clone(), cwd, cols, rows, backend)?;
+        session.background = opts.background;
+        if let Some(command) = opts.command {
+            if !command.trim().is_empty() {
+                session.write(format!("{}\r", command).as_bytes())?;
+            }
+        }
         let info = self.session_info(&name, &session);
         self.sessions.lock().await.insert(name, session);
         Ok(info)
+    }
+
+    /// Eviction policy when at capacity: exited sessions go first (oldest
+    /// created first), then the oldest-idle live non-background session.
+    /// Live background sessions are never evicted — if only those remain,
+    /// the cap is exceeded rather than killing a background server.
+    async fn evict_for_capacity(&self) -> Vec<TerminalSession> {
+        let mut sessions = self.sessions.lock().await;
+        let mut evicted = Vec::new();
+        while sessions.len() >= self.max_sessions {
+            for session in sessions.values_mut() {
+                session.refresh_status();
+            }
+            let victim = sessions
+                .iter()
+                .filter(|(_, s)| !s.is_alive())
+                .min_by_key(|(_, s)| s.created_at)
+                .map(|(k, _)| k.clone())
+                .or_else(|| {
+                    sessions
+                        .iter()
+                        .filter(|(_, s)| !s.background)
+                        .min_by_key(|(_, s)| s.last_output_at)
+                        .map(|(k, _)| k.clone())
+                });
+            match victim {
+                Some(key) => {
+                    if let Some(s) = sessions.remove(&key) {
+                        evicted.push(s);
+                    }
+                }
+                None => break,
+            }
+        }
+        evicted
+    }
+
+    /// Kill a session and its full process tree (backend pidfile kill →
+    /// SIGTERM descendants + process group → 500ms grace → SIGKILL → reap).
+    /// Returns `Ok(true)` if the process was still alive when the kill was
+    /// issued, `Ok(false)` if it had already exited.
+    // TODO(background-exec tool layer): remove this allow once the tool wires
+    // in session killing.
+    #[allow(dead_code)]
+    pub async fn kill_session(&self, name: &str) -> Result<bool> {
+        let session = {
+            let mut sessions = self.sessions.lock().await;
+            sessions.remove(name)
+        };
+        let mut session =
+            session.with_context(|| format!("terminal session '{}' not found", name))?;
+        session.refresh_status();
+        let was_alive = session.is_alive();
+        session.kill().await?;
+        Ok(was_alive)
     }
 
     pub async fn write_stdin(
@@ -369,6 +478,239 @@ mod tests {
     use crate::sandbox::{
         SandboxSession, SandboxSpec, DEFAULT_SANDBOX_IMAGE, DEFAULT_SANDBOX_WORKDIR,
     };
+
+    fn test_backend() -> Arc<ExecutionBackend> {
+        crate::sandbox::execution_backend_from_sandbox(
+            None,
+            &std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/")),
+        )
+    }
+
+    #[cfg(unix)]
+    fn process_exists(pid: u32) -> bool {
+        unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    }
+
+    #[cfg(unix)]
+    fn parse_child_pid(output: &str) -> Option<u32> {
+        output.lines().find_map(|line| {
+            line.split_once("NAC_CHILD:").and_then(|(_, rest)| {
+                rest.chars()
+                    .take_while(|ch| ch.is_ascii_digit())
+                    .collect::<String>()
+                    .parse()
+                    .ok()
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn spawn_background_returns_while_process_runs() {
+        let manager = TerminalManager::new();
+        let backend = test_backend();
+        let start = Instant::now();
+        let info = manager
+            .spawn_background(
+                "bg-run".to_string(),
+                Some("sleep 30"),
+                None,
+                120,
+                40,
+                &backend,
+            )
+            .await
+            .unwrap();
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "spawn_background blocked waiting for output"
+        );
+        assert!(info.alive);
+        assert!(info.pid.is_some());
+
+        let got = manager.get("bg-run").await.expect("session registered");
+        assert!(got.alive, "background session should still be running");
+
+        let was_alive = manager.kill_session("bg-run").await.unwrap();
+        assert!(was_alive, "session was running when killed");
+        assert!(manager.get("bg-run").await.is_none());
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn kill_session_reaps_full_process_group() {
+        let manager = TerminalManager::new();
+        let backend = test_backend();
+        manager
+            .spawn_background(
+                "bg-kill".to_string(),
+                Some("sleep 30 & echo NAC_CHILD:$!"),
+                None,
+                120,
+                40,
+                &backend,
+            )
+            .await
+            .unwrap();
+
+        let mut collected = String::new();
+        let mut child_pid = None;
+        for _ in 0..40 {
+            let out = manager
+                .write_stdin("bg-kill", "", 100, 100_000)
+                .await
+                .unwrap();
+            collected.push_str(&out.output);
+            child_pid = parse_child_pid(&collected);
+            if child_pid.is_some() {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        let child_pid =
+            child_pid.unwrap_or_else(|| panic!("child pid not found in: {collected:?}"));
+        assert!(process_exists(child_pid), "child exited too early");
+
+        let was_alive = manager.kill_session("bg-kill").await.unwrap();
+        assert!(was_alive);
+        assert!(manager.get("bg-kill").await.is_none());
+
+        let mut orphaned = true;
+        for _ in 0..40 {
+            orphaned = process_exists(child_pid);
+            if !orphaned {
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        if orphaned {
+            unsafe {
+                libc::kill(child_pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+        assert!(!orphaned, "kill_session left an orphaned descendant");
+    }
+
+    #[tokio::test]
+    async fn kill_session_unknown_name_errors() {
+        let manager = TerminalManager::new();
+        let err = manager.kill_session("nope").await.unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn poll_dead_session_reports_exit_code_and_removes_entry() {
+        let manager = TerminalManager::new();
+        let backend = test_backend();
+        manager
+            .spawn_background(
+                "bg-exit".to_string(),
+                Some("exit 7"),
+                None,
+                120,
+                40,
+                &backend,
+            )
+            .await
+            .unwrap();
+
+        let mut observed = None;
+        for _ in 0..40 {
+            match manager.write_stdin("bg-exit", "", 100, 8000).await {
+                Ok(out) if out.session_name.is_none() => {
+                    observed = Some(out);
+                    break;
+                }
+                Ok(_) => sleep(Duration::from_millis(50)).await,
+                Err(_) => break,
+            }
+        }
+        let out = observed.expect("poll never observed session exit");
+        assert_eq!(out.exit_code, Some(7), "exit code must be live-derived");
+        assert!(
+            manager.get("bg-exit").await.is_none(),
+            "dead session entry must be removed after poll"
+        );
+    }
+
+    #[tokio::test]
+    async fn live_background_session_survives_lru_pressure() {
+        let manager = TerminalManager::with_max_sessions(3);
+        let backend = test_backend();
+        manager
+            .spawn_background(
+                "bg-server".to_string(),
+                Some("sleep 60"),
+                None,
+                120,
+                40,
+                &backend,
+            )
+            .await
+            .unwrap();
+
+        for i in 0..5 {
+            manager
+                .create(format!("churn-{i}"), None, 120, 40, &backend)
+                .await
+                .unwrap();
+        }
+
+        let info = manager
+            .get("bg-server")
+            .await
+            .expect("background session was evicted under LRU pressure");
+        assert!(info.alive, "background session should still be running");
+        manager.remove_all().await;
+    }
+
+    #[tokio::test]
+    async fn eviction_prefers_exited_sessions_over_live_ones() {
+        let manager = TerminalManager::with_max_sessions(2);
+        let backend = test_backend();
+        manager
+            .create("live-old".to_string(), None, 120, 40, &backend)
+            .await
+            .unwrap();
+        sleep(Duration::from_millis(10)).await;
+        manager
+            .create("dead-new".to_string(), None, 120, 40, &backend)
+            .await
+            .unwrap();
+
+        // Ask the shell to exit without letting write_stdin observe the
+        // death (yield 0), so the exited entry stays in the map.
+        manager
+            .write_stdin("dead-new", "exit\r", 0, 8000)
+            .await
+            .unwrap();
+        let mut dead = false;
+        for _ in 0..40 {
+            if let Some(info) = manager.get("dead-new").await {
+                if !info.alive {
+                    dead = true;
+                    break;
+                }
+            } else {
+                dead = true;
+                break;
+            }
+            sleep(Duration::from_millis(50)).await;
+        }
+        assert!(dead, "shell did not exit in time");
+
+        manager
+            .create("third".to_string(), None, 120, 40, &backend)
+            .await
+            .unwrap();
+
+        let live_old = manager
+            .get("live-old")
+            .await
+            .expect("live session evicted while an exited session existed");
+        assert!(live_old.alive);
+        assert!(manager.get("dead-new").await.is_none());
+        manager.remove_all().await;
+    }
 
     #[test]
     fn terminal_pipe_command_delegates_to_sandbox_session() {

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -16,9 +16,14 @@ use super::keyparse::parse_keys;
 use super::session::{terminal_env_owned, TerminalSession};
 use super::{TerminalInfo, TerminalOutput};
 
-struct SpawnOpts<'a> {
-    background: bool,
-    command: Option<&'a str>,
+/// Outcome of killing a session that existed: whether the process was still
+/// alive when the kill was issued, a final tail of its output (including
+/// anything flushed during teardown), and the exit code if one was reaped.
+pub struct KilledSession {
+    pub was_alive: bool,
+    pub tail: String,
+    pub tail_truncated: bool,
+    pub exit_code: Option<i32>,
 }
 
 #[derive(Clone)]
@@ -47,23 +52,13 @@ impl TerminalManager {
         rows: u16,
         backend: &Arc<ExecutionBackend>,
     ) -> Result<TerminalInfo> {
-        self.create_inner(
-            name,
-            cwd,
-            cols,
-            rows,
-            backend,
-            SpawnOpts {
-                background: false,
-                command: None,
-            },
-        )
-        .await
+        self.create_inner(name, cwd, cols, rows, backend, None)
+            .await
     }
 
     /// Spawn a PTY session for a long-running background command and return
-    /// immediately — no initial output wait. The command (if any) is written
-    /// to the shell followed by a carriage return. The session is flagged as
+    /// immediately — no initial output wait. The command is written to the
+    /// shell followed by a carriage return. The session is flagged as
     /// background, which exempts it from LRU eviction while its process is
     /// alive. The PTY child runs in its own session/process group (portable_pty
     /// calls setsid on spawn) and the command is built via the sandbox
@@ -71,26 +66,19 @@ impl TerminalManager {
     pub async fn spawn_background(
         &self,
         name: String,
-        command: Option<&str>,
+        command: &str,
         cwd: Option<PathBuf>,
         cols: u16,
         rows: u16,
         backend: &Arc<ExecutionBackend>,
     ) -> Result<TerminalInfo> {
-        self.create_inner(
-            name,
-            cwd,
-            cols,
-            rows,
-            backend,
-            SpawnOpts {
-                background: true,
-                command,
-            },
-        )
-        .await
+        self.create_inner(name, cwd, cols, rows, backend, Some(command))
+            .await
     }
 
+    /// `background_command`: `Some(cmd)` spawns a background session (see
+    /// `spawn_background`) running `cmd`; `None` spawns a plain foreground
+    /// session.
     async fn create_inner(
         &self,
         name: String,
@@ -98,7 +86,7 @@ impl TerminalManager {
         cols: u16,
         rows: u16,
         backend: &Arc<ExecutionBackend>,
-        opts: SpawnOpts<'_>,
+        background_command: Option<&str>,
     ) -> Result<TerminalInfo> {
         let old = {
             let mut sessions = self.sessions.lock().await;
@@ -114,8 +102,8 @@ impl TerminalManager {
         }
 
         let mut session = TerminalSession::spawn(name.clone(), cwd, cols, rows, backend)?;
-        session.background = opts.background;
-        if let Some(command) = opts.command {
+        session.background = background_command.is_some();
+        if let Some(command) = background_command {
             if !command.trim().is_empty() {
                 session.write(format!("{}\r", command).as_bytes())?;
             }
@@ -162,19 +150,37 @@ impl TerminalManager {
 
     /// Kill a session and its full process tree (backend pidfile kill →
     /// SIGTERM descendants + process group → 500ms grace → SIGKILL → reap).
-    /// Returns `Ok(true)` if the process was still alive when the kill was
-    /// issued, `Ok(false)` if it had already exited.
-    pub async fn kill_session(&self, name: &str) -> Result<bool> {
+    /// Returns `Ok(None)` if no such session exists (already killed or
+    /// exited-and-reaped), making repeated kills structurally idempotent.
+    /// Otherwise returns the kill outcome including a final output tail
+    /// (bounded by `max_output`) and the reaped exit code when available.
+    pub async fn kill_session(
+        &self,
+        name: &str,
+        max_output: usize,
+    ) -> Result<Option<KilledSession>> {
         let session = {
             let mut sessions = self.sessions.lock().await;
             sessions.remove(name)
         };
-        let mut session =
-            session.with_context(|| format!("terminal session '{}' not found", name))?;
+        let Some(mut session) = session else {
+            return Ok(None);
+        };
         session.refresh_status();
         let was_alive = session.is_alive();
+        // Drain output produced since the last poll before tearing down,
+        // then again afterwards to catch anything flushed during shutdown.
+        let mut tail = session.read_output();
         session.kill().await?;
-        Ok(was_alive)
+        tail.push_str(&session.read_output());
+        let exit_code = session.exit_code();
+        let (tail, tail_truncated) = head_tail_truncate(&tail, max_output);
+        Ok(Some(KilledSession {
+            was_alive,
+            tail,
+            tail_truncated,
+            exit_code,
+        }))
     }
 
     pub async fn write_stdin(
@@ -504,14 +510,7 @@ mod tests {
         let backend = test_backend();
         let start = Instant::now();
         let info = manager
-            .spawn_background(
-                "bg-run".to_string(),
-                Some("sleep 30"),
-                None,
-                120,
-                40,
-                &backend,
-            )
+            .spawn_background("bg-run".to_string(), "sleep 30", None, 120, 40, &backend)
             .await
             .unwrap();
         assert!(
@@ -524,8 +523,12 @@ mod tests {
         let got = manager.get("bg-run").await.expect("session registered");
         assert!(got.alive, "background session should still be running");
 
-        let was_alive = manager.kill_session("bg-run").await.unwrap();
-        assert!(was_alive, "session was running when killed");
+        let killed = manager
+            .kill_session("bg-run", 8000)
+            .await
+            .unwrap()
+            .expect("session existed");
+        assert!(killed.was_alive, "session was running when killed");
         assert!(manager.get("bg-run").await.is_none());
     }
 
@@ -537,7 +540,7 @@ mod tests {
         manager
             .spawn_background(
                 "bg-kill".to_string(),
-                Some("sleep 30 & echo NAC_CHILD:$!"),
+                "sleep 30 & echo NAC_CHILD:$!",
                 None,
                 120,
                 40,
@@ -564,8 +567,12 @@ mod tests {
             child_pid.unwrap_or_else(|| panic!("child pid not found in: {collected:?}"));
         assert!(process_exists(child_pid), "child exited too early");
 
-        let was_alive = manager.kill_session("bg-kill").await.unwrap();
-        assert!(was_alive);
+        let killed = manager
+            .kill_session("bg-kill", 8000)
+            .await
+            .unwrap()
+            .expect("session existed");
+        assert!(killed.was_alive);
         assert!(manager.get("bg-kill").await.is_none());
 
         let mut orphaned = true;
@@ -585,10 +592,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn kill_session_unknown_name_errors() {
+    async fn kill_session_unknown_name_is_idempotent_none() {
         let manager = TerminalManager::new();
-        let err = manager.kill_session("nope").await.unwrap_err();
-        assert!(err.to_string().contains("not found"));
+        let killed = manager.kill_session("nope", 8000).await.unwrap();
+        assert!(killed.is_none(), "unknown session must report None");
     }
 
     #[tokio::test]
@@ -596,14 +603,7 @@ mod tests {
         let manager = TerminalManager::new();
         let backend = test_backend();
         manager
-            .spawn_background(
-                "bg-exit".to_string(),
-                Some("exit 7"),
-                None,
-                120,
-                40,
-                &backend,
-            )
+            .spawn_background("bg-exit".to_string(), "exit 7", None, 120, 40, &backend)
             .await
             .unwrap();
 
@@ -631,14 +631,7 @@ mod tests {
         let manager = TerminalManager::with_max_sessions(3);
         let backend = test_backend();
         manager
-            .spawn_background(
-                "bg-server".to_string(),
-                Some("sleep 60"),
-                None,
-                120,
-                40,
-                &backend,
-            )
+            .spawn_background("bg-server".to_string(), "sleep 60", None, 120, 40, &backend)
             .await
             .unwrap();
 

--- a/crates/nac-core/src/terminal/session.rs
+++ b/crates/nac-core/src/terminal/session.rs
@@ -25,6 +25,9 @@ pub struct TerminalSession {
     _reader_thread: std::thread::JoinHandle<()>,
     pub created_at: Instant,
     pub last_output_at: Instant,
+    /// Background sessions (long-running servers etc.) are exempt from LRU
+    /// eviction while alive; see `TerminalManager` eviction policy.
+    pub background: bool,
     alive: Arc<AtomicBool>,
     exit_code: Option<i32>,
     /// Remote process-tree cleanup: backends that return a pidfile from
@@ -112,6 +115,7 @@ impl TerminalSession {
             _reader_thread: reader_thread,
             created_at: Instant::now(),
             last_output_at: Instant::now(),
+            background: false,
             alive,
             exit_code: None,
             backend_cleanup,

--- a/crates/nac-core/src/test_http.rs
+++ b/crates/nac-core/src/test_http.rs
@@ -1,0 +1,115 @@
+//! Shared raw-HTTP test scaffolding for in-process fake servers (fake model
+//! server, fake MCP server): a minimal request reader, response writer, and
+//! a scripted fake chat-completions server.
+
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::PathBuf;
+use std::time::Duration;
+
+pub(crate) struct HttpRequest {
+    pub method: String,
+    pub body: Option<Value>,
+}
+
+/// Read one HTTP request (headers plus Content-Length body) from `stream`.
+/// Returns `None` on read failure or connection close before a full request.
+pub(crate) fn read_http_request(stream: &mut TcpStream) -> Option<HttpRequest> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .ok()?;
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        let read = stream.read(&mut chunk).ok()?;
+        if read == 0 {
+            return None;
+        }
+        buf.extend_from_slice(&chunk[..read]);
+        let Some(header_end) = buf.windows(4).position(|window| window == b"\r\n\r\n") else {
+            continue;
+        };
+        let header_text = String::from_utf8_lossy(&buf[..header_end]);
+        let method = header_text
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().next())
+            .unwrap_or("")
+            .to_string();
+        let content_length = header_text
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().ok())
+                    .flatten()
+            })
+            .unwrap_or(0);
+        let body_start = header_end + 4;
+        while buf.len() < body_start + content_length {
+            let read = stream.read(&mut chunk).ok()?;
+            if read == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&chunk[..read]);
+        }
+        let body = if content_length == 0 {
+            None
+        } else {
+            serde_json::from_slice(&buf[body_start..body_start + content_length]).ok()
+        };
+        return Some(HttpRequest { method, body });
+    }
+}
+
+pub(crate) fn write_http_response(
+    stream: &mut TcpStream,
+    status: &str,
+    content_type: Option<&str>,
+    body: &str,
+) {
+    let content_type = content_type
+        .map(|value| format!("Content-Type: {value}\r\n"))
+        .unwrap_or_default();
+    let response = format!(
+        "HTTP/1.1 {status}\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Minimal fake chat-completions server: serves the given JSON bodies to
+/// sequential requests. Before serving the last response it optionally
+/// waits for `wait_file_before_last` to exist, so a background command
+/// started by a tool call is guaranteed to be running when the turn ends.
+pub(crate) fn spawn_fake_model_server(
+    responses: Vec<String>,
+    wait_file_before_last: Option<PathBuf>,
+) -> (String, std::thread::JoinHandle<()>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind fake model server");
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let handle = std::thread::spawn(move || {
+        let total = responses.len();
+        for (index, body) in responses.into_iter().enumerate() {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            // Drain the request (best effort) before responding.
+            let _ = read_http_request(&mut stream);
+
+            if index + 1 == total {
+                if let Some(path) = &wait_file_before_last {
+                    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+                    while !path.exists() && std::time::Instant::now() < deadline {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                }
+            }
+
+            write_http_response(&mut stream, "200 OK", Some("application/json"), &body);
+        }
+    });
+    (url, handle)
+}

--- a/crates/nac-core/src/tools/exec_command.rs
+++ b/crates/nac-core/src/tools/exec_command.rs
@@ -1,11 +1,34 @@
-//! Terminal-backed command execution tools: `exec_command` and `write_stdin`.
+//! Terminal-backed command execution tools: `exec_command`, `write_stdin`,
+//! and `kill_shell`.
 
 use anyhow::{anyhow, Result};
+use serde::Serialize;
 use serde_json::Value;
 use std::path::PathBuf;
 
 use crate::tools::ToolRuntime;
 use crate::types::{FunctionDef, ToolDefinition};
+
+/// Response for `exec_command` with `background=true`: the session started
+/// and the call returned immediately without waiting for output.
+#[derive(Serialize)]
+struct BackgroundStarted {
+    session_name: String,
+    background: bool,
+}
+
+/// Response for `kill_shell`. Field presence is fixed across all outcomes:
+/// `was_running=false` with empty output means the session was already gone
+/// (kill_shell is idempotent); `exit_code` is present when the process had
+/// exited and its status was reaped.
+#[derive(Serialize)]
+struct KillShellResult {
+    session_name: String,
+    was_running: bool,
+    output: String,
+    output_truncated: bool,
+    exit_code: Option<i32>,
+}
 
 // ============================================================================
 // exec_command
@@ -51,75 +74,95 @@ The background session stays alive across tool calls until killed; write_stdin c
     }
 }
 
+/// The three execution modes of `exec_command`. `background=true` overrides
+/// `tty`; background mode returns immediately and ignores `yield_time_ms`
+/// and `max_output_chars` (they apply to later `write_stdin` polls instead).
+enum ExecMode {
+    Background,
+    OneShot,
+    Tty,
+}
+
+impl ExecMode {
+    fn from_args(args: &Value) -> Self {
+        let flag = |key| args.get(key).and_then(|v| v.as_bool()).unwrap_or(false);
+        if flag("background") {
+            ExecMode::Background
+        } else if flag("tty") {
+            ExecMode::Tty
+        } else {
+            ExecMode::OneShot
+        }
+    }
+}
+
 pub async fn execute_exec_command(args: &Value, runtime: &ToolRuntime) -> Result<String> {
-    let manager = &runtime.terminal_manager;
     let cmd = require_str(args, "cmd")?;
-    let tty = args.get("tty").and_then(|v| v.as_bool()).unwrap_or(false);
-    let background = args
-        .get("background")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-    let default_yield_ms = if tty { 500 } else { 30_000 };
-    let yield_ms = clamp_yield(
-        args.get("yield_time_ms")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(default_yield_ms),
-    );
-    let max_output = args
-        .get("max_output_chars")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(8000) as usize;
     let cwd = resolve_command_cwd(args, runtime)?;
-
-    if background {
-        let session_name = make_session_name();
-        let info = manager
-            .spawn_background(
-                session_name.clone(),
-                Some(&cmd),
-                cwd,
-                120,
-                40,
-                &runtime.backend,
-            )
-            .await?;
-        return Ok(serde_json::to_string_pretty(&serde_json::json!({
-            "session_name": info.name,
-            "background": true,
-            "hint": "Command started in a background session. Poll output with write_stdin (empty chars); send input the same way; stop it with kill_shell.",
-        }))?);
+    match ExecMode::from_args(args) {
+        ExecMode::Background => exec_background(&cmd, cwd, runtime).await,
+        ExecMode::OneShot => exec_one_shot(&cmd, cwd, args, runtime).await,
+        ExecMode::Tty => exec_tty(&cmd, cwd, args, runtime).await,
     }
+}
 
-    if !tty {
-        let output = manager
-            .exec_one_shot(
-                &cmd,
-                cwd,
-                120,
-                40,
-                yield_ms,
-                max_output,
-                runtime.backend.as_ref(),
-            )
-            .await?;
-        return Ok(serde_json::to_string_pretty(&output)?);
-    }
+async fn exec_background(cmd: &str, cwd: Option<PathBuf>, runtime: &ToolRuntime) -> Result<String> {
+    let info = runtime
+        .terminal_manager
+        .spawn_background(make_session_name(), cmd, cwd, 120, 40, &runtime.backend)
+        .await?;
+    Ok(serde_json::to_string_pretty(&BackgroundStarted {
+        session_name: info.name,
+        background: true,
+    })?)
+}
 
+async fn exec_one_shot(
+    cmd: &str,
+    cwd: Option<PathBuf>,
+    args: &Value,
+    runtime: &ToolRuntime,
+) -> Result<String> {
+    let yield_ms = yield_ms_arg(args, 30_000);
+    let max_output = max_output_arg(args);
+    let output = runtime
+        .terminal_manager
+        .exec_one_shot(
+            cmd,
+            cwd,
+            120,
+            40,
+            yield_ms,
+            max_output,
+            runtime.backend.as_ref(),
+        )
+        .await?;
+    Ok(serde_json::to_string_pretty(&output)?)
+}
+
+async fn exec_tty(
+    cmd: &str,
+    cwd: Option<PathBuf>,
+    args: &Value,
+    runtime: &ToolRuntime,
+) -> Result<String> {
+    let manager = &runtime.terminal_manager;
+    let yield_ms = yield_ms_arg(args, 500);
+    let max_output = max_output_arg(args);
     let session_name = make_session_name();
     let _info = manager
         .create(session_name.clone(), cwd, 120, 40, &runtime.backend)
         .await?;
 
-    if cmd.trim().is_empty() {
-        let output = manager
+    let output = if cmd.trim().is_empty() {
+        manager
             .write_stdin(&session_name, "", 200, max_output)
-            .await?;
-        return Ok(serde_json::to_string_pretty(&output)?);
-    }
-
-    let output = manager
-        .write_stdin(&session_name, &format!("{}\r", cmd), yield_ms, max_output)
-        .await?;
+            .await?
+    } else {
+        manager
+            .write_stdin(&session_name, &format!("{}\r", cmd), yield_ms, max_output)
+            .await?
+    };
     Ok(serde_json::to_string_pretty(&output)?)
 }
 
@@ -135,8 +178,7 @@ pub fn write_stdin_definition() -> ToolDefinition {
             description: "Send input to a persistent terminal session created by exec_command with tty=true or background=true. \
 Also use this to poll for output by sending empty input.\n\n\
 Calling write_stdin with empty chars is the canonical way to check on a background session: it returns \
-whatever output the session has produced, or the exit_code (with session_name=null) if the process has ended. \
-Poll a background server this way until it reports ready before running commands against it.\n\n\
+whatever output the session has produced, or the exit_code (with session_name=null) if the process has ended.\n\n\
 Supports key notation: <RET> (Enter), <C-c> (Ctrl+C), <C-d> (Ctrl+D), <TAB>, <BSPC> (Backspace), \
 <UP>/<DOWN>/<LEFT>/<RIGHT>."
                 .to_string(),
@@ -158,15 +200,8 @@ pub async fn execute_write_stdin(args: &Value, runtime: &ToolRuntime) -> Result<
     let manager = &runtime.terminal_manager;
     let session_id = require_str(args, "session_id")?;
     let chars = args.get("chars").and_then(|v| v.as_str()).unwrap_or("");
-    let yield_ms = clamp_yield(
-        args.get("yield_time_ms")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(500),
-    );
-    let max_output = args
-        .get("max_output_chars")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(8000) as usize;
+    let yield_ms = yield_ms_arg(args, 500);
+    let max_output = max_output_arg(args);
 
     if manager.get(&session_id).await.is_none() {
         return Err(anyhow!(
@@ -194,9 +229,6 @@ pub fn kill_shell_definition() -> ToolDefinition {
                 "Kill a terminal session created by exec_command (background=true or tty=true). \
 Terminates the session's whole process tree and returns whether it was still running, \
 plus a final tail of its output.\n\n\
-This is the cleanup step of the run-server-then-test flow: start a server with \
-exec_command background=true, poll it with write_stdin (empty chars), test against it \
-with one-shot exec_command calls, then kill_shell its session id when done.\n\n\
 Killing is idempotent: calling kill_shell on a session that already exited or was \
 already killed reports was_running=false instead of erroring."
                     .to_string(),
@@ -213,46 +245,32 @@ already killed reports was_running=false instead of erroring."
 }
 
 pub async fn execute_kill_shell(args: &Value, runtime: &ToolRuntime) -> Result<String> {
-    let manager = &runtime.terminal_manager;
     let session_id = require_str(args, "session_id")?;
-    let max_output = args
-        .get("max_output_chars")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(8000) as usize;
+    let max_output = max_output_arg(args);
 
-    if manager.get(&session_id).await.is_none() {
-        return Ok(serde_json::to_string_pretty(&serde_json::json!({
-            "session_name": session_id,
-            "was_running": false,
-            "output": "",
-            "note": "session not found - it already exited or was already killed",
-        }))?);
-    }
-
-    // Grab a final output tail before killing.
-    let polled = manager
-        .write_stdin(&session_id, "", 100, max_output)
-        .await?;
-
-    if polled.session_name.is_none() {
-        // The process had already exited; the poll reaped it and removed the
-        // entry, so there is nothing left to kill.
-        return Ok(serde_json::to_string_pretty(&serde_json::json!({
-            "session_name": session_id,
-            "was_running": false,
-            "output": polled.output,
-            "output_truncated": polled.output_truncated,
-            "exit_code": polled.exit_code,
-        }))?);
-    }
-
-    let was_running = manager.kill_session(&session_id).await?;
-    Ok(serde_json::to_string_pretty(&serde_json::json!({
-        "session_name": session_id,
-        "was_running": was_running,
-        "output": polled.output,
-        "output_truncated": polled.output_truncated,
-    }))?)
+    // A single manager call: the kill is atomic with the final-output grab,
+    // and a missing session (already exited or killed) is a normal outcome.
+    let result = match runtime
+        .terminal_manager
+        .kill_session(&session_id, max_output)
+        .await?
+    {
+        Some(killed) => KillShellResult {
+            session_name: session_id,
+            was_running: killed.was_alive,
+            output: killed.tail,
+            output_truncated: killed.tail_truncated,
+            exit_code: killed.exit_code,
+        },
+        None => KillShellResult {
+            session_name: session_id,
+            was_running: false,
+            output: String::new(),
+            output_truncated: false,
+            exit_code: None,
+        },
+    };
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 // ============================================================================
@@ -269,6 +287,20 @@ fn require_str(args: &Value, key: &str) -> Result<String> {
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
         .ok_or_else(|| anyhow!("missing required argument '{}'", key))
+}
+
+fn yield_ms_arg(args: &Value, default_ms: u64) -> u64 {
+    clamp_yield(
+        args.get("yield_time_ms")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(default_ms),
+    )
+}
+
+fn max_output_arg(args: &Value) -> usize {
+    args.get("max_output_chars")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(8000) as usize
 }
 
 const MAX_YIELD_MS: u64 = 3_600_000; // 1 hour
@@ -584,13 +616,16 @@ mod tests {
         let session = parsed["session_name"].as_str().unwrap().to_string();
         assert!(session.starts_with("shell-"), "got: {}", session);
         assert_eq!(parsed["background"].as_bool(), Some(true));
-        assert!(parsed["hint"].as_str().unwrap().contains("kill_shell"));
 
         // The command is still running: the session exists and is alive.
         let info = runtime.terminal_manager.get(&session).await.unwrap();
         assert!(info.alive, "background command should still be running");
 
-        runtime.terminal_manager.kill_session(&session).await.ok();
+        runtime
+            .terminal_manager
+            .kill_session(&session, 8000)
+            .await
+            .ok();
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/tools/exec_command.rs
+++ b/crates/nac-core/src/tools/exec_command.rs
@@ -25,7 +25,15 @@ Use tty=true for:\n\
 (cd into a directory, set env vars, then run commands)\n\
 - When you need more than one command in the same shell session\n\n\
 When tty=true, yield_time_ms only controls how long to wait for output before returning; it does not kill the session.\n\n\
-When tty=true, you get a session_name back. Use write_stdin to continue interacting with that session."
+When tty=true, you get a session_name back. Use write_stdin to continue interacting with that session.\n\n\
+Use background=true for long-running processes like dev servers, watchers, or `python3 -m http.server`: \
+the command starts in a persistent PTY session and this call returns immediately with the session id — \
+it does NOT wait for output. Typical run-server-then-test flow: \
+1) exec_command with background=true to start the server, \
+2) write_stdin with empty chars to poll its output until it is ready, \
+3) run one-shot exec_command calls (curl, tests, etc.) against it, \
+4) kill_shell with the session id to stop it. \
+The background session stays alive across tool calls until killed; write_stdin can also send it interactive input."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -33,6 +41,7 @@ When tty=true, you get a session_name back. Use write_stdin to continue interact
                     "cmd": { "type": "string", "description": "Shell command to execute" },
                     "workdir": { "type": "string", "description": "Working directory for the command (default: project root)" },
                     "tty": { "type": "boolean", "description": "Use false as the bash tool for one-shot shell commands; use true for an interactive/persistent PTY session (default: false)" },
+                    "background": { "type": "boolean", "description": "Start the command in a persistent background PTY session and return immediately with the session id (default: false). Use for servers and other long-running processes. Poll output with write_stdin (empty chars), stop with kill_shell. Overrides tty." },
                     "yield_time_ms": { "type": "number", "description": "For tty=false, command timeout in milliseconds (default: 30000, max: 3600000 = 1 hour). For tty=true, maximum time to wait for terminal output without killing the session (default: 500, max: 3600000)." },
                     "max_output_chars": { "type": "number", "description": "Maximum characters of output to return (default: 8000, head-tail truncated if exceeded)" }
                 },
@@ -46,6 +55,10 @@ pub async fn execute_exec_command(args: &Value, runtime: &ToolRuntime) -> Result
     let manager = &runtime.terminal_manager;
     let cmd = require_str(args, "cmd")?;
     let tty = args.get("tty").and_then(|v| v.as_bool()).unwrap_or(false);
+    let background = args
+        .get("background")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     let default_yield_ms = if tty { 500 } else { 30_000 };
     let yield_ms = clamp_yield(
         args.get("yield_time_ms")
@@ -57,6 +70,25 @@ pub async fn execute_exec_command(args: &Value, runtime: &ToolRuntime) -> Result
         .and_then(|v| v.as_u64())
         .unwrap_or(8000) as usize;
     let cwd = resolve_command_cwd(args, runtime)?;
+
+    if background {
+        let session_name = make_session_name();
+        let info = manager
+            .spawn_background(
+                session_name.clone(),
+                Some(&cmd),
+                cwd,
+                120,
+                40,
+                &runtime.backend,
+            )
+            .await?;
+        return Ok(serde_json::to_string_pretty(&serde_json::json!({
+            "session_name": info.name,
+            "background": true,
+            "hint": "Command started in a background session. Poll output with write_stdin (empty chars); send input the same way; stop it with kill_shell.",
+        }))?);
+    }
 
     if !tty {
         let output = manager
@@ -100,8 +132,11 @@ pub fn write_stdin_definition() -> ToolDefinition {
         def_type: "function".to_string(),
         function: FunctionDef {
             name: "write_stdin".to_string(),
-            description: "Send input to a persistent terminal session created by exec_command with tty=true. \
+            description: "Send input to a persistent terminal session created by exec_command with tty=true or background=true. \
 Also use this to poll for output by sending empty input.\n\n\
+Calling write_stdin with empty chars is the canonical way to check on a background session: it returns \
+whatever output the session has produced, or the exit_code (with session_name=null) if the process has ended. \
+Poll a background server this way until it reports ready before running commands against it.\n\n\
 Supports key notation: <RET> (Enter), <C-c> (Ctrl+C), <C-d> (Ctrl+D), <TAB>, <BSPC> (Backspace), \
 <UP>/<DOWN>/<LEFT>/<RIGHT>."
                 .to_string(),
@@ -109,7 +144,7 @@ Supports key notation: <RET> (Enter), <C-c> (Ctrl+C), <C-d> (Ctrl+D), <TAB>, <BS
                 "type": "object",
                 "properties": {
                     "session_id": { "type": "string", "description": "Session ID returned by exec_command" },
-                    "chars": { "type": "string", "description": "Input to send to the terminal. Supports key notation: <RET>, <C-c>, <C-d>, <TAB>, <BSPC>, <UP>/<DOWN>/<LEFT>/<RIGHT>. Leave empty to just poll for output." },
+                    "chars": { "type": "string", "description": "Input to send to the terminal. Supports key notation: <RET>, <C-c>, <C-d>, <TAB>, <BSPC>, <UP>/<DOWN>/<LEFT>/<RIGHT>. Leave empty to just poll for output — the canonical output check for background sessions." },
                     "yield_time_ms": { "type": "number", "description": "Maximum time to wait for output in milliseconds (default: 500, max: 3600000 = 1 hour)" },
                     "max_output_chars": { "type": "number", "description": "Maximum characters of output to return (default: 8000)" }
                 },
@@ -144,6 +179,80 @@ pub async fn execute_write_stdin(args: &Value, runtime: &ToolRuntime) -> Result<
         .write_stdin(&session_id, chars, yield_ms, max_output)
         .await?;
     Ok(serde_json::to_string_pretty(&output)?)
+}
+
+// ============================================================================
+// kill_shell
+// ============================================================================
+
+pub fn kill_shell_definition() -> ToolDefinition {
+    ToolDefinition {
+        def_type: "function".to_string(),
+        function: FunctionDef {
+            name: "kill_shell".to_string(),
+            description:
+                "Kill a terminal session created by exec_command (background=true or tty=true). \
+Terminates the session's whole process tree and returns whether it was still running, \
+plus a final tail of its output.\n\n\
+This is the cleanup step of the run-server-then-test flow: start a server with \
+exec_command background=true, poll it with write_stdin (empty chars), test against it \
+with one-shot exec_command calls, then kill_shell its session id when done.\n\n\
+Killing is idempotent: calling kill_shell on a session that already exited or was \
+already killed reports was_running=false instead of erroring."
+                    .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "session_id": { "type": "string", "description": "Session ID returned by exec_command" },
+                    "max_output_chars": { "type": "number", "description": "Maximum characters of final output to return (default: 8000, head-tail truncated if exceeded)" }
+                },
+                "required": ["session_id"]
+            }),
+        },
+    }
+}
+
+pub async fn execute_kill_shell(args: &Value, runtime: &ToolRuntime) -> Result<String> {
+    let manager = &runtime.terminal_manager;
+    let session_id = require_str(args, "session_id")?;
+    let max_output = args
+        .get("max_output_chars")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(8000) as usize;
+
+    if manager.get(&session_id).await.is_none() {
+        return Ok(serde_json::to_string_pretty(&serde_json::json!({
+            "session_name": session_id,
+            "was_running": false,
+            "output": "",
+            "note": "session not found - it already exited or was already killed",
+        }))?);
+    }
+
+    // Grab a final output tail before killing.
+    let polled = manager
+        .write_stdin(&session_id, "", 100, max_output)
+        .await?;
+
+    if polled.session_name.is_none() {
+        // The process had already exited; the poll reaped it and removed the
+        // entry, so there is nothing left to kill.
+        return Ok(serde_json::to_string_pretty(&serde_json::json!({
+            "session_name": session_id,
+            "was_running": false,
+            "output": polled.output,
+            "output_truncated": polled.output_truncated,
+            "exit_code": polled.exit_code,
+        }))?);
+    }
+
+    let was_running = manager.kill_session(&session_id).await?;
+    Ok(serde_json::to_string_pretty(&serde_json::json!({
+        "session_name": session_id,
+        "was_running": was_running,
+        "output": polled.output,
+        "output_truncated": polled.output_truncated,
+    }))?)
 }
 
 // ============================================================================
@@ -443,6 +552,226 @@ mod tests {
         assert!(result.is_ok(), "error: {:?}", result.err());
         let parsed: Value = serde_json::from_str(&result.unwrap()).unwrap();
         assert!(parsed["session_name"].is_string());
+    }
+
+    // ------------------------------------------------------------------
+    // background exec + kill_shell
+    // ------------------------------------------------------------------
+
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    #[tokio::test]
+    async fn exec_command_background_returns_immediately_while_command_runs() {
+        let runtime = test_runtime();
+        let start = std::time::Instant::now();
+        let output = execute_exec_command(
+            &json!({ "cmd": "sleep 30", "background": true, "yield_time_ms": 30000 }),
+            &runtime,
+        )
+        .await
+        .unwrap();
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(2),
+            "background exec blocked instead of returning immediately"
+        );
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+        let session = parsed["session_name"].as_str().unwrap().to_string();
+        assert!(session.starts_with("shell-"), "got: {}", session);
+        assert_eq!(parsed["background"].as_bool(), Some(true));
+        assert!(parsed["hint"].as_str().unwrap().contains("kill_shell"));
+
+        // The command is still running: the session exists and is alive.
+        let info = runtime.terminal_manager.get(&session).await.unwrap();
+        assert!(info.alive, "background command should still be running");
+
+        runtime.terminal_manager.kill_session(&session).await.ok();
+    }
+
+    #[tokio::test]
+    async fn background_server_serves_one_shot_request_then_kill_shell_stops_it() {
+        let runtime = test_runtime();
+        let port = free_port();
+
+        // 1. Start the server in the background.
+        let output = execute_exec_command(
+            &json!({
+                "cmd": format!("python3 -m http.server {} --bind 127.0.0.1", port),
+                "background": true
+            }),
+            &runtime,
+        )
+        .await
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+        let session = parsed["session_name"].as_str().unwrap().to_string();
+
+        // 2. Poll with empty-input write_stdin until the server reports ready.
+        let mut ready = false;
+        for _ in 0..50 {
+            let poll = execute_write_stdin(
+                &json!({ "session_id": session, "chars": "", "yield_time_ms": 200 }),
+                &runtime,
+            )
+            .await
+            .unwrap();
+            let poll: Value = serde_json::from_str(&poll).unwrap();
+            assert!(
+                poll["session_name"].is_string(),
+                "server died during startup: {}",
+                poll
+            );
+            if poll["output"]
+                .as_str()
+                .unwrap_or("")
+                .contains("Serving HTTP")
+            {
+                ready = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(ready, "server never reported ready");
+
+        // 3. A one-shot exec succeeds against the live background server.
+        let curl = execute_exec_command(
+            &json!({
+                "cmd": format!("curl -s -o /dev/null -w '%{{http_code}}' http://127.0.0.1:{}/", port),
+                "tty": false,
+                "yield_time_ms": 10000
+            }),
+            &runtime,
+        )
+        .await
+        .unwrap();
+        let curl: Value = serde_json::from_str(&curl).unwrap();
+        assert_eq!(curl["exit_code"].as_i64(), Some(0), "got: {}", curl);
+        assert!(
+            curl["output"].as_str().unwrap().contains("200"),
+            "got: {}",
+            curl
+        );
+
+        // 4. kill_shell terminates the server and reports it was running.
+        let killed = execute_kill_shell(&json!({ "session_id": session }), &runtime)
+            .await
+            .unwrap();
+        let killed: Value = serde_json::from_str(&killed).unwrap();
+        assert_eq!(
+            killed["was_running"].as_bool(),
+            Some(true),
+            "got: {}",
+            killed
+        );
+        // The final tail contains output produced since the last poll —
+        // here, the server's log line for the curl request above.
+        assert!(
+            killed["output"].as_str().unwrap().contains("GET /"),
+            "final tail missing server output: {}",
+            killed
+        );
+
+        // The port is actually free again (server really died).
+        let mut freed = false;
+        for _ in 0..20 {
+            if std::net::TcpListener::bind(("127.0.0.1", port)).is_ok() {
+                freed = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(freed, "port still bound after kill_shell");
+
+        // 5. A second kill_shell reports not-running instead of erroring.
+        let second = execute_kill_shell(&json!({ "session_id": session }), &runtime)
+            .await
+            .unwrap();
+        let second: Value = serde_json::from_str(&second).unwrap();
+        assert_eq!(
+            second["was_running"].as_bool(),
+            Some(false),
+            "got: {}",
+            second
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_shell_on_exited_session_reports_not_running() {
+        let runtime = test_runtime();
+        let output =
+            execute_exec_command(&json!({ "cmd": "exit 3", "background": true }), &runtime)
+                .await
+                .unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+        let session = parsed["session_name"].as_str().unwrap().to_string();
+
+        // Wait for the shell to exit.
+        let mut gone = false;
+        for _ in 0..50 {
+            match runtime.terminal_manager.get(&session).await {
+                None => {
+                    gone = true;
+                    break;
+                }
+                Some(info) if !info.alive => break,
+                _ => tokio::time::sleep(std::time::Duration::from_millis(100)).await,
+            }
+        }
+
+        let killed = execute_kill_shell(&json!({ "session_id": session }), &runtime)
+            .await
+            .unwrap();
+        let killed: Value = serde_json::from_str(&killed).unwrap();
+        assert_eq!(
+            killed["was_running"].as_bool(),
+            Some(false),
+            "gone={} got: {}",
+            gone,
+            killed
+        );
+    }
+
+    #[tokio::test]
+    async fn kill_shell_missing_session_id_fails() {
+        assert!(execute_kill_shell(&json!({}), &test_runtime())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn kill_shell_definition_shape() {
+        let def = kill_shell_definition();
+        assert_eq!(def.function.name, "kill_shell");
+        let required = def
+            .function
+            .parameters
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("session_id")));
+        assert!(def.function.description.contains("background=true"));
+    }
+
+    #[tokio::test]
+    async fn exec_command_foreground_unaffected_by_background_default() {
+        // background defaults to false: one-shot output shape is unchanged.
+        let output = execute_exec_command(
+            &json!({ "cmd": "echo fg-check", "tty": false, "yield_time_ms": 2000 }),
+            &test_runtime(),
+        )
+        .await
+        .unwrap();
+        let parsed: Value = serde_json::from_str(&output).unwrap();
+        assert!(parsed["output"].as_str().unwrap().contains("fg-check"));
+        assert_eq!(parsed["exit_code"].as_i64(), Some(0));
+        assert!(parsed["session_name"].is_null());
+        assert!(parsed.get("background").is_none() || parsed["background"].is_null());
+        assert!(parsed.get("hint").is_none() || parsed["hint"].is_null());
     }
 
     // ------------------------------------------------------------------

--- a/crates/nac-core/src/tools/mod.rs
+++ b/crates/nac-core/src/tools/mod.rs
@@ -171,6 +171,21 @@ pub fn require_string_array(args: &Value, key: &str) -> Result<Vec<String>, Tool
     Ok(out)
 }
 
+/// Convert a plain `Result<String>` tool outcome into a `ToolResult`,
+/// formatting errors with their full anyhow context chain.
+fn to_tool_result(result: anyhow::Result<String>) -> ToolResult {
+    match result {
+        Ok(content) => ToolResult {
+            content,
+            is_error: false,
+        },
+        Err(e) => ToolResult {
+            content: format!("Error: {:#}", e),
+            is_error: true,
+        },
+    }
+}
+
 pub async fn execute_tool(
     name: &str,
     args: Value,
@@ -191,36 +206,9 @@ pub async fn execute_tool(
         "read" => read::execute(args, runtime).await,
         "write" => write::execute(args, runtime).await,
         "edit" => edit::execute(args, runtime).await,
-        "exec_command" => match exec_command::execute_exec_command(&args, runtime).await {
-            Ok(content) => ToolResult {
-                content,
-                is_error: false,
-            },
-            Err(e) => ToolResult {
-                content: format!("Error: {:#}", e),
-                is_error: true,
-            },
-        },
-        "write_stdin" => match exec_command::execute_write_stdin(&args, runtime).await {
-            Ok(content) => ToolResult {
-                content,
-                is_error: false,
-            },
-            Err(e) => ToolResult {
-                content: format!("Error: {:#}", e),
-                is_error: true,
-            },
-        },
-        "kill_shell" => match exec_command::execute_kill_shell(&args, runtime).await {
-            Ok(content) => ToolResult {
-                content,
-                is_error: false,
-            },
-            Err(e) => ToolResult {
-                content: format!("Error: {:#}", e),
-                is_error: true,
-            },
-        },
+        "exec_command" => to_tool_result(exec_command::execute_exec_command(&args, runtime).await),
+        "write_stdin" => to_tool_result(exec_command::execute_write_stdin(&args, runtime).await),
+        "kill_shell" => to_tool_result(exec_command::execute_kill_shell(&args, runtime).await),
         "thread" => thread::execute_dispatch(args, runtime, client).await,
         "threads" => thread::execute_threads(runtime).await,
         "thread_read" => thread::execute_thread_read(args, runtime).await,

--- a/crates/nac-core/src/tools/mod.rs
+++ b/crates/nac-core/src/tools/mod.rs
@@ -107,6 +107,7 @@ pub fn worker_tool_definitions() -> Vec<ToolDefinition> {
 
     tools.push(exec_command::exec_command_definition());
     tools.push(exec_command::write_stdin_definition());
+    tools.push(exec_command::kill_shell_definition());
 
     tools
 }
@@ -201,6 +202,16 @@ pub async fn execute_tool(
             },
         },
         "write_stdin" => match exec_command::execute_write_stdin(&args, runtime).await {
+            Ok(content) => ToolResult {
+                content,
+                is_error: false,
+            },
+            Err(e) => ToolResult {
+                content: format!("Error: {:#}", e),
+                is_error: true,
+            },
+        },
+        "kill_shell" => match exec_command::execute_kill_shell(&args, runtime).await {
             Ok(content) => ToolResult {
                 content,
                 is_error: false,


### PR DESCRIPTION
## Summary

Adds first-class background process support to the worker toolset, enabling run-server-then-test workflows (start a server, poll readiness, hit it with one-shot commands, kill it). Design informed by common patterns in other coding-agent CLIs.

- **`background: true` on `exec_command`**: spawns the command via `TerminalManager::spawn_background` and returns immediately with the session id (typed `BackgroundStarted` response) instead of waiting for output. Foreground/one-shot and tty behavior unchanged; `execute_exec_command` is now an explicit 3-way mode dispatch (background / one-shot / tty).
- **Empty-input `write_stdin` polling**: sending empty input is the canonical way to check output/liveness of a background session; polling a self-exited session reports its exit code and removes the entry.
- **New `kill_shell` tool**: kills a background session's full process tree in a single atomic manager call (`kill_session` returns `Option<KilledSession { was_alive, tail, tail_truncated, exit_code }>`), returning a final output tail. Structurally idempotent: repeated kills on an already-dead or missing session are safe and report `was_running: false`.
- **Backend-aware process-group cleanup**: kill path routes through the sandbox backend (pidfile kill), then SIGTERM to descendants + process group, 500ms grace, SIGKILL, reap.
- **LRU eviction policy**: exited sessions are evicted first (oldest created), then oldest-idle live non-background sessions; live background sessions are never evicted (the cap may be exceeded rather than killing a running server).
- **Dispatch-end cleanup**: the existing `remove_all()` exit paths reap background sessions when a dispatch ends, on both success and model-error paths.
- **Worker prompt guidance**: the system prompt and `exec_command` description document the flow (background start → empty-input poll → one-shot test commands → `kill_shell`), including idempotency, exit-code-on-poll, eviction exemption, and dispatch-end teardown.

## Testing

- 277 tests pass, including an end-to-end run-server-then-test integration flow: spawn `http.server` in background → poll until ready → curl 200 → `kill_shell` → port freed → second kill reports not-running.
- Agent-level tests confirm background sessions are killed and reaped (process gone, session removed) after `Agent::send` returns, on both the success path and the model-error path.
- Coverage for background spawn returning immediately, kill on already-exited sessions, tool schema shapes, unchanged foreground output shape, and background-aware eviction ordering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process spawning, signal-based teardown, and session eviction in the agent execution path; regressions could leak background processes or kill servers unexpectedly, though coverage includes E2E server tests and dispatch cleanup.
> 
> **Overview**
> Workers can run **long-lived processes** (dev servers, watchers) via **`exec_command` with `background=true`**, which returns immediately with a session id instead of blocking on output. **`write_stdin` with empty input** is documented as the way to poll background output or learn when a process exited.
> 
> A new **`kill_shell`** tool stops a session’s full process tree and returns **`was_running`**, a final output tail, and optional **`exit_code`**; missing or already-dead sessions are handled idempotently (**`was_running: false`**).
> 
> **`TerminalManager`** gains **`spawn_background`**, **`kill_session`** / **`KilledSession`**, and revised **capacity eviction**: dead sessions first, then oldest idle non-background sessions—**live background sessions are never LRU-evicted** (the cap may be exceeded). **`TerminalSession`** marks background sessions for that policy.
> 
> **`exec_command`** is refactored into explicit **background / one-shot / tty** modes; **`kill_shell`** is registered on the worker toolset. The worker **system prompt** and tool descriptions spell out the run-server-then-test flow and dispatch-end cleanup.
> 
> Shared test HTTP helpers live in **`test_http`** (fake model server + MCP tests deduplicated). **Agent integration tests** assert background PIDs are reaped after **`Agent::send`** on both success and model-error paths via existing **`remove_all()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ba5486aa11649748747ea09819a6e4d9b890da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->