### PR TITLE
Arcee Auth

### DIFF
--- a/crates/nac-core/src/model/arcee.rs
+++ b/crates/nac-core/src/model/arcee.rs
@@ -1,0 +1,305 @@
+use super::auth_store::{
+    auth_file_path, read_auth_string, remove_auth_file, with_auth_lock, write_auth_string,
+};
+use super::*;
+use anyhow::Context;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const CLIENT_ID: &str = "nac-cli";
+const AUTH_TYPE: &str = "arcee_api_key";
+const DEFAULT_BASE_URL: &str = "http://api.internal.arcee.ai";
+const DEFAULT_INTERVAL_SECS: u64 = 5;
+const DEFAULT_EXPIRES_IN_SECS: u64 = 900;
+const SLOW_DOWN_BACKOFF_SECS: u64 = 5;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct StoredArceeAuth {
+    #[serde(rename = "type")]
+    auth_type: String,
+    pub(super) api_key: String,
+    pub(super) base_url: String,
+    organization_id: String,
+    workspace_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenSuccess {
+    api_key: String,
+    base_url: String,
+    organization_id: String,
+    workspace_name: String,
+}
+
+#[derive(Debug)]
+struct DeviceCode {
+    device_code: String,
+    user_code: String,
+    verification_uri_complete: String,
+    interval_secs: u64,
+    expires_in_secs: u64,
+}
+
+pub(super) async fn arcee_auth_login() -> Result<()> {
+    let client = Client::new();
+    let base = arcee_api_base();
+    let device = request_device_code(&client, &base).await?;
+
+    println!("Open this URL in a browser to authorize nac:");
+    println!("{}", device.verification_uri_complete);
+    println!();
+    println!("Confirm this code matches what the page shows:");
+    println!("{}", device.user_code);
+    println!();
+    println!("Waiting for authorization...");
+
+    let success = poll_device_code(&client, &base, &device).await?;
+    let auth = StoredArceeAuth {
+        auth_type: AUTH_TYPE.to_string(),
+        api_key: success.api_key,
+        base_url: success.base_url,
+        organization_id: success.organization_id,
+        workspace_name: success.workspace_name,
+    };
+    with_auth_lock(|| write_stored_auth(&auth))?;
+
+    println!("Arcee auth saved.");
+    println!("workspace: {}", auth.workspace_name);
+    println!("base_url: {}", auth.base_url);
+    println!("path: {}", auth_file_path()?.display());
+    Ok(())
+}
+
+pub(super) fn arcee_auth_status() -> Result<()> {
+    let path = auth_file_path()?;
+    let auth = with_auth_lock(read_stored_auth_optional)?;
+    match auth {
+        Some(auth) => {
+            println!("Arcee auth: signed in");
+            println!("workspace: {}", auth.workspace_name);
+            println!("organization: {}", auth.organization_id);
+            println!("base_url: {}", auth.base_url);
+            println!("path: {}", path.display());
+        }
+        None => {
+            println!("Arcee auth: not signed in");
+            println!("path: {}", path.display());
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn arcee_auth_logout() -> Result<()> {
+    let path = auth_file_path()?;
+    let removed = with_auth_lock(|| match read_stored_auth_optional()? {
+        Some(_) => remove_auth_file(),
+        None => Ok(false),
+    })?;
+    if removed {
+        println!("Arcee auth removed.");
+    } else {
+        println!("No Arcee auth found.");
+    }
+    println!("path: {}", path.display());
+    Ok(())
+}
+
+pub(super) fn read_stored_auth() -> Result<StoredArceeAuth> {
+    read_stored_auth_optional()?
+        .ok_or_else(|| anyhow!("Arcee auth is not configured. Run `nac arcee-auth login` to sign in."))
+}
+
+pub(super) fn has_stored_auth() -> bool {
+    matches!(read_stored_auth_optional(), Ok(Some(_)))
+}
+
+fn read_stored_auth_optional() -> Result<Option<StoredArceeAuth>> {
+    let path = auth_file_path()?;
+    let raw = match read_auth_string()? {
+        Some(raw) => raw,
+        None => return Ok(None),
+    };
+    let value: Value =
+        serde_json::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    if value.get("type").and_then(Value::as_str) != Some(AUTH_TYPE) {
+        return Ok(None);
+    }
+    let auth: StoredArceeAuth = serde_json::from_value(value)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(auth))
+}
+
+fn write_stored_auth(auth: &StoredArceeAuth) -> Result<()> {
+    let raw = serde_json::to_string_pretty(auth).context("failed to serialize Arcee auth")?;
+    write_auth_string(&raw)
+}
+
+async fn request_device_code(client: &Client, base: &str) -> Result<DeviceCode> {
+    let url = format!("{base}/app/v1/device/code");
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("User-Agent", user_agent())
+        .json(&json!({ "client_id": CLIENT_ID }))
+        .send()
+        .await
+        .context("failed to request Arcee device code")?;
+
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("failed to read Arcee device-code response")?;
+    if !status.is_success() {
+        return Err(anyhow!(
+            "Arcee device-code request failed with HTTP {}: {}",
+            status.as_u16(),
+            truncate(&body)
+        ));
+    }
+
+    let value: Value =
+        serde_json::from_str(&body).context("failed to parse Arcee device-code response")?;
+    let device_code = string_field(&value, "device_code")?;
+    let user_code = string_field(&value, "user_code")?;
+    let verification_uri_complete = value
+        .get("verification_uri_complete")
+        .or_else(|| value.get("verification_uri"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("Arcee device-code response did not include a verification URI"))?;
+    let interval_secs = value
+        .get("interval")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_INTERVAL_SECS)
+        .max(1);
+    let expires_in_secs = value
+        .get("expires_in")
+        .and_then(Value::as_u64)
+        .unwrap_or(DEFAULT_EXPIRES_IN_SECS);
+
+    Ok(DeviceCode {
+        device_code,
+        user_code,
+        verification_uri_complete,
+        interval_secs,
+        expires_in_secs,
+    })
+}
+
+async fn poll_device_code(
+    client: &Client,
+    base: &str,
+    device: &DeviceCode,
+) -> Result<TokenSuccess> {
+    let url = format!("{base}/app/v1/device/token");
+    let started = now_ms();
+    let mut interval_secs = device.interval_secs;
+
+    loop {
+        let response = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("User-Agent", user_agent())
+            .json(&json!({ "device_code": device.device_code, "client_id": CLIENT_ID }))
+            .send()
+            .await
+            .context("failed to poll Arcee device authorization")?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .context("failed to read Arcee device authorization response")?;
+
+        if status.is_success() {
+            return serde_json::from_str::<TokenSuccess>(&body)
+                .context("failed to parse Arcee device authorization response");
+        }
+
+        let error_code = serde_json::from_str::<Value>(&body)
+            .ok()
+            .and_then(|value| value.get("error").and_then(Value::as_str).map(str::to_string));
+
+        match error_code.as_deref() {
+            Some("authorization_pending") => {}
+            Some("slow_down") => interval_secs = interval_secs.saturating_add(SLOW_DOWN_BACKOFF_SECS),
+            Some("access_denied") => return Err(anyhow!("Arcee authorization was denied")),
+            Some("expired_token") => {
+                return Err(anyhow!(
+                    "Arcee device code expired; run `nac arcee-auth login` again"
+                ))
+            }
+            Some(other) => return Err(anyhow!("Arcee device authorization failed: {other}")),
+            None => {
+                return Err(anyhow!(
+                    "Arcee device authorization failed with HTTP {}: {}",
+                    status.as_u16(),
+                    truncate(&body)
+                ))
+            }
+        }
+
+        if now_ms().saturating_sub(started) >= device.expires_in_secs.saturating_mul(1000) {
+            return Err(anyhow!(
+                "Arcee device authorization timed out; run `nac arcee-auth login` again"
+            ));
+        }
+
+        sleep(Duration::from_secs(interval_secs)).await;
+    }
+}
+
+fn arcee_api_base() -> String {
+    std::env::var("ARCEE_BASE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_BASE_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn string_field(value: &Value, key: &str) -> Result<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("Arcee device-code response did not include {key}"))
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+fn user_agent() -> String {
+    format!("nac/{}", env!("CARGO_PKG_VERSION"))
+}
+
+fn truncate(value: &str) -> String {
+    value.chars().take(500).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stored_auth_round_trips() {
+        let auth = StoredArceeAuth {
+            auth_type: AUTH_TYPE.to_string(),
+            api_key: "rcai-abc".to_string(),
+            base_url: "https://api.arcee.ai".to_string(),
+            organization_id: "org-1".to_string(),
+            workspace_name: "acme".to_string(),
+        };
+        let raw = serde_json::to_string(&auth).unwrap();
+        let value: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(value["type"], "arcee_api_key");
+        assert_eq!(value["api_key"], "rcai-abc");
+        assert_eq!(value["base_url"], "https://api.arcee.ai");
+    }
+}

--- a/crates/nac-core/src/model/arcee.rs
+++ b/crates/nac-core/src/model/arcee.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 const CLIENT_ID: &str = "nac-cli";
 const AUTH_TYPE: &str = "arcee_api_key";
-const DEFAULT_BASE_URL: &str = "http://api.internal.arcee.ai";
+const DEFAULT_BASE_URL: &str = "https://api.arcee.ai";
 const DEFAULT_INTERVAL_SECS: u64 = 5;
 const DEFAULT_EXPIRES_IN_SECS: u64 = 900;
 const SLOW_DOWN_BACKOFF_SECS: u64 = 5;

--- a/crates/nac-core/src/model/arcee.rs
+++ b/crates/nac-core/src/model/arcee.rs
@@ -104,12 +104,12 @@ pub(super) fn arcee_auth_logout() -> Result<()> {
 }
 
 pub(super) fn read_stored_auth() -> Result<StoredArceeAuth> {
-    read_stored_auth_optional()?
+    with_auth_lock(read_stored_auth_optional)?
         .ok_or_else(|| anyhow!("Arcee auth is not configured. Run `nac arcee-auth login` to sign in."))
 }
 
-pub(super) fn has_stored_auth() -> bool {
-    matches!(read_stored_auth_optional(), Ok(Some(_)))
+pub(super) fn stored_auth_present() -> Result<bool> {
+    Ok(with_auth_lock(read_stored_auth_optional)?.is_some())
 }
 
 fn read_stored_auth_optional() -> Result<Option<StoredArceeAuth>> {
@@ -301,5 +301,39 @@ mod tests {
         assert_eq!(value["type"], "arcee_api_key");
         assert_eq!(value["api_key"], "rcai-abc");
         assert_eq!(value["base_url"], "https://api.arcee.ai");
+    }
+
+    #[test]
+    fn stored_auth_present_distinguishes_states() {
+        let _guard = crate::TEST_ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("NAC_HOME");
+        let dir = std::env::temp_dir().join("nac-arcee-stored-auth-present-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let auth = dir.join("auth.json");
+        unsafe {
+            std::env::set_var("NAC_HOME", &dir);
+        }
+
+        let _ = std::fs::remove_file(&auth);
+        assert!(!stored_auth_present().unwrap());
+
+        std::fs::write(&auth, r#"{"type":"chatgpt-codex","access":"a"}"#).unwrap();
+        assert!(!stored_auth_present().unwrap());
+
+        std::fs::write(
+            &auth,
+            r#"{"type":"arcee_api_key","api_key":"rcai-x","base_url":"https://api.arcee.ai","organization_id":"o","workspace_name":"w"}"#,
+        )
+        .unwrap();
+        assert!(stored_auth_present().unwrap());
+
+        std::fs::write(&auth, "{ not valid json").unwrap();
+        assert!(stored_auth_present().is_err());
+
+        let _ = std::fs::remove_file(&auth);
+        match original {
+            Some(value) => unsafe { std::env::set_var("NAC_HOME", value) },
+            None => unsafe { std::env::remove_var("NAC_HOME") },
+        }
     }
 }

--- a/crates/nac-core/src/model/auth_store.rs
+++ b/crates/nac-core/src/model/auth_store.rs
@@ -1,0 +1,134 @@
+use anyhow::{anyhow, Context, Result};
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub(super) fn auth_file_path() -> Result<PathBuf> {
+    crate::paths::nac_home_dir()
+        .map(|dir| dir.join("auth.json"))
+        .ok_or_else(|| anyhow!("could not determine NAC_HOME or HOME for auth storage"))
+}
+
+fn auth_lock_path() -> Result<PathBuf> {
+    Ok(auth_file_path()?.with_extension("auth.json.lock"))
+}
+
+pub(super) fn acquire_auth_lock() -> Result<FileLock> {
+    let path = auth_lock_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    FileLock::acquire(&path)
+}
+
+pub(super) fn with_auth_lock<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock = acquire_auth_lock()?;
+    let result = operation();
+    drop(lock);
+    result
+}
+
+pub(super) fn read_auth_string() -> Result<Option<String>> {
+    let path = auth_file_path()?;
+    match fs::read_to_string(&path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+pub(super) fn write_auth_string(raw: &str) -> Result<()> {
+    let path = auth_file_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&path)
+        .with_context(|| format!("failed to open {}", path.display()))?;
+    use std::io::Write;
+    file.write_all(raw.as_bytes())
+        .with_context(|| format!("failed to write {}", path.display()))?;
+    file.flush()
+        .with_context(|| format!("failed to flush {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to chmod {}", path.display()))?;
+    }
+    Ok(())
+}
+
+pub(super) fn remove_auth_file() -> Result<bool> {
+    let path = auth_file_path()?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
+    }
+}
+
+pub(super) struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(path)
+            .with_context(|| format!("failed to open auth lock {}", path.display()))?;
+        lock_file(&file).with_context(|| format!("failed to lock {}", path.display()))?;
+        Ok(Self { file })
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = unlock_file(&self.file);
+    }
+}
+
+#[cfg(unix)]
+fn lock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn unlock_file(file: &File) -> io::Result<()> {
+    use std::os::unix::io::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_UN) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(unix))]
+fn lock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn unlock_file(_file: &File) -> io::Result<()> {
+    Ok(())
+}

--- a/crates/nac-core/src/model/backend.rs
+++ b/crates/nac-core/src/model/backend.rs
@@ -8,6 +8,7 @@ pub(super) fn default_model_for_backend(backend: BackendKind) -> String {
         BackendKind::FireworksChat => "gpt-5.5".to_string(),
         BackendKind::TogetherChat => "meta-llama/Llama-3.3-70B-Instruct-Turbo".to_string(),
         BackendKind::AnthropicMessages => "claude-opus-4-6".to_string(),
+        BackendKind::Arcee => "trinity-large-thinking".to_string(),
         BackendKind::Auto => unreachable!("auto backend does not have a default model"),
     }
 }
@@ -21,6 +22,7 @@ pub(super) fn default_reasoning_effort(backend: BackendKind) -> Option<Reasoning
         BackendKind::FireworksChat => None,
         BackendKind::TogetherChat => None,
         BackendKind::AnthropicMessages => None,
+        BackendKind::Arcee => None,
         BackendKind::Auto => None,
     }
 }
