### PR TITLE
add in headers for arcee endpoint requests

### DIFF
--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -322,7 +322,7 @@ impl ModelClient {
                 self.post_arcee_auth_with_refresh(url.as_str(), &request)
                     .await?
             }
-            _ => self.post_json_with_retry(url.as_str(), &request).await?,
+            _ => self.post_arcee_api_json(url.as_str(), &request).await?,
         };
         parse_chat_completions_response(&value, url.as_str())
     }
@@ -374,6 +374,22 @@ impl ModelClient {
         let api_key = self.api_key.as_str();
         self.post_json_with_retry_headers(url, body, |request| {
             request.header("Authorization", format!("Bearer {}", api_key))
+        })
+        .await
+    }
+
+    /// Sends an `arcee-api` (bring-your-own key) inference request. Unlike
+    /// `arcee-auth`, the API key carries no client identity, so nac attributes
+    /// itself to ArceeFM with `User-Agent` and `X-Arcee-Client` for logging.
+    async fn post_arcee_api_json(&self, url: &str, body: &Value) -> Result<Value> {
+        let api_key = self.api_key.as_str();
+        let user_agent = format!("nac/{}", env!("CARGO_PKG_VERSION"));
+        let user_agent = user_agent.as_str();
+        self.post_json_with_retry_headers(url, body, |request| {
+            request
+                .header("Authorization", format!("Bearer {api_key}"))
+                .header("User-Agent", user_agent)
+                .header("X-Arcee-Client", "nac-cli")
         })
         .await
     }
@@ -741,9 +757,13 @@ mod tests {
             request.headers.get("authorization").map(String::as_str),
             Some("Bearer stored-login-credential")
         );
