### PR TITLE
Move the composer into the orchestrator pane

### DIFF
--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -4094,7 +4094,10 @@ function handleThreadClick(event) {
   if (["running", "queued"].includes(button.dataset.threadState)) {
     state.targetedThread = state.targetedThread === name ? null : name;
     renderThreads(currentSnapshot());
-    if (state.targetedThread) el.promptInput.focus();
+    if (state.targetedThread) {
+      setWorkspaceView("chat");
+      el.promptInput.focus();
+    }
   } else openFocusView("thread", name);
 }
 

--- a/crates/nac-server/assets/app.test.js
+++ b/crates/nac-server/assets/app.test.js
@@ -68,7 +68,7 @@ function loadApp(overrides = {}) {
       captureFocusTarget, restoreFocusTarget,
       captureFormControlStates, restoreFormControlStates, captureScrollPositions,
       restoreScrollPositions, openFocusView, closeFocusView, renderFocusView, renderCommandReference,
-      handleOrchestratorChatScroll,
+      handleOrchestratorChatScroll, handleThreadClick,
       setWorkspaceView, captureWorkspaceViewScroll, restoreWorkspaceViewScroll,
       renderConfigRepairGuidance, recordSessionEnvelope,
       connectEventStream, worksetsPresentation, renderWorksetsFocus,
@@ -4082,6 +4082,27 @@ test("workspace view toggle flips layout class and button state, defaulting to c
   assert.ok(!(isolated.el.sessionLayout.classList.contains("is-threads-view")));
   assert.equal(isolated.el.viewToggle.dataset.view, "chat");
   assert.equal(isolated.el.viewToggle.getAttribute("aria-pressed"), "false");
+});
+
+test("targeting a thread returns mobile users to the visible composer", () => {
+  const isolated = loadApp();
+  installWorkspaceElements(isolated);
+  isolated.state.currentId = "mobile-target";
+  isolated.state.snapshots.set("mobile-target", sessionSnapshot("mobile-target", {
+    threads: [{ name: "worker" }],
+    active_threads: ["worker"],
+  }));
+  isolated.el.promptInput.focus = function focus() { this.focused = true; };
+  isolated.setWorkspaceView("threads");
+  const button = { dataset: { threadName: "worker", threadState: "running" } };
+  isolated.handleThreadClick({
+    target: { closest(selector) { return selector === "[data-thread-name]" ? button : null; } },
+  });
+  assert.equal(isolated.state.targetedThread, "worker");
+  assert.equal(isolated.state.workspaceView, "chat");
+  assert.ok(!isolated.el.sessionLayout.classList.contains("is-threads-view"));
+  assert.equal(isolated.el.viewToggle.getAttribute("aria-pressed"), "false");
+  assert.equal(isolated.el.promptInput.focused, true);
 });
 
 test("workspace view switching preserves each pane's scroll position", () => {

--- a/crates/nac-server/assets/app.test.js
+++ b/crates/nac-server/assets/app.test.js
@@ -293,13 +293,22 @@ function installComposerElements(uiInstance, sessionId, draft = "") {
   return uiInstance;
 }
 
-test("production shell preserves privacy and mobile chat-only access", () => {
+test("production shell keeps the composer inside the orchestrator pane", () => {
   for (const id of ["sessionPicker", "sessionWorkspace", "focusPanel", "promptInput"]) {
     assert.match(indexSource, new RegExp(`id="${id}"`));
   }
   assert.doesNotMatch(indexSource, /Session Events/i);
+  const railStart = indexSource.indexOf('<aside class="overview-rail"');
+  const railEnd = indexSource.indexOf("</aside>", railStart);
+  const composerStart = indexSource.indexOf('<form id="commandComposer"', railStart);
+  assert.ok(railStart >= 0 && railEnd > railStart, "the orchestrator pane is present");
+  assert.ok(composerStart > railStart && composerStart < railEnd,
+    "the composer is structurally part of the orchestrator pane");
   assert.match(redesignSource, /\.session-layout \{[^}]*grid-template-columns: min\(780px, 48vw\) minmax\(0, 1fr\)/s);
   assert.match(redesignSource, /\.orchestrator-chat-content \{/);
+  assert.match(redesignSource, /\.overview-rail \{[^}]*display: flex;[^}]*flex-direction: column;/s);
+  assert.match(redesignSource, /\.composer \{[^}]*flex: none;/s,
+    "the composer forms the fixed footer of the orchestrator pane");
 });
 
 test("session opening renders the workspace and starts snapshot and SSE without removed-surface references", () => {
@@ -4030,7 +4039,7 @@ test("mobile view switch CSS: toggle hidden on desktop, panes swap below the 780
 });
 
 test("desktop workspace layout rules are unchanged by the mobile view switch", () => {
-  assert.match(redesignSource, /\.session-layout \{\s*height: calc\(100dvh - 72px\);\s*display: grid;\s*grid-template-columns: min\(780px, 48vw\) minmax\(0, 1fr\);\s*grid-template-rows: minmax\(0, 1fr\) auto;\s*overflow: hidden;\s*\}/);
+  assert.match(redesignSource, /\.session-layout \{\s*height: calc\(100dvh - 72px\);\s*display: grid;\s*grid-template-columns: min\(780px, 48vw\) minmax\(0, 1fr\);\s*grid-template-rows: minmax\(0, 1fr\);\s*overflow: hidden;\s*\}/);
   assert.match(redesignSource, /@media \(max-width: 1060px\) \{\s*\.session-bar \{ grid-template-columns: auto minmax\(140px,1fr\) auto auto auto; \}/,
     "the 1060px session-bar grid keeps its five tracks");
   assert.doesNotMatch(redesignSource.slice(0, redesignSource.indexOf("@media")), /is-threads-view/,

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -147,6 +147,6 @@
 
     <script src="/assets/vendor/markdown-it.min.js" defer></script>
     <script src="/assets/vendor/purify.min.js" defer></script>
-    <script src="/assets/app.js?v=quality-38" defer></script>
+    <script src="/assets/app.js?v=quality-39" defer></script>
   </body>
 </html>

--- a/crates/nac-server/assets/index.html
+++ b/crates/nac-server/assets/index.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="dark" />
     <title>nac</title>
     <link rel="preload" as="font" type="font/woff2" href="/assets/fonts/doto/Doto-RoundedExtraBold-latin.woff2" crossorigin>
-    <link rel="stylesheet" href="/assets/redesign.css?v=quality-37" />
+    <link rel="stylesheet" href="/assets/redesign.css?v=quality-38" />
   </head>
   <body>
     <div id="app" class="app-frame">
@@ -71,6 +71,18 @@
             </section>
             <h2 class="rail-heading">Orchestrator</h2>
             <div id="orchestratorChatContent" class="orchestrator-chat-content"></div>
+            <form id="commandComposer" class="composer">
+              <div id="composerTarget" class="composer-target" hidden>
+                <span>Thread</span><strong id="composerTargetName"></strong>
+                <button id="clearTarget" type="button" aria-label="Clear thread target"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"></path></svg></button>
+              </div>
+              <textarea id="promptInput" rows="1" spellcheck="false" placeholder="Message the orchestrator · / for commands" aria-label="Message the orchestrator" role="combobox" aria-autocomplete="list" aria-controls="commandMenu" aria-expanded="false" aria-describedby="commandHint"></textarea>
+              <span id="commandHint" class="sr-only">Type slash to open session commands. Use the arrow keys to choose a command.</span>
+              <button id="sendPrompt" class="composer-send" type="submit" aria-label="Send">
+                <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22 2 11 13M22 2l-7 20-4-9-9-4 20-7z"></path></svg>
+              </button>
+              <div id="commandMenu" class="command-menu" role="listbox" aria-label="Session commands" hidden></div>
+            </form>
           </aside>
 
           <section id="focusPanel" class="focus-panel" aria-labelledby="focusTitle" hidden>
@@ -89,19 +101,6 @@
           <main class="thread-canvas" aria-label="Threads">
             <div id="threadGrid" class="thread-board"></div>
           </main>
-
-          <form id="commandComposer" class="composer">
-            <div id="composerTarget" class="composer-target" hidden>
-              <span>Thread</span><strong id="composerTargetName"></strong>
-              <button id="clearTarget" type="button" aria-label="Clear thread target"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"></path></svg></button>
-            </div>
-            <textarea id="promptInput" rows="1" spellcheck="false" placeholder="Message the orchestrator · / for commands" aria-label="Message the orchestrator" role="combobox" aria-autocomplete="list" aria-controls="commandMenu" aria-expanded="false" aria-describedby="commandHint"></textarea>
-            <span id="commandHint" class="sr-only">Type slash to open session commands. Use the arrow keys to choose a command.</span>
-            <button id="sendPrompt" class="composer-send" type="submit" aria-label="Send">
-              <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22 2 11 13M22 2l-7 20-4-9-9-4 20-7z"></path></svg>
-            </button>
-            <div id="commandMenu" class="command-menu" role="listbox" aria-label="Session commands" hidden></div>
-          </form>
         </div>
       </section>
     </div>

--- a/crates/nac-server/assets/redesign.css
+++ b/crates/nac-server/assets/redesign.css
@@ -418,12 +418,13 @@ body.session-reordering { cursor: grabbing; user-select: none; }
   height: calc(100dvh - 72px);
   display: grid;
   grid-template-columns: min(780px, 48vw) minmax(0, 1fr);
-  grid-template-rows: minmax(0, 1fr) auto;
+  grid-template-rows: minmax(0, 1fr);
   overflow: hidden;
 }
 
 .overview-rail {
-  grid-row: 1 / span 2;
+  grid-row: 1;
+  grid-column: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -462,7 +463,7 @@ body.session-reordering { cursor: grabbing; user-select: none; }
 .expand-button svg { width: 13px; height: 13px; stroke-width: 1.6; }
 
 
-.thread-canvas { min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
+.thread-canvas { grid-row: 1; grid-column: 2; min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; background: var(--bg); }
 
 .thread-board {
   min-height: 0;
@@ -566,7 +567,6 @@ body.session-reordering { cursor: grabbing; user-select: none; }
 
 .session-layout.is-focused > .overview-rail,
 .session-layout.is-focused > .thread-canvas { display: none; }
-.session-layout.is-focused > .composer { grid-column: 1 / -1; }
 
 .focus-panel {
   grid-row: 1;
@@ -846,19 +846,19 @@ body.session-reordering { cursor: grabbing; user-select: none; }
 .composer {
   --composer-control-height: 40px;
   position: relative;
-  grid-column: 2;
+  flex: none;
   min-width: 0;
   display: grid;
-  grid-template-columns: auto minmax(0,1fr) auto;
+  grid-template-columns: minmax(0,1fr) auto;
   align-items: end;
   gap: 8px;
-  padding: 10px;
+  padding: 10px 12px 12px;
   border-top: 1px solid var(--line);
   background: var(--surface);
 }
 
 .composer textarea {
-  grid-column: 2;
+  grid-column: 1;
   width: 100%;
   max-height: 134px;
   min-height: var(--composer-control-height);
@@ -874,10 +874,10 @@ body.session-reordering { cursor: grabbing; user-select: none; }
 
 .composer textarea::placeholder { color: var(--ink-soft); font: inherit; }
 .composer textarea:focus { border-color: #666; }
-.composer-send { grid-column: 3; width: var(--composer-control-height); height: var(--composer-control-height); align-self: end; display: grid; place-items: center; padding: 0; border-radius: var(--r-md); background: var(--paper); color: #111; }
+.composer-send { grid-column: 2; width: var(--composer-control-height); height: var(--composer-control-height); align-self: end; display: grid; place-items: center; padding: 0; border-radius: var(--r-md); background: var(--paper); color: #111; }
 .composer-send:hover { background: #fff; }
 .composer-send:disabled { opacity: 0.4; cursor: wait; }
-.composer-target { grid-column: 1; height: var(--composer-control-height); display: inline-flex; align-items: center; gap: 7px; padding: 0 9px 0 11px; border: 1px solid var(--line-strong); border-radius: var(--r-md); background: #171717; white-space: nowrap; }
+.composer-target { grid-column: 1 / -1; width: fit-content; max-width: 100%; height: var(--composer-control-height); display: inline-flex; align-items: center; gap: 7px; padding: 0 9px 0 11px; border: 1px solid var(--line-strong); border-radius: var(--r-md); background: #171717; white-space: nowrap; }
 .composer-target span { color: var(--ink-muted); font: var(--fs-xs)/var(--lh-none) var(--mono); text-transform: uppercase; }
 .composer-target strong { max-width: 170px; overflow: hidden; font: var(--fs-base)/var(--lh-none) var(--mono); text-overflow: ellipsis; }
 .composer-target button { width: 20px; height: 20px; padding: 0; border: 0; border-radius: 4px; background: #252525; color: var(--ink-soft); cursor: pointer; }
@@ -1016,24 +1016,21 @@ body.session-reordering { cursor: grabbing; user-select: none; }
   .picker-bar { position: relative; }
   .session-browser { padding-top: 18px; }
   /* Mobile view switch: below this breakpoint the workspace shows one pane at
-     a time — the orchestrator chat or the thread canvas — toggled by the
-     .view-toggle button in the session bar. .session-layout carries
-     .is-threads-view while the threads pane is active; without it the chat
-     pane is active. The active pane fills the layout height and scrolls
-     internally, so the page itself never scrolls and the composer stays
-     visible at the bottom in both views. */
+     a time — the orchestrator chat (with its composer) or the thread canvas —
+     toggled by the .view-toggle button in the session bar. .session-layout
+     carries .is-threads-view while the threads pane is active; without it the
+     chat pane is active. The active pane fills the layout height and scrolls
+     internally, so the page itself never scrolls. */
   .view-toggle { display: inline-flex; }
   .session-bar { grid-template-columns: auto minmax(140px,1fr) auto auto auto auto; }
-  .session-layout { height: calc(100dvh - 112px); grid-template-columns: 1fr; grid-template-rows: minmax(0, 1fr) auto; overflow: hidden; }
+  .session-layout { height: calc(100dvh - 112px); grid-template-columns: 1fr; grid-template-rows: minmax(0, 1fr); overflow: hidden; }
   .session-layout > .overview-rail, .session-layout > .thread-canvas { grid-row: 1; grid-column: 1; }
   .session-layout:not(.is-threads-view) > .thread-canvas { display: none; }
   .session-layout.is-threads-view > .overview-rail { display: none; }
   .session-layout.is-focused > .focus-panel { grid-row: 1; }
-  .session-layout.is-focused > .composer { position: relative; grid-row: 2; }
   .overview-rail { border-right: 0; }
   .config-repair-notice { grid-column: 1 / -1; }
   .rail-section { border-right: 1px solid var(--line); }
-  .composer { grid-row: 2; grid-column: 1; }
   .focus-panel.is-thread .focus-content { overflow: auto; }
   .focus-panel.is-thread .focus-thread-layout { display: grid; height: auto; min-height: 100%; grid-template-columns: 1fr; grid-template-rows: minmax(260px, auto) auto; }
   .focus-panel.is-thread .focus-activity { min-height: 260px; max-height: 52dvh; display: block; border-right: 0; border-bottom: 1px solid var(--line); }


### PR DESCRIPTION
## Description

Suggestion for lowering cognitive dissonance by putting the input widget in the session pane instead of in the thread pane.

This PR:

<img width="1396" height="1037" alt="image" src="https://github.com/user-attachments/assets/e582398c-05ad-4ff4-b268-fdcf204e6d6a" />


## Summary
- place the message composer inside the left-hand orchestrator pane
- integrate the composer as the fixed footer of the orchestrator conversation
- hide the composer with thread-only and fullscreen views to avoid cross-pane input dissonance
- add regression coverage for the DOM placement and responsive layout

## Test plan
- [x] `node --check crates/nac-server/assets/app.js`
- [x] `node --test crates/nac-server/assets/app.test.js`
- [x] `cargo test --workspace --locked`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)