@@ -31,6 +33,7 @@ pub(super) fn default_base_url_for_backend_hint(backend: BackendKind) -> &'stati
         BackendKind::ChatGptCodexResponses => "https://chatgpt.com/backend-api",
         BackendKind::AnthropicMessages => "https://api.anthropic.com",
         BackendKind::TogetherChat => "https://api.together.ai/v1",
+        BackendKind::Arcee => "http://api.internal.arcee.ai",
         BackendKind::Auto | BackendKind::FireworksChat | BackendKind::OpenAiResponses => {
             "https://api.openai.com/v1"
         }
@@ -42,7 +45,7 @@ pub(super) fn api_key_for_backend(
     configured_env: Option<&str>,
 ) -> Result<String> {
     match backend {
-        BackendKind::ChatGptCodexResponses => Ok(String::new()),
+        BackendKind::ChatGptCodexResponses | BackendKind::Arcee => Ok(String::new()),
         BackendKind::TogetherChat => {
             if let Ok(api_key) = std::env::var("TOGETHER_API_KEY") {
                 return Ok(api_key);
@@ -98,6 +101,9 @@ pub fn detect_backend(base_url: &str) -> Result<BackendKind> {
         .host_str()
         .ok_or_else(|| anyhow!("OPENAI_BASE_URL '{}' does not include a host", base_url))?;
 
+    if host.contains("arcee.ai") {
+        return Ok(BackendKind::Arcee);
+    }
     if host.contains("together.ai") {
         return Ok(BackendKind::TogetherChat);
     }
@@ -118,7 +124,7 @@ pub fn detect_backend(base_url: &str) -> Result<BackendKind> {
     }
 
     Err(anyhow!(
-        "could not infer backend from '{}'; pass --backend deepseek-chat, --backend fireworks-chat, --backend together-chat, --backend openai-responses, --backend chatgpt-codex-responses, or --backend anthropic-messages",
+        "could not infer backend from '{}'; pass --backend deepseek-chat, --backend fireworks-chat, --backend together-chat, --backend openai-responses, --backend chatgpt-codex-responses, --backend anthropic-messages, or --backend arcee",
         base_url
     ))
 }

--- a/crates/nac-core/src/model/backend.rs
+++ b/crates/nac-core/src/model/backend.rs
@@ -33,7 +33,7 @@ pub(super) fn default_base_url_for_backend_hint(backend: BackendKind) -> &'stati
         BackendKind::ChatGptCodexResponses => "https://chatgpt.com/backend-api",
         BackendKind::AnthropicMessages => "https://api.anthropic.com",
         BackendKind::TogetherChat => "https://api.together.ai/v1",
-        BackendKind::Arcee => "http://api.internal.arcee.ai",
+        BackendKind::Arcee => "https://api.arcee.ai",
         BackendKind::Auto | BackendKind::FireworksChat | BackendKind::OpenAiResponses => {
             "https://api.openai.com/v1"
         }

--- a/crates/nac-core/src/model/backend.rs
+++ b/crates/nac-core/src/model/backend.rs
@@ -101,7 +101,7 @@ pub fn detect_backend(base_url: &str) -> Result<BackendKind> {
         .host_str()
         .ok_or_else(|| anyhow!("OPENAI_BASE_URL '{}' does not include a host", base_url))?;
 
-    if host.contains("arcee.ai") {
+    if host == "arcee.ai" || host.ends_with(".arcee.ai") {
         return Ok(BackendKind::Arcee);
     }
     if host.contains("together.ai") {

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -93,10 +93,15 @@ pub async fn codex_auth_login() -> Result<()> {
 
 pub fn codex_auth_logout() -> Result<()> {
     let path = auth_file_path()?;
-    let removed = with_auth_lock(|| match fs::remove_file(&path) {
-        Ok(()) => Ok(true),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
+    let removed = with_auth_lock(|| match read_auth_file_optional()? {
+        Some(_) => match fs::remove_file(&path) {
+            Ok(()) => Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => {
+                Err(error).with_context(|| format!("failed to remove {}", path.display()))
+            }
+        },
+        None => Ok(false),
     })?;
 
     if removed {

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -671,15 +671,13 @@ fn read_auth_file_optional() -> Result<Option<StoredCodexAuth>> {
             return Err(error).with_context(|| format!("failed to read {}", path.display()))
         }
     };
-    let auth: StoredCodexAuth = serde_json::from_str(&raw)
+    let value: Value = serde_json::from_str(&raw)
         .with_context(|| format!("failed to parse {}", path.display()))?;
-    if auth.auth_type != AUTH_TYPE {
-        return Err(anyhow!(
-            "{} contains unsupported auth type '{}'",
-            path.display(),
-            auth.auth_type
-        ));
+    if value.get("type").and_then(Value::as_str) != Some(AUTH_TYPE) {
+        return Ok(None);
     }
+    let auth: StoredCodexAuth = serde_json::from_value(value)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(Some(auth))
 }
 

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -222,7 +222,7 @@ impl ModelClient {
                 serde_json::to_value(&tools).unwrap_or_else(|_| Value::Array(Vec::new()));
         }
 
-        let value = self.post_json_with_retry(&url, &request).await?;
+        let value = self.post_arcee_json_with_retry(&url, &request).await?;
         parse_chat_completions_response(&value, &url)
     }
 
@@ -284,6 +284,16 @@ impl ModelClient {
         let api_key = self.api_key.as_str();
         self.post_json_with_retry_headers(url, body, |request| {
             request.header("Authorization", format!("Bearer {}", api_key))
+        })
+        .await
+    }
+
+    async fn post_arcee_json_with_retry(&self, url: &str, body: &Value) -> Result<Value> {
+        let api_key = self.api_key.as_str();
+        self.post_json_with_retry_headers(url, body, |request| {
+            request
+                .header("Authorization", format!("Bearer {}", api_key))
+                .header("X-Arcee-Client", "nac-cli")
         })
         .await
     }

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -29,16 +29,15 @@ impl ModelClient {
             .clone()
             .or_else(|| std::env::var("OPENAI_BASE_URL").ok());
         let backend = match requested_backend {
-            BackendKind::Auto if explicit_base_url.is_none() && arcee::has_stored_auth() => {
-                BackendKind::Arcee
-            }
             BackendKind::Auto => {
-                let probe = explicit_base_url
-                    .clone()
-                    .unwrap_or_else(|| {
+                if explicit_base_url.is_none() && arcee::stored_auth_present()? {
+                    BackendKind::Arcee
+                } else {
+                    let probe = explicit_base_url.clone().unwrap_or_else(|| {
                         default_base_url_for_backend_hint(BackendKind::Auto).to_string()
                     });
-                detect_backend(&probe)?
+                    detect_backend(&probe)?
+                }
             }
             explicit => explicit,
         };

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -30,7 +30,15 @@ impl ModelClient {
             .or_else(|| std::env::var("OPENAI_BASE_URL").ok());
         let backend = match requested_backend {
             BackendKind::Auto => {
-                if explicit_base_url.is_none() && arcee::stored_auth_present()? {
+                let prefer_arcee = explicit_base_url.is_none()
+                    && match arcee::stored_auth_present() {
+                        Ok(present) => present,
+                        Err(error) => {
+                            eprintln!("nac: ignoring unreadable Arcee auth: {error:#}");
+                            false
+                        }
+                    };
+                if prefer_arcee {
                     BackendKind::Arcee
                 } else {
                     let probe = explicit_base_url.clone().unwrap_or_else(|| {

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -24,16 +24,36 @@ impl ModelClient {
 
     pub fn from_env_with_overrides(overrides: ClientOverrides) -> Result<Self> {
         let requested_backend = overrides.backend.unwrap_or(BackendKind::Auto);
-        let base_url = overrides.base_url.unwrap_or_else(|| {
-            std::env::var("OPENAI_BASE_URL").unwrap_or_else(|_| {
-                default_base_url_for_backend_hint(requested_backend).to_string()
-            })
-        });
+        let explicit_base_url = overrides
+            .base_url
+            .clone()
+            .or_else(|| std::env::var("OPENAI_BASE_URL").ok());
         let backend = match requested_backend {
-            BackendKind::Auto => detect_backend(&base_url)?,
+            BackendKind::Auto if explicit_base_url.is_none() && arcee::has_stored_auth() => {
+                BackendKind::Arcee
+            }
+            BackendKind::Auto => {
+                let probe = explicit_base_url
+                    .clone()
+                    .unwrap_or_else(|| {
+                        default_base_url_for_backend_hint(BackendKind::Auto).to_string()
+                    });
+                detect_backend(&probe)?
+            }
             explicit => explicit,
         };
-        let api_key = api_key_for_backend(backend, overrides.api_key_env.as_deref())?;
+        let mut base_url = explicit_base_url
+            .clone()
+            .unwrap_or_else(|| default_base_url_for_backend_hint(backend).to_string());
+        let mut api_key = api_key_for_backend(backend, overrides.api_key_env.as_deref())?;
+
+        if backend == BackendKind::Arcee {
+            let record = arcee::read_stored_auth()?;
+            api_key = record.api_key;
+            if explicit_base_url.is_none() {
+                base_url = record.base_url;
+            }
+        }
         let model = overrides.model.unwrap_or_else(|| {
             std::env::var("OPENAI_MODEL").unwrap_or_else(|_| default_model_for_backend(backend))
         });
@@ -74,6 +94,7 @@ impl ModelClient {
             BackendKind::DeepSeekChat => self.send_deepseek_chat(messages, tools).await,
             BackendKind::FireworksChat => self.send_fireworks_chat(messages, tools).await,
             BackendKind::TogetherChat => self.send_together_chat(messages, tools).await,
+            BackendKind::Arcee => self.send_arcee_chat(messages, tools).await,
             BackendKind::OpenAiResponses => self.send_openai_responses(messages, tools).await,
             BackendKind::AnthropicMessages => self.send_anthropic_messages(messages, tools).await,
             BackendKind::ChatGptCodexResponses => {
@@ -179,6 +200,30 @@ impl ModelClient {
 
         let value = self.post_json_with_retry(&url, &request).await?;
         parse_together_chat_response(&value, &url)
+    }
+
+    async fn send_arcee_chat(
+        &self,
+        messages: Vec<Message>,
+        tools: Vec<ToolDefinition>,
+    ) -> Result<ModelTurnResponse> {
+        let url = format!("{}/v1/chat/completions", self.base_url.trim_end_matches('/'));
+        let mut request = json!({
+            "model": self.model,
+            "messages": messages
+                .iter()
+                .map(fireworks_message_to_value)
+                .collect::<Vec<_>>(),
+            "temperature": 0.0,
+        });
+
+        if !tools.is_empty() {
+            request["tools"] =
+                serde_json::to_value(&tools).unwrap_or_else(|_| Value::Array(Vec::new()));
+        }
+
+        let value = self.post_json_with_retry(&url, &request).await?;
+        parse_chat_completions_response(&value, &url)
     }
 
     async fn send_deepseek_chat(

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -142,6 +142,37 @@ mod tests {
     }
 
     #[test]
+    fn corrupt_arcee_auth_does_not_block_other_backends() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+
+        let original_key = std::env::var_os("OPENAI_API_KEY");
+        let original_base = std::env::var_os("OPENAI_BASE_URL");
+        let original_model = std::env::var_os("OPENAI_MODEL");
+        let original_home = std::env::var_os("NAC_HOME");
+
+        let home = std::env::temp_dir().join("nac-corrupt-auth-fallback-test");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(home.join("auth.json"), "{ not valid json").unwrap();
+
+        unsafe {
+            std::env::set_var("OPENAI_API_KEY", "test_openai_key");
+            std::env::remove_var("OPENAI_BASE_URL");
+            std::env::remove_var("OPENAI_MODEL");
+            std::env::set_var("NAC_HOME", &home);
+        }
+
+        let client = ModelClient::from_env_with_overrides(ClientOverrides::default())
+            .expect("corrupt Arcee auth must not block an OpenAI run");
+        assert_eq!(client.backend(), BackendKind::OpenAiResponses);
+
+        let _ = std::fs::remove_file(home.join("auth.json"));
+        restore_env("OPENAI_API_KEY", original_key);
+        restore_env("OPENAI_BASE_URL", original_base);
+        restore_env("OPENAI_MODEL", original_model);
+        restore_env("NAC_HOME", original_home);
+    }
+
+    #[test]
     fn detects_backend_from_url() {
         assert_eq!(
             detect_backend("https://api.openai.com/v1").unwrap(),

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -163,6 +163,21 @@ mod tests {
             detect_backend("https://api.together.ai/v1").unwrap(),
             BackendKind::TogetherChat
         );
+        assert_eq!(
+            detect_backend("https://api.arcee.ai").unwrap(),
+            BackendKind::Arcee
+        );
+        assert_eq!(
+            detect_backend("https://api.internal.arcee.ai").unwrap(),
+            BackendKind::Arcee
+        );
+        assert_eq!(
+            detect_backend("https://arcee.ai").unwrap(),
+            BackendKind::Arcee
+        );
+        assert!(detect_backend("https://arcee.ai.evil.com/v1").is_err());
+        assert!(detect_backend("https://evil-arcee.ai.attacker.com/v1").is_err());
+        assert!(detect_backend("https://notarcee.ai").is_err());
         assert!(detect_backend("https://example.com/v1").is_err());
     }
 

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -9,6 +9,8 @@ use url::Url;
 use crate::types::{FunctionCall, Message, ToolCall, ToolDefinition};
 
 mod anthropic;
+mod arcee;
+mod auth_store;
 mod backend;
 mod chat;
 mod chatgpt_codex;
@@ -17,6 +19,7 @@ mod requests;
 mod responses;
 mod types;
 
+use arcee::{arcee_auth_login, arcee_auth_logout, arcee_auth_status};
 pub(crate) use backend::detect_backend;
 use chatgpt_codex::{codex_auth_login, codex_auth_logout, codex_auth_status};
 pub(crate) use client::ModelClient;
@@ -35,6 +38,21 @@ pub async fn run_codex_auth_action(action: CodexAuthAction) -> Result<()> {
         CodexAuthAction::Login => codex_auth_login().await,
         CodexAuthAction::Status => codex_auth_status(),
         CodexAuthAction::Logout => codex_auth_logout(),
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArceeAuthAction {
+    Login,
+    Status,
+    Logout,
+}
+
+pub async fn run_arcee_auth_action(action: ArceeAuthAction) -> Result<()> {
+    match action {
+        ArceeAuthAction::Login => arcee_auth_login().await,
+        ArceeAuthAction::Status => arcee_auth_status(),
+        ArceeAuthAction::Logout => arcee_auth_logout(),
     }
 }
 
@@ -62,8 +80,11 @@ mod tests {
         let _guard = TEST_ENV_LOCK.lock().unwrap();
 
         let original = std::env::var("OPENAI_API_KEY").ok();
+        let original_nac_home = std::env::var_os("NAC_HOME");
+        let empty_home = std::env::temp_dir().join("nac-missing-api-key-test-home");
         unsafe {
             std::env::remove_var("OPENAI_API_KEY");
+            std::env::set_var("NAC_HOME", &empty_home);
         }
 
         let result = ModelClient::from_env();
@@ -87,6 +108,7 @@ mod tests {
                 std::env::remove_var("OPENAI_API_KEY");
             }
         }
+        restore_env("NAC_HOME", original_nac_home);
     }
 
     #[test]

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -14,6 +14,7 @@ pub enum BackendKind {
     ChatGptCodexResponses,
     #[serde(rename = "anthropic-messages")]
     AnthropicMessages,
+    Arcee,
 }
 
 impl BackendKind {
@@ -26,6 +27,7 @@ impl BackendKind {
             Self::OpenAiResponses => "openai-responses",
             Self::ChatGptCodexResponses => "chatgpt-codex-responses",
             Self::AnthropicMessages => "anthropic-messages",
+            Self::Arcee => "arcee",
         }
     }
 }

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -354,6 +354,7 @@ fn parse_backend(raw: Option<String>, base_url: &str) -> Result<BackendKind> {
         Some("openai-responses") => Ok(BackendKind::OpenAiResponses),
         Some("chatgpt-codex-responses") => Ok(BackendKind::ChatGptCodexResponses),
         Some("anthropic-messages") => Ok(BackendKind::AnthropicMessages),
+        Some("arcee") => Ok(BackendKind::Arcee),
         Some(other) => Err(anyhow!("unsupported stored backend '{}'", other)),
         None => detect_backend(base_url),
     }

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -154,6 +154,7 @@
                 <option value="anthropic-messages">anthropic-messages</option>
                 <option value="deepseek-chat">deepseek-chat</option>
                 <option value="fireworks-chat">fireworks-chat</option>
+                <option value="arcee">arcee</option>
               </select>
             </label>
             <label>
@@ -284,6 +285,7 @@
                 <option value="anthropic-messages">anthropic-messages</option>
                 <option value="deepseek-chat">deepseek-chat</option>
                 <option value="fireworks-chat">fireworks-chat</option>
+                <option value="arcee">arcee</option>
               </select>
             </label>
             <label>

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -91,6 +91,8 @@ enum BackendArg {
     ChatGptCodexResponses,
     #[value(name = "anthropic-messages")]
     AnthropicMessages,
+    #[value(name = "arcee")]
+    Arcee,
 }
 
 impl From<BackendArg> for BackendKind {
@@ -103,6 +105,7 @@ impl From<BackendArg> for BackendKind {
             BackendArg::OpenAiResponses => Self::OpenAiResponses,
             BackendArg::ChatGptCodexResponses => Self::ChatGptCodexResponses,
             BackendArg::AnthropicMessages => Self::AnthropicMessages,
+            BackendArg::Arcee => Self::Arcee,
         }
     }
 }

--- a/crates/nac-tui/src/cli/args.rs
+++ b/crates/nac-tui/src/cli/args.rs
@@ -4,7 +4,7 @@ use super::*;
 #[command(
     name = "nac",
     about = "agent",
-    after_help = "Commands:\n  nac resume [SESSION_ID]    Continue a saved session\n  nac codex-auth [COMMAND]   Manage ChatGPT Codex auth\n  nac upgrade                Reinstall the latest nac release"
+    after_help = "Commands:\n  nac resume [SESSION_ID]    Continue a saved session\n  nac codex-auth [COMMAND]   Manage ChatGPT Codex auth\n  nac arcee-auth [COMMAND]   Manage Arcee auth\n  nac upgrade                Reinstall the latest nac release"
 )]
 pub(super) struct RunCli {
     /// Working directory (default: current directory)
@@ -76,6 +76,8 @@ pub(super) enum BackendArg {
     ChatGptCodexResponses,
     #[value(name = "anthropic-messages")]
     AnthropicMessages,
+    #[value(name = "arcee")]
+    Arcee,
 }
 
 impl From<BackendArg> for BackendKind {
@@ -88,6 +90,7 @@ impl From<BackendArg> for BackendKind {
             BackendArg::OpenAiResponses => Self::OpenAiResponses,
             BackendArg::ChatGptCodexResponses => Self::ChatGptCodexResponses,
             BackendArg::AnthropicMessages => Self::AnthropicMessages,
+            BackendArg::Arcee => Self::Arcee,
         }
     }
 }
@@ -258,6 +261,23 @@ pub(super) enum CodexAuthCommand {
 }
 
 #[derive(Parser)]
+#[command(name = "nac arcee-auth", about = "manage Arcee auth")]
+pub(super) struct ArceeAuthCli {
+    #[command(subcommand)]
+    pub(super) command: Option<ArceeAuthCommand>,
+}
+
+#[derive(Subcommand)]
+pub(super) enum ArceeAuthCommand {
+    /// Sign in with Arcee using device code authorization
+    Login,
+    /// Show stored Arcee auth status
+    Status,
+    /// Remove stored Arcee auth
+    Logout,
+}
+
+#[derive(Parser)]
 #[command(name = "nac upgrade", about = "reinstall the latest nac release")]
 pub(super) struct UpgradeCli {
     /// Install directory to replace (default: current nac executable directory)
@@ -270,6 +290,7 @@ pub(super) enum ParsedCli {
     ManagedWorker(ManagedWorkerCli),
     Resume(ResumeCli),
     CodexAuth(CodexAuthCli),
+    ArceeAuth(ArceeAuthCli),
     Upgrade(UpgradeCli),
 }
 
@@ -299,6 +320,14 @@ pub(super) fn parse_cli_from(args: Vec<OsString>) -> ParsedCli {
         ParsedCli::CodexAuth(CodexAuthCli::parse_from(subcommand_args(
             args,
             "nac codex-auth",
+        )))
+    } else if args
+        .get(1)
+        .is_some_and(|value| value == OsStr::new("arcee-auth"))
+    {
+        ParsedCli::ArceeAuth(ArceeAuthCli::parse_from(subcommand_args(
+            args,
+            "nac arcee-auth",
         )))
     } else if args
         .get(1)

--- a/crates/nac-tui/src/cli/mod.rs
+++ b/crates/nac-tui/src/cli/mod.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 
-use nac_core::model::{run_codex_auth_action, BackendKind, CodexAuthAction, ReasoningEffort};
+use nac_core::model::{
+    run_arcee_auth_action, run_codex_auth_action, ArceeAuthAction, BackendKind, CodexAuthAction,
+    ReasoningEffort,
+};
 use nac_core::runtime::{
     self, run_managed_worker, ManagedWorkerOptions, ModelOptions, ResumeOptions, RunOptions,
     RunState, SandboxOptions, StoreOptions, WorkerDispatchOptions,
@@ -25,7 +28,10 @@ pub async fn run() -> Result<()> {
         io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal();
     if !matches!(
         cli,
-        ParsedCli::ManagedWorker(_) | ParsedCli::CodexAuth(_) | ParsedCli::Upgrade(_)
+        ParsedCli::ManagedWorker(_)
+            | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_)
+            | ParsedCli::Upgrade(_)
     ) && !terminal_available
     {
         if matches!(&cli, ParsedCli::Resume(resume_cli) if resume_cli.session_id.is_none() && !resume_cli.last)
@@ -37,6 +43,11 @@ pub async fn run() -> Result<()> {
 
     if let ParsedCli::CodexAuth(cli) = cli {
         run_codex_auth_cli(cli).await?;
+        return Ok(());
+    }
+
+    if let ParsedCli::ArceeAuth(cli) = cli {
+        run_arcee_auth_cli(cli).await?;
         return Ok(());
     }
 
@@ -144,6 +155,7 @@ async fn build_run_state(
             start_in_session_picker: false,
         }),
         ParsedCli::CodexAuth(_) => unreachable!("codex-auth is handled before loading config"),
+        ParsedCli::ArceeAuth(_) => unreachable!("arcee-auth is handled before loading config"),
         ParsedCli::Upgrade(_) => unreachable!("upgrade is handled before loading config"),
     }
 }
@@ -168,6 +180,26 @@ fn codex_auth_action(command: CodexAuthCommand) -> CodexAuthAction {
     }
 }
 
+async fn run_arcee_auth_cli(cli: ArceeAuthCli) -> Result<()> {
+    match cli.command {
+        Some(command) => run_arcee_auth_action(arcee_auth_action(command)).await,
+        None => {
+            let mut command = ArceeAuthCli::command();
+            command.print_help()?;
+            println!();
+            Ok(())
+        }
+    }
+}
+
+fn arcee_auth_action(command: ArceeAuthCommand) -> ArceeAuthAction {
+    match command {
+        ArceeAuthCommand::Login => ArceeAuthAction::Login,
+        ArceeAuthCommand::Status => ArceeAuthAction::Status,
+        ArceeAuthCommand::Logout => ArceeAuthAction::Logout,
+    }
+}
+
 async fn run_upgrade_cli(cli: UpgradeCli) -> Result<()> {
     run_upgrade(UpgradeRequest {
         install_dir: cli.install_dir,
@@ -189,7 +221,9 @@ fn effective_cli_cwd(cli: &ParsedCli, launch_cwd: &Path) -> Result<PathBuf> {
             (Some(_), Some(remote_cwd)) => Ok(remote_cwd.clone()),
             _ => resolve_cli_cwd(launch_cwd, cli.workspace_cwd.as_deref()),
         },
-        ParsedCli::CodexAuth(_) | ParsedCli::Upgrade(_) => Ok(launch_cwd.to_path_buf()),
+        ParsedCli::CodexAuth(_) | ParsedCli::ArceeAuth(_) | ParsedCli::Upgrade(_) => {
+            Ok(launch_cwd.to_path_buf())
+        }
     }
 }
 
@@ -205,7 +239,9 @@ fn effective_cli_config_cwd(
             None => Ok(effective_cwd.to_path_buf()),
         },
         ParsedCli::Run(_) | ParsedCli::Resume(_) => Ok(effective_cwd.to_path_buf()),
-        ParsedCli::CodexAuth(_) | ParsedCli::Upgrade(_) => Ok(launch_cwd.to_path_buf()),
+        ParsedCli::CodexAuth(_) | ParsedCli::ArceeAuth(_) | ParsedCli::Upgrade(_) => {
+            Ok(launch_cwd.to_path_buf())
+        }
     }
 }
 
@@ -334,6 +370,7 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::ManagedWorker(_)
             | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected resume cli")
             }
@@ -351,6 +388,7 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::ManagedWorker(_)
             | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected resume cli")
             }
@@ -392,6 +430,7 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected managed worker cli")
             }
@@ -421,6 +460,7 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected managed worker cli")
             }
@@ -441,6 +481,7 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::ManagedWorker(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected codex-auth cli")
             }
@@ -458,8 +499,42 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::ManagedWorker(_)
+            | ParsedCli::ArceeAuth(_)
             | ParsedCli::Upgrade(_) => {
                 panic!("expected codex-auth cli")
+            }
+        }
+    }
+
+    #[test]
+    fn parse_arcee_auth_command_uses_arcee_auth_cli() {
+        let parsed = parse_cli_from(vec![OsString::from("nac"), OsString::from("arcee-auth")]);
+        match parsed {
+            ParsedCli::ArceeAuth(cli) => assert!(cli.command.is_none()),
+            ParsedCli::Run(_)
+            | ParsedCli::Resume(_)
+            | ParsedCli::ManagedWorker(_)
+            | ParsedCli::CodexAuth(_)
+            | ParsedCli::Upgrade(_) => {
+                panic!("expected arcee-auth cli")
+            }
+        }
+
+        let parsed = parse_cli_from(vec![
+            OsString::from("nac"),
+            OsString::from("arcee-auth"),
+            OsString::from("login"),
+        ]);
+        match parsed {
+            ParsedCli::ArceeAuth(cli) => {
+                assert!(matches!(cli.command, Some(ArceeAuthCommand::Login)))
+            }
+            ParsedCli::Run(_)
+            | ParsedCli::Resume(_)
+            | ParsedCli::ManagedWorker(_)
+            | ParsedCli::CodexAuth(_)
+            | ParsedCli::Upgrade(_) => {
+                panic!("expected arcee-auth cli")
             }
         }
     }
@@ -472,7 +547,8 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::ManagedWorker(_)
-            | ParsedCli::CodexAuth(_) => panic!("expected upgrade cli"),
+            | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_) => panic!("expected upgrade cli"),
         }
 
         let parsed = parse_cli_from(vec![
@@ -488,7 +564,8 @@ mod tests {
             ParsedCli::Run(_)
             | ParsedCli::Resume(_)
             | ParsedCli::ManagedWorker(_)
-            | ParsedCli::CodexAuth(_) => panic!("expected upgrade cli"),
+            | ParsedCli::CodexAuth(_)
+            | ParsedCli::ArceeAuth(_) => panic!("expected upgrade cli"),
         }
     }
 }


### PR DESCRIPTION
NOTE: This PR is directly dependent on another PR in the ArceeFM repo. 

This pull request adds support for the Arcee backend to the codebase, including authentication, backend detection, and chat completion functionality. It introduces a new `arcee` module for device code authentication, updates the backend selection logic to support Arcee, and ensures that Arcee credentials are used when appropriate. The pull request also refactors authentication file handling for generality and security.

**Arcee backend support:**

* Added a new `arcee` module (`arcee.rs`) implementing device code authentication flow, credential storage, and status/logout commands, including file locking for safe concurrent access. [[1]](diffhunk://#diff-31e984246b9709b5876862e0c7845b0b3238ddb9734a064d059a2391cd64f0f6R1-R305) [[2]](diffhunk://#diff-08f0f39deceb97be454bff80f3426dc2d29043cdccb7274945fc9c701836167cR1-R134)
* Integrated Arcee into backend detection, model selection, base URL selection, and API key handling in `backend.rs`. [[1]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaR11) [[2]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaR25) [[3]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaR36) [[4]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaL45-R48) [[5]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaR104-R106) [[6]](diffhunk://#diff-4effd6b42e3c3b52316b2a4521ae19f8975a6c29c1c83da3de71d58594dff7aaL121-R127)
* Updated `ModelClient` to use Arcee credentials and send chat completions to the Arcee API when Arcee is selected as the backend. [[1]](diffhunk://#diff-78ff70a4e540f3dbed065f38c5dea6b927d553c6ccfdf18c770081e6f6960ed1L27-R56) [[2]](diffhunk://#diff-78ff70a4e540f3dbed065f38c5dea6b927d553c6ccfdf18c770081e6f6960ed1R97) [[3]](diffhunk://#diff-78ff70a4e540f3dbed065f38c5dea6b927d553c6ccfdf18c770081e6f6960ed1R205-R228)
* Registered Arcee authentication commands in the module root for CLI access.

**Authentication and file handling improvements:**

* Added a generic `auth_store` module for secure, locked reading/writing of authentication files, used by both Arcee and Codex authentication. [[1]](diffhunk://#diff-08f0f39deceb97be454bff80f3426dc2d29043cdccb7274945fc9c701836167cR1-R134) [[2]](diffhunk://#diff-e9c2108b3c8e90cf7f71d1e616fb630cab235abf297df91cc2d15ecdacccd6aeR12-R13)
* Refactored `chatgpt_codex.rs` to use the new authentication file reading logic, supporting multiple auth types in the same file.

These changes collectively enable seamless use of Arcee as a backend with secure authentication and proper API integration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication storage, default backend resolution, and API key handling; behavior changes when `auth.json` holds non-Codex types, though tests cover host spoofing and corrupt-auth fallback.
> 
> **Overview**
> Adds **Arcee** as a model backend with device-code sign-in via `nac arcee-auth` (login/status/logout), persisted credentials in `NAC_HOME/auth.json`, and chat completions against `/v1/chat/completions` using `Bearer` plus `X-Arcee-Client: nac-cli`.
> 
> **Auto backend selection** now prefers Arcee when stored Arcee auth exists and `OPENAI_BASE_URL` is unset; unreadable `auth.json` is logged and ignored so OpenAI/env backends still work. Explicit `--backend arcee`, URL detection for `*.arcee.ai`, session restore, CLI, and the web UI launch/settings pickers are wired through.
> 
> Introduces shared **`auth_store`** (locked read/write, `0o600` on Unix) for Arcee; **Codex** logout/optional read now only treats `chatgpt-codex` entries as Codex (other types in the same file are ignored instead of erroring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02ff01f6482b7844133b9f7d3b047658ba153e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->