### PR TITLE
Harden NAC web origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,9 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tower-http",
+ "url",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,24 @@ Open `http://127.0.0.1:3210/` for the dense session dashboard. `nac-web` exposes
 - `GET /sessions/{session_id}/events/stream?after_sequence_id=0`
 - `POST /sessions/{session_id}/cancel-active-run`
 
+The default bind is loopback-only and allows the exact
+`http://127.0.0.1:3210` browser origin. When a trusted reverse proxy exposes
+the dashboard at another origin, configure that exact origin (scheme, host,
+and optional port; no path):
+
+```sh
+NAC_PUBLIC_BASE_URL=https://nac.example.com nac-web -C /path/to/project
+```
+
+Use repeated `--allowed-origin` flags, or a comma-separated
+`NAC_ALLOWED_ORIGINS`, only when additional browser origins must call the API.
+Unsafe browser requests are rejected unless their `Origin` is allowed and
+their `Sec-Fetch-Site` value, when present, is `same-origin`. Local CLI/API
+clients that do not send browser-origin headers continue to work. A
+non-loopback `--bind` requires an explicit public base URL or allowed origin;
+put authentication and TLS in front of nac-web rather than exposing it
+directly.
+
 `AGENTS.md` is loaded hierarchically from the project and globally from `NAC_HOME` / `~/.config/nac`. Skills are discovered from project and user skill directories; the orchestrator sees compact skill metadata and preloads selected skills for worker threads, while workers do not activate skills themselves. nac ignores `disable-model-invocation`; avoid interactive skills because nac is intended to run rather autonomously. Sessions are stored in the project store (`.nac/store.db` by default): use `nac resume` for the picker, `nac resume --last` for the newest session, or `nac resume SESSION_ID` for a specific session. Thread history does not auto-compact right now.
 
 Uninstall:

--- a/crates/nac-server/Cargo.toml
+++ b/crates/nac-server/Cargo.toml
@@ -15,9 +15,13 @@ nac-core = { path = "../nac-core" }
 anyhow = "1"
 async-stream = "0.3"
 axum = "0.8"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 futures-core = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tower-http = { version = "0.6", features = ["cors"] }
+url = "2"
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     convert::Infallible,
     net::SocketAddr,
     path::PathBuf,
