### PR TITLE
Fix flaky server test that reads ambient NAC_HOME config

### DIFF
--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2820,7 +2820,10 @@ mod tests {
 
     #[tokio::test]
     async fn server_create_rejects_removed_backend_names_as_bad_requests() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
         let root = temp_root("removed_backend_create");
+        let nac_home = root.join("nac-home");
+        let _env = ScopedModelEnv::isolated(&nac_home, None);
         let manager = test_manager(&root);
 
         for backend in ["arcee", "auto"] {


### PR DESCRIPTION
## Summary
- `tests::server_create_rejects_removed_backend_names_as_bad_requests` did not take `SERVER_MODEL_ENV_LOCK` or install a `ScopedModelEnv`, unlike every other test that exercises ambient model config
- Concurrently, `server_attach_ignores_invalid_ambient_model_but_create_remains_strict` sets the process-wide `NAC_HOME` to a temp dir containing a deliberately invalid config (`backend = "auto"`)
- When the two overlap, `create_session` fails while parsing that foreign config, so `error.to_string()` is `failed to parse config …` rather than the expected `unsupported backend`, and the assertion trips

This is why the failure log shows the test panicking inside another test's temp directory:

```
thread 'tests::server_create_rejects_removed_backend_names_as_bad_requests' panicked at crates/nac-server/src/lib.rs:2842:13:
failed to parse config /tmp/nac_server_test_persisted_attach_invalid_ambient_model_.../nac-home/config.toml
```

The fix takes the same lock and scoped environment as its sibling tests.

## Impact
CI has failed on **every** run since #47 (2026-07-20), including pushes to `main`, which also blocks the `build` and `publish` jobs. This unblocks the pipeline for all open PRs.

## Test plan
- [x] Reproduced locally: `cargo test -p nac-server -- --test-threads=2 server_create_rejects_removed_backend_names_as_bad_requests server_attach_ignores_invalid_ambient_model_but_create_remains_strict` fails on the first iteration before the fix
- [x] Same command passes 10/10 iterations after the fix
- [x] `cargo test --workspace --locked` fully green locally (522 + 64 + 6 passed, 0 failed)


Made with [Cursor](https://cursor.com)