### PR TITLE
Add /btw side questions during active runs

### DIFF
--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -17,6 +17,7 @@ pub use crate::events::{
     SessionClientId, SessionEventEnvelope, SessionEventReceiver, SessionEventReplaySubscription,
     SessionEventSubscription, SessionRunId, SessionSubscriptionId, SubmittedUserMessageSnapshot,
 };
+use crate::model::ModelClient;
 use crate::runtime::{OrchestratorRunConfig, OrchestratorSession};
 use crate::sessions::{self, SessionSnapshot};
 use crate::types::Message;
@@ -26,6 +27,10 @@ use crate::view::{
 };
 
 pub type AgentEventReceiver = mpsc::UnboundedReceiver<AgentEvent>;
+
+const SIDE_QUESTION_CONTEXT_MAX_CHARS: usize = 8_000;
+const SIDE_QUESTION_CONTEXT_MAX_THREADS: usize = 8;
+const SIDE_QUESTION_CONTEXT_MAX_EVENTS: usize = 512;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionMetadata {
@@ -263,6 +268,7 @@ impl SessionClientHandle {
 #[derive(Clone)]
 pub struct SessionService {
     agent: Arc<Mutex<Agent>>,
+    side_question_client: ModelClient,
     metadata: Arc<SessionMetadata>,
     session_snapshot: Arc<Mutex<Option<SessionSnapshot>>>,
     event_bus: SessionEventBus,
@@ -332,6 +338,7 @@ impl SessionService {
         let active_threads = run_config.agent.active_threads_handle();
         let service = Self {
             agent: Arc::new(Mutex::new(run_config.agent)),
+            side_question_client: run_config.client,
             metadata: Arc::new(metadata.clone()),
             session_snapshot: Arc::new(Mutex::new(session_snapshot)),
             event_bus,
@@ -547,6 +554,59 @@ impl SessionService {
             worksets: self.worksets_snapshot(),
             workspace: self.workspace_snapshot(),
         })
+    }
+
+    /// Answer a one-turn side question without changing the durable session or
+    /// competing with the active agent for its tool runtime. This is the
+    /// server-side equivalent of Claude Code's `/btw` command.
+    pub async fn answer_side_question(&self, question: &str) -> Result<String> {
+        let question = question.trim();
+        if question.is_empty() {
+            anyhow::bail!("side question is empty");
+        }
+
+        // Persisted messages provide the stable conversation context while a
+        // run may be mutating the live agent history. The side turn is sent
+        // without tools and is never appended or persisted.
+        let mut messages = self
+            .session_snapshot
+            .lock()
+            .await
+            .as_ref()
+            .map(|snapshot| snapshot.messages.clone())
+            .unwrap_or_default();
+        let active_run = self.active_run();
+        if let Some(submitted) = active_run
+            .as_ref()
+            .and_then(|run| run.submitted_user_message.as_ref())
+        {
+            messages.push(crate::types::Message::User {
+                content: submitted.content.clone(),
+            });
+        }
+        let active_threads = self.active_thread_names().await;
+        let recent_events = self.recent_events(None, SIDE_QUESTION_CONTEXT_MAX_EVENTS);
+        let thread_episodes = self.all_thread_episodes()?;
+        let live_context = render_side_question_live_context(
+            active_run.as_ref(),
+            &active_threads,
+            &recent_events,
+            &thread_episodes,
+        );
+        messages.push(crate::types::Message::User {
+            content: format!(
+                "This is a one-turn side question. Answer it directly using the conversation context and read-only live snapshot below. The snapshot may change after capture. Do not propose edits, run tools, or continue the main task.\n\n{live_context}\n\nSide question: {question}"
+            ),
+        });
+        let response = self
+            .side_question_client
+            .send_turn(messages, Vec::new())
+            .await?;
+        response
+            .assistant
+            .content
+            .filter(|content| !content.trim().is_empty())
+            .ok_or_else(|| anyhow::anyhow!("side question returned no text"))
     }
 
     pub fn try_submit_prompt(
@@ -998,6 +1058,125 @@ fn prompt_preview(value: &str, max_chars: usize) -> String {
     preview
 }
 
+fn render_side_question_live_context(
+    active_run: Option<&ActiveRunSnapshot>,
+    active_threads: &[String],
+    recent_events: &[SessionEventEnvelope],
+    thread_episodes: &HashMap<String, Vec<EpisodeSnapshot>>,
+) -> String {
+    let mut context =
+        String::from("Read-only live run snapshot captured for this side question:\n");
+    match active_run {
+        Some(run) => {
+            context.push_str("Run active: yes\n");
+            context.push_str("Main task: ");
+            context.push_str(&run.prompt_preview);
+            context.push('\n');
+        }
+        None => context.push_str("Run active: no\n"),
+    }
+
+    let (running_threads, queued_threads, finished_threads) =
+        side_question_thread_states(active_run, active_threads, recent_events);
+    push_thread_list(&mut context, "Running workers", &running_threads);
+    push_thread_list(&mut context, "Queued workers", &queued_threads);
+    push_thread_list(
+        &mut context,
+        "Finished workers still in the current dispatch batch",
+        &finished_threads,
+    );
+
+    let mut latest_episodes = thread_episodes
+        .iter()
+        .filter_map(|(name, episodes)| episodes.last().map(|episode| (name, episode)))
+        .collect::<Vec<_>>();
+    latest_episodes.sort_by(|(left, _), (right, _)| left.cmp(right));
+    context.push_str("Latest retained worker summaries:\n");
+    if latest_episodes.is_empty() {
+        context.push_str("none\n");
+    } else {
+        for (name, episode) in latest_episodes
+            .into_iter()
+            .take(SIDE_QUESTION_CONTEXT_MAX_THREADS)
+        {
+            context.push_str("- ");
+            context.push_str(name);
+            context.push_str("\n  Action: ");
+            context.push_str(&prompt_preview(&episode.action, 240));
+            context.push_str("\n  Result: ");
+            context.push_str(&prompt_preview(&episode.content, 1_200));
+            context.push('\n');
+        }
+    }
+
+    truncate_chars(&context, SIDE_QUESTION_CONTEXT_MAX_CHARS)
+}
+
+fn side_question_thread_states(
+    active_run: Option<&ActiveRunSnapshot>,
+    active_threads: &[String],
+    recent_events: &[SessionEventEnvelope],
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let Some(active_run) = active_run else {
+        return (Vec::new(), Vec::new(), Vec::new());
+    };
+    let mut states = HashMap::new();
+    for envelope in recent_events {
+        if envelope.run_id.as_ref() != Some(&active_run.run_id) {
+            continue;
+        }
+        let SessionEvent::Agent { event } = &envelope.event else {
+            continue;
+        };
+        match event {
+            AgentEvent::ThreadStarted { name, .. } => {
+                states.insert(name.as_str(), true);
+            }
+            AgentEvent::ThreadFinished { name, .. } => {
+                states.insert(name.as_str(), false);
+            }
+            _ => {}
+        }
+    }
+
+    let mut running = Vec::new();
+    let mut queued = Vec::new();
+    let mut finished = Vec::new();
+    for name in active_threads {
+        match states.get(name.as_str()) {
+            Some(true) => running.push(name.clone()),
+            Some(false) => finished.push(name.clone()),
+            None => queued.push(name.clone()),
+        }
+    }
+    running.sort();
+    queued.sort();
+    finished.sort();
+    (running, queued, finished)
+}
+
+fn push_thread_list(context: &mut String, label: &str, threads: &[String]) {
+    context.push_str(&format!("{label} ({}): ", threads.len()));
+    if threads.is_empty() {
+        context.push_str("none\n");
+    } else {
+        context.push_str(&threads.join(", "));
+        context.push('\n');
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+    let mut truncated = value.chars().take(max_chars - 1).collect::<String>();
+    truncated.push('…');
+    truncated
+}
+
 fn duration_ms(duration: Duration) -> u64 {
     duration.as_millis().min(u64::MAX as u128) as u64
 }
@@ -1178,6 +1357,120 @@ mod tests {
             }
             other => panic!("expected run started, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn side_question_live_context_includes_current_workers_and_latest_episodes() {
+        let active_run = ActiveRunSnapshot {
+            run_id: SessionRunId::new(),
+            client_id: None,
+            prompt_preview: "Inspect the dashboard architecture".to_string(),
+            submitted_user_message: None,
+            started_at_epoch_ms: 123,
+        };
+        let mut episodes = HashMap::new();
+        episodes.insert(
+            "qa_routes".to_string(),
+            vec![
+                EpisodeSnapshot {
+                    id: 1,
+                    thread_name: "qa_routes".to_string(),
+                    session_id: "session".to_string(),
+                    action: "old action".to_string(),
+                    content: "old result".to_string(),
+                    created_at: "earlier".to_string(),
+                },
+                EpisodeSnapshot {
+                    id: 2,
+                    thread_name: "qa_routes".to_string(),
+                    session_id: "session".to_string(),
+                    action: "trace server routes".to_string(),
+                    content: "found the side-question route".to_string(),
+                    created_at: "later".to_string(),
+                },
+            ],
+        );
+
+        let context = render_side_question_live_context(
+            Some(&active_run),
+            &["qa_wait".to_string(), "qa_routes".to_string()],
+            &[
+                SessionEventEnvelope {
+                    session_id: Some("session".to_string()),
+                    sequence_id: 1,
+                    client_id: None,
+                    run_id: Some(active_run.run_id.clone()),
+                    event: SessionEvent::Agent {
+                        event: AgentEvent::ThreadStarted {
+                            name: "qa_routes".to_string(),
+                            action: "trace server routes".to_string(),
+                            source_threads: Vec::new(),
+                        },
+                    },
+                },
+                SessionEventEnvelope {
+                    session_id: Some("session".to_string()),
+                    sequence_id: 2,
+                    client_id: None,
+                    run_id: Some(active_run.run_id.clone()),
+                    event: SessionEvent::Agent {
+                        event: AgentEvent::ThreadFinished {
+                            name: "qa_routes".to_string(),
+                            exit_code: 0,
+                            timed_out: false,
+                            timeout_reason: None,
+                            usage: None,
+                        },
+                    },
+                },
+                SessionEventEnvelope {
+                    session_id: Some("session".to_string()),
+                    sequence_id: 3,
+                    client_id: None,
+                    run_id: Some(active_run.run_id.clone()),
+                    event: SessionEvent::Agent {
+                        event: AgentEvent::ThreadStarted {
+                            name: "qa_wait".to_string(),
+                            action: "continue inspecting".to_string(),
+                            source_threads: Vec::new(),
+                        },
+                    },
+                },
+            ],
+            &episodes,
+        );
+
+        assert!(context.contains("Run active: yes"));
+        assert!(context.contains("Main task: Inspect the dashboard architecture"));
+        assert!(context.contains("Running workers (1): qa_wait"));
+        assert!(context.contains("Queued workers (0): none"));
+        assert!(context.contains(
+            "Finished workers still in the current dispatch batch (1): qa_routes"
+        ));
+        assert!(context.contains("Action: trace server routes"));
+        assert!(context.contains("Result: found the side-question route"));
+        assert!(!context.contains("old result"));
+    }
+
+    #[test]
+    fn side_question_live_context_is_bounded() {
+        let mut episodes = HashMap::new();
+        episodes.insert(
+            "qa_large".to_string(),
+            vec![EpisodeSnapshot {
+                id: 1,
+                thread_name: "qa_large".to_string(),
+                session_id: "session".to_string(),
+                action: "inspect".repeat(100),
+                content: "result".repeat(2_000),
+                created_at: "now".to_string(),
+            }],
+        );
+
+        let context = render_side_question_live_context(None, &[], &[], &episodes);
+
+        assert!(context.chars().count() <= SIDE_QUESTION_CONTEXT_MAX_CHARS);
+        assert!(context.contains("Run active: no"));
     }
 
     #[test]

--- a/crates/nac-server/assets/app.css
+++ b/crates/nac-server/assets/app.css
@@ -2642,3 +2642,13 @@ button.session-card {
   .thread-card-details .dense-detail-row { grid-template-columns: minmax(0, 1fr); }
   .thread-card-details pre { max-height: 40dvh; }
 }
+
+@media (max-width: 520px) {
+  .inspector-head {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .inspector-actions {
+    justify-self: end;
+  }
+}

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -120,6 +120,7 @@ function bindElements() {
     "paneSeparator",
     "inspectorTitle",
     "inspectorMeta",
+    "btwTrigger",
     "cancelRun",
     "mobileBack",
     "tabs",
@@ -132,6 +133,11 @@ function bindElements() {
     "transcript",
     "promptForm",
     "promptInput",
+    "btwOverlay",
+    "closeBtw",
+    "btwForm",
+    "btwQuestion",
+    "btwAnswer",
     "eventStreamStatus",
     "eventLog",
     "threadsView",
@@ -174,6 +180,12 @@ function bindEvents() {
   el.launchSshHost.addEventListener("input", renderLaunchHostFields);
   el.promptForm.addEventListener("submit", submitPrompt);
   el.promptInput.addEventListener("keydown", handlePromptKeydown);
+  el.closeBtw.addEventListener("click", hideBtwOverlay);
+  el.btwOverlay.addEventListener("click", (event) => {
+    if (event.target === el.btwOverlay) hideBtwOverlay();
+  });
+  el.btwForm.addEventListener("submit", submitBtw);
+  el.btwTrigger.addEventListener("click", showBtwOverlay);
   el.cancelRun.addEventListener("click", cancelActiveRun);
   el.deleteSessionBtn.addEventListener("click", () => {
     if (state.selectedId) deleteSession(state.selectedId);
@@ -912,6 +924,38 @@ function handlePromptKeydown(event) {
   if (event.key !== "Enter" || (!event.metaKey && !event.ctrlKey)) return;
   event.preventDefault();
   el.promptForm.requestSubmit();
+}
+
+function showBtwOverlay() {
+  if (!state.selectedId || !sessionHasActiveRun(state.selectedId)) return;
+  el.btwAnswer.hidden = true;
+  el.btwAnswer.textContent = "";
+  el.btwQuestion.value = "";
+  el.btwOverlay.hidden = false;
+  requestAnimationFrame(() => el.btwQuestion.focus());
+}
+
+function hideBtwOverlay() {
+  el.btwOverlay.hidden = true;
+}
+
+async function submitBtw(event) {
+  event.preventDefault();
+  const sessionId = state.selectedId;
+  const question = el.btwQuestion.value.trim();
+  if (!sessionId || !question) return;
+  const submit = el.btwForm.querySelector("button[type=submit]");
+  submit.disabled = true;
+  el.btwAnswer.hidden = false;
+  el.btwAnswer.textContent = "Thinking…";
+  try {
+    const result = await apiPost(`/sessions/${encodeURIComponent(sessionId)}/side-question`, { question });
+    el.btwAnswer.textContent = result.answer;
+  } catch (error) {
+    el.btwAnswer.textContent = `Could not answer side question: ${error.message}`;
+  } finally {
+    submit.disabled = false;
+  }
 }
 
 async function cancelActiveRun() {
@@ -2252,6 +2296,7 @@ function renderInspector() {
     el.snapRun.textContent = "idle";
     el.snapTokens.textContent = "--";
     el.snapContext.textContent = "--";
+    el.btwTrigger.disabled = true;
     el.cancelRun.disabled = true;
     el.deleteSessionBtn.disabled = !selectedEntry;
     el.renameSessionBtn.disabled = !selectedEntry;
@@ -2287,6 +2332,7 @@ function renderInspector() {
     const lastDur = snapshot.response_timing?.last_response_duration_ms;
     el.snapRun.textContent = lastDur != null ? formatDuration(lastDur) : "idle";
   }
+  el.btwTrigger.disabled = !runActive;
   el.cancelRun.disabled = !runActive;
   el.deleteSessionBtn.disabled = false;
   el.renameSessionBtn.disabled = false;

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -85,6 +85,13 @@
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
               </svg>
             </button>
+            <button id="btwTrigger" class="icon-button" type="button" aria-label="Ask side question (/btw)" title="Ask side question (/btw)" disabled>
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
+                <path d="M9.1 9a3 3 0 0 1 5.8 1c0 2-2.9 3-2.9 3"></path>
+                <path d="M12 17h.01"></path>
+              </svg>
+            </button>
             <button id="cancelRun" class="icon-button icon-button-destructive" type="button" aria-label="Stop active run" title="Stop active run">
               <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
                 <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
@@ -143,6 +150,20 @@
           <div id="workspaceView" class="dense-list"></div>
         </div>
       </aside>
+    </div>
+
+    <div class="launch-overlay" id="btwOverlay" hidden>
+      <section class="launch-dialog launch-dialog--compact" role="dialog" aria-modal="true" aria-labelledby="btwDialogTitle">
+        <header class="launch-dialog-head">
+          <div><div class="eyebrow" id="btwDialogTitle">/btw · Side question</div></div>
+          <button id="closeBtw" class="icon-button" type="button" aria-label="Close side question" title="Close">×</button>
+        </header>
+        <form id="btwForm" class="launch-form">
+          <label for="btwQuestion"><span>Ask without interrupting the run</span><textarea id="btwQuestion" rows="3" spellcheck="false" placeholder="What does the retry logic do?"></textarea></label>
+          <div class="launch-actions"><button id="submitBtw" class="primary-action" type="submit">Ask</button></div>
+        </form>
+        <div id="btwAnswer" class="confirm-text" role="status" aria-live="polite" hidden></div>
+      </section>
     </div>
 
     <div class="launch-overlay" id="renameOverlay" hidden>

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -168,6 +168,16 @@ pub struct SubmitPromptResponse {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct SideQuestionRequest {
+    pub question: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SideQuestionResponse {
+    pub answer: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct EventsQuery {
     pub after_sequence_id: Option<u64>,
     pub limit: Option<usize>,
@@ -526,6 +536,17 @@ impl SessionManager {
         }
     }
 
+    pub async fn answer_side_question(
+        &self,
+        session_id: &str,
+        request: SideQuestionRequest,
+    ) -> Result<SideQuestionResponse> {
+        let service = self.attach_session(session_id).await?;
+        Ok(SideQuestionResponse {
+            answer: service.answer_side_question(&request.question).await?,
+        })
+    }
+
     pub async fn recent_events(
         &self,
         session_id: &str,
@@ -745,6 +766,7 @@ pub fn router(manager: SessionManager) -> Router {
             patch(update_config_handler),
         )
         .route("/sessions/{session_id}/runs", post(submit_prompt))
+        .route("/sessions/{session_id}/side-question", post(side_question))
         .route("/sessions/{session_id}/events", get(recent_events))
         .route("/sessions/{session_id}/events/stream", get(stream_events))
         .route(
@@ -902,6 +924,16 @@ async fn submit_prompt(
     Ok((
         StatusCode::ACCEPTED,
         Json(manager.submit_prompt(&session_id, request).await?),
+    ))
+}
+
+async fn side_question(
+    State(manager): State<SessionManager>,
+    AxumPath(session_id): AxumPath<String>,
+    Json(request): Json<SideQuestionRequest>,
+) -> std::result::Result<Json<SideQuestionResponse>, ApiError> {
+    Ok(Json(
+        manager.answer_side_question(&session_id, request).await?,
     ))
 }
 


### PR DESCRIPTION
## Summary

- add a compact `/btw` icon button and side-question dialog to active session controls
- answer side questions through a separate, tool-free model turn while the primary run continues
- provide that turn with a bounded read-only snapshot of the main task, current worker lifecycle, and latest retained worker summaries
- keep side questions transient so they do not enter the main transcript or durable message history
- preserve the existing Game of Life waiting visualization unchanged

## Why

Users sometimes need to ask a context-dependent question while a long NAC run is still active. This adds a minimal way to do that without interrupting the orchestrator or creating a second durable conversation.

The live snapshot is point-in-time and capped at 8,000 characters, eight worker summaries, and 512 recent lifecycle events. It does not expose tools or mutate the run.

## Validation

Manual browser QA used ChatGPT Codex OAuth with `chatgpt-codex-responses`, `gpt-5.5`, a temporary SQLite store, and `127.0.0.1:3211`.

- verified the button is enabled only during an active general session
- verified `/btw` correctly distinguished one running worker from one finished worker and used its retained summary
- verified the primary run remained active and the durable message count stayed at 2
- verified closing and reloading removed the side question and answer
- verified normal Cancel Run still works afterward
- verified no browser console warnings or errors
- verified desktop and narrow/mobile layouts

Commands:

```text
node --check crates/nac-server/assets/app.js
node --test crates/nac-server/assets/app.test.js
cargo test -p nac-core --lib
cargo test -p nac-server --lib
git diff --check
```

Results: 275 core tests passed (2 API-key live tests ignored), 15 server tests passed, and 2 frontend tests passed.