### PR TITLE
Add Makefile with basic build/test/install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ CARGO ?= cargo
 PKG := nac-server
 BIN := nac-web
 
+# The workspace is not clippy-clean yet, so lints are advisory by default.
+# Run `make clippy CLIPPY_ARGS='-D warnings'` to fail on them.
+CLIPPY_ARGS ?=
+
+# Matches the location used by scripts/install.sh ($(INSTALL_ROOT)/bin).
+INSTALL_ROOT ?= $(HOME)/.local
+
 # Default target
 all: build
 
@@ -15,9 +22,9 @@ build:
 release:
 	$(CARGO) build --release --locked -p $(PKG) --bin $(BIN)
 
-## Install nac-web into cargo's bin directory
+## Install nac-web into $(INSTALL_ROOT)/bin
 install:
-	$(CARGO) install --path crates/$(PKG) --bin $(BIN) --locked --force
+	$(CARGO) install --path crates/$(PKG) --bin $(BIN) --locked --force --root $(INSTALL_ROOT)
 
 ## Run workspace Rust tests and web asset checks
 test: test-rust test-assets
@@ -39,7 +46,7 @@ fmt:
 
 ## Lint with clippy
 clippy:
-	$(CARGO) clippy --workspace --locked --all-targets -- -D warnings
+	$(CARGO) clippy --workspace --locked --all-targets -- $(CLIPPY_ARGS)
 
 ## Remove build artifacts
 clean:
@@ -53,12 +60,12 @@ help:
 		'Targets:' \
 		'  build        Build nac-web (debug) [default]' \
 		'  release      Build nac-web (release)' \
-		'  install      Install nac-web with cargo install' \
+		'  install      Install nac-web into $$INSTALL_ROOT/bin (~/.local)' \
 		'  test         Run Rust tests and web asset checks' \
 		'  test-rust    Run cargo test --workspace --locked' \
 		'  test-assets  Check/run Node web asset tests' \
 		'  check        Run cargo check --workspace --locked' \
 		'  fmt          Run rustfmt' \
-		'  clippy       Run clippy with -D warnings' \
+		'  clippy       Run clippy (CLIPPY_ARGS=-D warnings to fail on lints)' \
 		'  clean        Remove target/ artifacts' \
 		'  help         Show this help'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,64 @@
+.PHONY: all build release install test test-rust test-assets check fmt clippy clean help
+
+CARGO ?= cargo
+PKG := nac-server
+BIN := nac-web
+
+# Default target
+all: build
+
+## Build the nac-web binary (debug)
+build:
+	$(CARGO) build --locked -p $(PKG) --bin $(BIN)
+
+## Build the nac-web binary (release)
+release:
+	$(CARGO) build --release --locked -p $(PKG) --bin $(BIN)
+
+## Install nac-web into cargo's bin directory
+install:
+	$(CARGO) install --path crates/$(PKG) --bin $(BIN) --locked --force
+
+## Run workspace Rust tests and web asset checks
+test: test-rust test-assets
+
+test-rust:
+	$(CARGO) test --workspace --locked
+
+test-assets:
+	node --check crates/nac-server/assets/app.js
+	node --test crates/nac-server/assets/app.test.js
+
+## Type-check the workspace without producing binaries
+check:
+	$(CARGO) check --workspace --locked
+
+## Format Rust sources
+fmt:
+	$(CARGO) fmt --all
+
+## Lint with clippy
+clippy:
+	$(CARGO) clippy --workspace --locked --all-targets -- -D warnings
+
+## Remove build artifacts
+clean:
+	$(CARGO) clean
+
+## Show available targets
+help:
+	@printf '%s\n' \
+		'Usage: make [target]' \
+		'' \
+		'Targets:' \
+		'  build        Build nac-web (debug) [default]' \
+		'  release      Build nac-web (release)' \
+		'  install      Install nac-web with cargo install' \
+		'  test         Run Rust tests and web asset checks' \
+		'  test-rust    Run cargo test --workspace --locked' \
+		'  test-assets  Check/run Node web asset tests' \
+		'  check        Run cargo check --workspace --locked' \
+		'  fmt          Run rustfmt' \
+		'  clippy       Run clippy with -D warnings' \
+		'  clean        Remove target/ artifacts' \
+		'  help         Show this help'


### PR DESCRIPTION
## Summary
- Introduce a root `Makefile` whose default target builds `nac-web` (debug)
- Add common developer targets: `build`, `release`, `install`, `test`, `check`, `fmt`, `clippy`, `clean`, and `help`
- Mirror CI: locked cargo workspace tests plus Node web asset checks under `make test`

## Test plan
- [ ] `make` / `make build` runs `cargo build --locked -p nac-server --bin nac-web`
- [ ] `make release` produces a release binary
- [ ] `make test` runs Rust workspace tests and Node asset checks
- [ ] `make install` installs `nac-web` via `cargo install`
- [ ] `make help` lists available targets


Made with [Cursor](https://cursor.com)