@@ -10,8 +10,9 @@ use std::{
 use anyhow::{anyhow, Context, Result};
 use async_stream::stream;
 use axum::{
-    extract::{Path as AxumPath, Query, State},
-    http::{header, StatusCode},
+    extract::{Path as AxumPath, Query, Request, State},
+    http::{header, HeaderValue, Method, StatusCode},
+    middleware::{self, Next},
     response::{
         sse::{Event, KeepAlive, Sse},
         Html, IntoResponse, Response,
@@ -34,6 +35,7 @@ use nac_core::{
 use serde::{Deserialize, Serialize};
 use tokio::{net::TcpListener, sync::RwLock};
 use tower_http::cors::CorsLayer;
+use url::Url;
 
 const DEFAULT_REPLAY_LIMIT: usize = 256;
 const WORKSPACE_DIFF_CACHE_TTL: Duration = Duration::from_secs(3);
@@ -43,6 +45,78 @@ pub struct ServerOptions {
     pub root_cwd: PathBuf,
     pub store_path: Option<PathBuf>,
     pub worker_executable: Option<PathBuf>,
+}
+
+/// Browser-facing security configuration for `nac-web`.
+///
+/// The public base URL and every additional allowed origin must be an exact
+/// HTTP(S) origin: scheme, host, and optional port only. Loopback binds also
+/// allow their own `http://<bind-address>` origin so local and SSM-forwarded
+/// dashboard access keeps working.
+#[derive(Debug, Clone, Default)]
+pub struct WebSecurityOptions {
+    pub public_base_url: Option<Url>,
+    pub allowed_origins: Vec<Url>,
+}
+
+#[derive(Debug, Clone)]
+struct WebSecurityPolicy {
+    allowed_origins: Arc<BTreeSet<String>>,
+    cors_origins: Vec<HeaderValue>,
+}
+
+impl WebSecurityOptions {
+    fn resolve(&self, bind_addr: SocketAddr) -> Result<WebSecurityPolicy> {
+        let mut allowed_origins = BTreeSet::new();
+
+        if bind_addr.ip().is_loopback() {
+            allowed_origins.insert(format!("http://{bind_addr}"));
+        }
+        if let Some(public_base_url) = &self.public_base_url {
+            allowed_origins.insert(exact_http_origin(public_base_url, "public base URL")?);
+        }
+        for allowed_origin in &self.allowed_origins {
+            allowed_origins.insert(exact_http_origin(allowed_origin, "allowed origin")?);
+        }
+
+        if allowed_origins.is_empty() {
+            anyhow::bail!(
+                "non-loopback binds require --public-base-url or at least one --allowed-origin"
+            );
+        }
+
+        let cors_origins = allowed_origins
+            .iter()
+            .map(|origin| {
+                origin
+                    .parse::<HeaderValue>()
+                    .with_context(|| format!("invalid HTTP origin header value '{origin}'"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(WebSecurityPolicy {
+            allowed_origins: Arc::new(allowed_origins),
+            cors_origins,
+        })
+    }
+}
+
+fn exact_http_origin(url: &Url, label: &str) -> Result<String> {
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!("{label} must use http or https: {url}");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        anyhow::bail!("{label} must not contain user information: {url}");
+    }
+    if url.path() != "/" || url.query().is_some() || url.fragment().is_some() {
+        anyhow::bail!("{label} must contain only scheme, host, and optional port: {url}");
+    }
+
+    let origin = url.origin().ascii_serialization();
+    if origin == "null" {
+        anyhow::bail!("{label} must have a network host: {url}");
+    }
+    Ok(origin)
 }
 
 #[derive(Clone)]
@@ -639,7 +713,33 @@ impl SessionManager {
 }
 
 pub fn router(manager: SessionManager) -> Router {
-    Router::new()
+    router_with_options(
+        manager,
+        SocketAddr::from(([127, 0, 0, 1], 3210)),
+        WebSecurityOptions::default(),
+    )
+    .expect("default loopback web security options must be valid")
+}
+
+pub fn router_with_options(
+    manager: SessionManager,
+    bind_addr: SocketAddr,
+    web_security: WebSecurityOptions,
+) -> Result<Router> {
+    let policy = web_security.resolve(bind_addr)?;
+    let cors = CorsLayer::new()
+        .allow_origin(policy.cors_origins.clone())
+        .allow_methods([
+            Method::GET,
+            Method::HEAD,
+            Method::POST,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([header::ACCEPT, header::CONTENT_TYPE]);
+
+    Ok(Router::new()
         .route("/", get(index_html))
         .route("/app", get(index_html))
         .route("/assets/app.css", get(app_css))
@@ -662,17 +762,92 @@ pub fn router(manager: SessionManager) -> Router {
             "/sessions/{session_id}/cancel-active-run",
             post(cancel_active_run),
         )
-        .layer(CorsLayer::permissive())
-        .with_state(manager)
+        .layer(cors)
+        .layer(middleware::from_fn_with_state(
+            policy,
+            enforce_browser_same_origin,
+        ))
+        .with_state(manager))
 }
 
 pub async fn serve(addr: SocketAddr, manager: SessionManager) -> Result<()> {
+    serve_with_options(addr, manager, WebSecurityOptions::default()).await
+}
+
+pub async fn serve_with_options(
+    addr: SocketAddr,
+    manager: SessionManager,
+    web_security: WebSecurityOptions,
+) -> Result<()> {
+    let app = router_with_options(manager, addr, web_security)?;
     let listener = TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind {}", addr))?;
-    axum::serve(listener, router(manager))
+    axum::serve(listener, app)
         .await
         .context("server stopped unexpectedly")
+}
+
+async fn enforce_browser_same_origin(
+    State(policy): State<WebSecurityPolicy>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if is_safe_method(request.method()) {
+        return next.run(request).await;
+    }
+
+    let headers = request.headers();
+    let origin_values = headers.get_all(header::ORIGIN);
+    if origin_values.iter().count() > 1 {
+        return forbidden_browser_request("multiple Origin headers are not allowed");
+    }
+    let fetch_site_values = headers.get_all("sec-fetch-site");
+    if fetch_site_values.iter().count() > 1 {
+        return forbidden_browser_request("multiple Sec-Fetch-Site headers are not allowed");
+    }
+
+    let origin = origin_values.iter().next();
+    let fetch_site = fetch_site_values.iter().next();
+
+    // Non-browser clients such as the local CLI generally send neither
+    // browser header. Preserve that local API behavior while validating any
+    // request that presents browser-origin metadata.
+    if origin.is_none() && fetch_site.is_none() {
+        return next.run(request).await;
+    }
+
+    if let Some(fetch_site) = fetch_site {
+        if fetch_site.to_str().ok() != Some("same-origin") {
+            return forbidden_browser_request("unsafe browser requests must be same-origin");
+        }
+    }
+
+    if let Some(origin) = origin {
+        let Ok(origin) = origin.to_str() else {
+            return forbidden_browser_request("Origin header is not valid text");
+        };
+        if !policy.allowed_origins.contains(origin) {
+            return forbidden_browser_request("Origin is not allowed");
+        }
+    }
+
+    next.run(request).await
+}
+
+fn is_safe_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET | Method::HEAD | Method::OPTIONS | Method::TRACE
+    )
+}
+
+fn forbidden_browser_request(message: &'static str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({ "error": message })),
+    )
+        .into_response()
 }
 
 async fn health() -> Json<serde_json::Value> {
@@ -1019,6 +1194,8 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use tower::ServiceExt;
 
     #[test]
     fn parses_model_option_enums_from_api_strings() {
@@ -1082,6 +1259,24 @@ mod tests {
         .expect("session manager")
     }
 
+    fn test_router_with_public_origin(root: &std::path::Path) -> Router {
+        router_with_options(
+            test_manager(root),
+            SocketAddr::from(([127, 0, 0, 1], 3210)),
+            WebSecurityOptions {
+                public_base_url: Some(Url::parse("https://nac.example.com").unwrap()),
+                allowed_origins: Vec::new(),
+            },
+        )
+        .expect("test router")
+    }
+
+    fn cancel_request() -> axum::http::request::Builder {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/sessions/missing/cancel-active-run")
+    }
+
     #[test]
     fn create_session_request_deserializes_optional_ssh_host() {
         let with_host: CreateSessionRequest =
@@ -1121,6 +1316,144 @@ mod tests {
         assert!(error.to_string().contains("ssh_host and sandbox"));
         assert_eq!(ApiError::from(error).status, StatusCode::BAD_REQUEST);
 
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn web_security_rejects_non_loopback_bind_without_an_origin() {
+        let error = WebSecurityOptions::default()
+            .resolve(SocketAddr::from(([0, 0, 0, 0], 3210)))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("non-loopback binds require --public-base-url"));
+    }
+
+    #[test]
+    fn web_security_requires_an_exact_origin_without_a_path() {
+        let options = WebSecurityOptions {
+            public_base_url: Some(Url::parse("https://nac.example.com/dashboard").unwrap()),
+            allowed_origins: Vec::new(),
+        };
+        let error = options
+            .resolve(SocketAddr::from(([127, 0, 0, 1], 3210)))
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("scheme, host, and optional port"));
+    }
+
+    #[tokio::test]
+    async fn unsafe_local_api_request_without_browser_headers_is_allowed() {
+        let root = temp_root("local_api_security");
+        let response = test_router_with_public_origin(&root)
+            .oneshot(cancel_request().body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn unsafe_browser_request_from_default_loopback_origin_is_allowed() {
+        let root = temp_root("loopback_origin_security");
+        let response = router(test_manager(&root))
+            .oneshot(
+                cancel_request()
+                    .header(header::ORIGIN, "http://127.0.0.1:3210")
+                    .header("sec-fetch-site", "same-origin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn unsafe_browser_request_from_allowed_origin_is_allowed() {
+        let root = temp_root("allowed_origin_security");
+        let response = test_router_with_public_origin(&root)
+            .oneshot(
+                cancel_request()
+                    .header(header::ORIGIN, "https://nac.example.com")
+                    .header("sec-fetch-site", "same-origin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&HeaderValue::from_static("https://nac.example.com"))
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn unsafe_browser_request_from_unlisted_origin_is_forbidden() {
+        let root = temp_root("unlisted_origin_security");
+        let response = test_router_with_public_origin(&root)
+            .oneshot(
+                cancel_request()
+                    .header(header::ORIGIN, "https://evil.example.com")
+                    .header("sec-fetch-site", "same-origin")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn unsafe_browser_request_with_cross_site_fetch_metadata_is_forbidden() {
+        let root = temp_root("cross_site_security");
+        let response = test_router_with_public_origin(&root)
+            .oneshot(
+                cancel_request()
+                    .header(header::ORIGIN, "https://nac.example.com")
+                    .header("sec-fetch-site", "cross-site")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn safe_requests_are_not_rejected_by_origin_middleware() {
+        let root = temp_root("safe_method_security");
+        let response = test_router_with_public_origin(&root)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/health")
+                    .header(header::ORIGIN, "https://evil.example.com")
+                    .header("sec-fetch-site", "cross-site")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .is_none());
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -14,7 +14,8 @@ use nac_core::{
         WorkerDispatchOptions,
     },
 };
-use nac_server::{serve, ServerOptions, SessionManager};
+use nac_server::{serve_with_options, ServerOptions, SessionManager, WebSecurityOptions};
+use url::Url;
 
 #[derive(Parser)]
 #[command(name = "nac-web", about = "web dashboard for managing nac sessions")]
@@ -22,6 +23,18 @@ struct ServerCli {
     /// Address to bind (default: localhost only).
     #[arg(long, default_value = "127.0.0.1:3210")]
     bind: SocketAddr,
+
+    /// Public HTTP(S) origin used to reach this server through a trusted proxy.
+    #[arg(long, env = "NAC_PUBLIC_BASE_URL")]
+    public_base_url: Option<Url>,
+
+    /// Additional exact HTTP(S) origin allowed by browser CORS and CSRF checks.
+    #[arg(
+        long = "allowed-origin",
+        env = "NAC_ALLOWED_ORIGINS",
+        value_delimiter = ','
+    )]
+    allowed_origins: Vec<Url>,
 
     /// Server root directory for default config and relative store paths.
     #[arg(short = 'C', long)]
@@ -286,8 +299,19 @@ async fn run_server(cli: ServerCli) -> Result<()> {
     })?;
     let info = manager.store_info();
     eprintln!("nac-web listening on http://{}", cli.bind);
+    if let Some(public_base_url) = &cli.public_base_url {
+        eprintln!("public base URL: {public_base_url}");
+    }
     eprintln!("store: {}", info.store_path.display());
-    serve(cli.bind, manager).await
+    serve_with_options(
+        cli.bind,
+        manager,
+        WebSecurityOptions {
+            public_base_url: cli.public_base_url,
+            allowed_origins: cli.allowed_origins,
+        },
+    )
+    .await
 }
 
 async fn run_managed_worker(cli: ManagedWorkerCli) -> Result<()> {


### PR DESCRIPTION
## Summary

- replace permissive CORS with exact configured browser origins
- require explicit origin configuration for non-loopback binds
- enforce allowed `Origin` and same-origin fetch metadata on unsafe browser methods
- preserve loopback and headerless local CLI/API behavior
- document proxy configuration and add focused regression coverage

## Validation

- `cargo test -p nac-server` (13 passed)
- `cargo check --workspace`
- `git diff --check`

`cargo fmt --all --check` remains blocked by pre-existing formatting differences outside this patch.