-        assert!(
-            request.headers.get("x-arcee-client").is_none(),
-            "x-arcee-client header must no longer be sent"
+        assert_eq!(
+            request.headers.get("x-arcee-client").map(String::as_str),
+            Some("nac-cli")
+        );
+        assert_eq!(
+            request.headers.get("user-agent").map(String::as_str),
+            Some(format!("nac/{}", env!("CARGO_PKG_VERSION")).as_str())
         );
         assert_eq!(
             request.headers.get("content-type").map(String::as_str),

--- a/crates/nac-core/src/model/client.rs
+++ b/crates/nac-core/src/model/client.rs
@@ -385,11 +385,19 @@ impl ModelClient {
         let api_key = self.api_key.as_str();
         let user_agent = format!("nac/{}", env!("CARGO_PKG_VERSION"));
         let user_agent = user_agent.as_str();
+        // Skip a built-in header the user has overridden via extra_headers; reqwest
+        // appends, so adding both would emit duplicate header lines.
+        let set_user_agent = !self.extra_headers_contains("user-agent");
+        let set_client = !self.extra_headers_contains("x-arcee-client");
         self.post_json_with_retry_headers(url, body, |request| {
+            let mut request = request.header("Authorization", format!("Bearer {api_key}"));
+            if set_user_agent {
+                request = request.header("User-Agent", user_agent);
+            }
+            if set_client {
+                request = request.header("X-Arcee-Client", "nac-cli");
+            }
             request
-                .header("Authorization", format!("Bearer {api_key}"))
-                .header("User-Agent", user_agent)
-                .header("X-Arcee-Client", "nac-cli")
         })
         .await
     }
@@ -472,7 +480,7 @@ impl ModelClient {
 
         for attempt in 0..10 {
             let mut request = self.client.post(url);
-            if !self.extra_headers_override_content_type() {
+            if !self.extra_headers_contains("content-type") {
                 request = request.header("Content-Type", "application/json");
             }
             let response = match self
@@ -575,10 +583,13 @@ impl ModelClient {
         Err(last_error)
     }
 
-    fn extra_headers_override_content_type(&self) -> bool {
+    /// Whether the configured extra_headers already set `name` (case-insensitive).
+    /// Built-in defaults skip a header the user has overridden, because reqwest
+    /// appends headers — adding both would emit duplicate lines, not an override.
+    fn extra_headers_contains(&self, name: &str) -> bool {
         self.extra_headers
             .keys()
-            .any(|name| name.eq_ignore_ascii_case("content-type"))
+            .any(|key| key.eq_ignore_ascii_case(name))
     }
 
     fn apply_extra_headers(
@@ -786,6 +797,43 @@ mod tests {
         assert_eq!(
             body["tools"],
             serde_json::to_value(&tools).expect("tool definitions serialize")
+        );
+    }
+
+    #[tokio::test]
+    async fn arcee_api_builtin_headers_defer_to_configured_extra_headers() {
+        let server = ScriptedServer::start(vec![ScriptedResponse::json(
+            "200 OK",
+            json!({
+                "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]
+            })
+            .to_string(),
+        )]);
+        let extra_headers = std::collections::BTreeMap::from([
+            ("User-Agent".to_string(), "custom-agent/9".to_string()),
+            ("X-Arcee-Client".to_string(), "custom-client".to_string()),
+        ]);
+        let client = test_model_client(BackendKind::ArceeApi, server.base_url.clone(), extra_headers);
+
+        client
+            .send_arcee_chat(Vec::new(), Vec::new())
+            .await
+            .expect("configured header override should succeed");
+        let requests = server.finish();
+
+        assert_eq!(requests.len(), 1);
+        let request = &requests[0];
+        // Built-in defaults are skipped when overridden — exactly one line each,
+        // carrying the user's value rather than a duplicate.
+        assert_eq!(request.header_counts.get("user-agent"), Some(&1));
+        assert_eq!(request.header_counts.get("x-arcee-client"), Some(&1));
+        assert_eq!(
+            request.headers.get("user-agent").map(String::as_str),
+            Some("custom-agent/9")
+        );
+        assert_eq!(
+            request.headers.get("x-arcee-client").map(String::as_str),
+            Some("custom-client")
         );
     }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2820,7 +2820,11 @@ mod tests {
 
     #[tokio::test]
     async fn server_create_rejects_removed_backend_names_as_bad_requests() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
         let root = temp_root("removed_backend_create");
+        let nac_home = root.join("nac-home");
+        std::fs::create_dir_all(&nac_home).unwrap();
+        let _env = ScopedModelEnv::isolated(&nac_home, None);
         let manager = test_manager(&root);
 
         for backend in ["arcee", "auto"] {


### PR DESCRIPTION
This pull request updates how the client sends requests to the Arcee API, ensuring that all "bring-your-own-key" (arcee-api) requests include proper identification headers for logging and attribution. It introduces a new method for sending these requests and updates the tests to reflect the new header requirements.

**Arcee API request handling:**

* Added a new method `post_arcee_api_json` to `ModelClient` that sends arcee-api requests with `Authorization`, `User-Agent`, and `X-Arcee-Client` headers for proper attribution and logging.
* Updated the main request dispatch logic to use `post_arcee_api_json` for arcee-api requests instead of the generic JSON request method.

**Testing updates:**

* Modified tests to assert that arcee-api requests now include the `X-Arcee-Client: nac-cli` and a versioned `User-Agent` header, ensuring compliance with new attribution requirements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Outbound header changes apply only to the arcee-api backend; auth and other backends are unchanged, with low blast radius beyond Arcee-side logging/attribution.
> 
> **Overview**
> **Arcee API (BYOK) chat** now goes through a dedicated `post_arcee_api_json` path that adds **`User-Agent: nac/{version}`** and **`X-Arcee-Client: nac-cli`** on top of the bearer key, so Arcee can attribute traffic when the key alone does not identify the client. **`arcee-auth`** still uses the device-token refresh flow unchanged.
> 
> Built-in defaults for **`Content-Type`**, **`User-Agent`**, and **`X-Arcee-Client`** are skipped when the same names appear in configured **`extra_headers`** (case-insensitive), because reqwest would otherwise send duplicate header lines instead of a single override.
> 
> Tests assert the new headers on the wire and add coverage for custom **`User-Agent`** / **`X-Arcee-Client`** via **`extra_headers`**. A server test for removed backend names now uses an isolated **`NAC_HOME`** under the existing model-env lock so it does not depend on ambient config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972a3cfc35e89ca332046193f42480cc2634a30c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->