### PR TITLE
Avoid full snapshots for live transcript updates

### DIFF
--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -1059,8 +1059,26 @@ function showPicker(updateHash = true) {
   });
 }
 
+function cancelTranscriptRefresh(sessionId) {
+  const timer = state.transcriptTimers.get(sessionId);
+  if (timer != null) {
+    window.clearTimeout(timer);
+    state.transcriptTimers.delete(sessionId);
+  }
+  const coordinator = state.transcriptRefreshCoordinators.get(sessionId);
+  if (!coordinator) return;
+  // Authoritative snapshots supersede transcript pages: discard the in-flight
+  // request and do not schedule a trailing /messages retry.
+  coordinator.invalidation += 1;
+  coordinator.dirty = false;
+}
+
 function loadSnapshot(sessionId, announce = false) {
   if (!sessionId) return Promise.resolve(null);
+  // Full snapshots and transcript pages are mutually exclusive. Invalidate any
+  // in-flight /messages refresh so a slower response cannot overwrite newer
+  // messages after this authoritative snapshot is accepted.
+  cancelTranscriptRefresh(sessionId);
   const existing = state.snapshotRefreshCoordinators.get(sessionId);
   if (existing) {
     existing.invalidation += 1;
@@ -1638,6 +1656,8 @@ function eventNeedsSnapshot(envelope) {
 }
 
 function scheduleSnapshot(sessionId) {
+  // Pending transcript timers are cancelled inside loadSnapshot; clear early so
+  // scheduleTranscriptRefresh cannot race the debounce window.
   const transcriptTimer = state.transcriptTimers.get(sessionId);
   if (transcriptTimer != null) {
     window.clearTimeout(transcriptTimer);
@@ -1647,12 +1667,7 @@ function scheduleSnapshot(sessionId) {
   if (existing != null) window.clearTimeout(existing);
   const timer = window.setTimeout(() => {
     state.snapshotTimers.delete(sessionId);
-    const transcriptRefresh = state.transcriptRefreshCoordinators.get(sessionId);
-    if (transcriptRefresh) {
-      transcriptRefresh.promise.finally(() => loadSnapshot(sessionId, false));
-    } else {
-      loadSnapshot(sessionId, false);
-    }
+    loadSnapshot(sessionId, false);
   }, 120);
   state.snapshotTimers.set(sessionId, timer);
 }

--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -16,6 +16,8 @@ const state = {
   sessionReorder: null,
   snapshotTimers: new Map(),
   snapshotRefreshCoordinators: new Map(),
+  transcriptTimers: new Map(),
+  transcriptRefreshCoordinators: new Map(),
   sessionListRefreshCoordinator: null,
   statsLoadedAt: 0,
   statusTimer: null,
@@ -1123,6 +1125,66 @@ function acceptSnapshot(sessionId, snapshot, { announce = false, compactionFence
   return snapshot;
 }
 
+function loadTranscriptMessages(sessionId) {
+  if (!sessionId) return Promise.resolve(null);
+  if (!state.snapshots.has(sessionId)) return loadSnapshot(sessionId, false);
+  const existing = state.transcriptRefreshCoordinators.get(sessionId);
+  if (existing) {
+    existing.invalidation += 1;
+    existing.dirty = true;
+    return existing.promise;
+  }
+
+  const coordinator = {
+    invalidation: 1,
+    dirty: true,
+    promise: null,
+  };
+  state.transcriptRefreshCoordinators.set(sessionId, coordinator);
+  coordinator.promise = drainTranscriptRefreshes(sessionId, coordinator);
+  return coordinator.promise;
+}
+
+async function drainTranscriptRefreshes(sessionId, coordinator) {
+  let accepted = null;
+  try {
+    while (coordinator.dirty) {
+      coordinator.dirty = false;
+      const requestInvalidation = coordinator.invalidation;
+      const currentIdAtRequest = state.currentId;
+      try {
+        const response = await apiGet(`/sessions/${encodeURIComponent(sessionId)}/messages?limit=${ORCHESTRATOR_MESSAGE_PAGE_LIMIT}`);
+        if (coordinator.invalidation !== requestInvalidation || state.currentId !== currentIdAtRequest) continue;
+        accepted = acceptTranscriptPage(sessionId, response);
+      } catch (error) {
+        if (coordinator.invalidation !== requestInvalidation || state.currentId !== currentIdAtRequest) continue;
+        if (state.currentId === sessionId) showToast(error.message, true);
+        accepted = null;
+      }
+    }
+    return accepted;
+  } finally {
+    if (state.transcriptRefreshCoordinators.get(sessionId) === coordinator) {
+      state.transcriptRefreshCoordinators.delete(sessionId);
+    }
+  }
+}
+
+function acceptTranscriptPage(sessionId, response) {
+  const current = state.snapshots.get(sessionId);
+  if (!current) return null;
+  const snapshot = {
+    ...current,
+    messages: response?.messages || [],
+    message_page: response?.page || null,
+  };
+  mergeSnapshotMessageWindow(sessionId, snapshot);
+  reconcilePendingEcho(sessionId, snapshot);
+  state.snapshots.set(sessionId, snapshot);
+  if (state.currentId === sessionId) scheduleWorkspaceRender(sessionId);
+  return snapshot;
+}
+
 function mergeSnapshotMessageWindow(sessionId, snapshot) {
   const page = snapshot?.message_page;
   const incoming = snapshot?.messages || [];
@@ -1534,7 +1596,11 @@ function connectEventStream(sessionId, { replayFromBeginning = false } = {}) {
     const historical = observationFloor === null || envelope.sequence_id <= observationFloor;
     if (!recordSessionEnvelope(sessionId, envelope, { historical })) return;
     if (state.currentId === sessionId) scheduleWorkspaceRender(sessionId);
-    if (!historical && eventNeedsSnapshot(envelope)) scheduleSnapshot(sessionId);
+    if (!historical && envelope.event?.type === "transcript_appended") {
+      scheduleTranscriptRefresh(sessionId);
+    } else if (!historical && eventNeedsSnapshot(envelope)) {
+      scheduleSnapshot(sessionId);
+    }
     if (!historical && ["run_started", "run_completed", "run_failed"].includes(envelope.event?.type)) {
       renderPicker();
       loadSessions({ workspaceStats: false });
@@ -1563,9 +1629,7 @@ function connectEventStream(sessionId, { replayFromBeginning = false } = {}) {
 
 function eventNeedsSnapshot(envelope) {
   const type = envelope.event?.type;
-  // transcript_appended is the live mid-run signal: a commit point just made
-  // new orchestrator messages visible in the store-backed transcript.
-  if (["run_started", "run_completed", "run_failed", "snapshot_saved", "transcript_appended"].includes(type)) return true;
+  if (["run_started", "run_completed", "run_failed", "snapshot_saved"].includes(type)) return true;
   const agent = agentEvent(envelope);
   if (agent?.reason === "manual"
       && (agent.type === COMPACTION_STARTED_EVENT_TYPE || COMPACTION_TERMINAL_EVENT_TYPES.has(agent.type))) return true;
@@ -1574,13 +1638,38 @@ function eventNeedsSnapshot(envelope) {
 }
 
 function scheduleSnapshot(sessionId) {
+  const transcriptTimer = state.transcriptTimers.get(sessionId);
+  if (transcriptTimer != null) {
+    window.clearTimeout(transcriptTimer);
+    state.transcriptTimers.delete(sessionId);
+  }
   const existing = state.snapshotTimers.get(sessionId);
   if (existing != null) window.clearTimeout(existing);
   const timer = window.setTimeout(() => {
     state.snapshotTimers.delete(sessionId);
-    loadSnapshot(sessionId, false);
+    const transcriptRefresh = state.transcriptRefreshCoordinators.get(sessionId);
+    if (transcriptRefresh) {
+      transcriptRefresh.promise.finally(() => loadSnapshot(sessionId, false));
+    } else {
+      loadSnapshot(sessionId, false);
+    }
   }, 120);
   state.snapshotTimers.set(sessionId, timer);
+}
+
+function scheduleTranscriptRefresh(sessionId) {
+  if (state.snapshotTimers.has(sessionId)) return;
+  const existing = state.transcriptTimers.get(sessionId);
+  if (existing != null) window.clearTimeout(existing);
+  const timer = window.setTimeout(() => {
+    state.transcriptTimers.delete(sessionId);
+    if (state.snapshotRefreshCoordinators.has(sessionId)) {
+      loadSnapshot(sessionId, false);
+    } else {
+      loadTranscriptMessages(sessionId);
+    }
+  }, 120);
+  state.transcriptTimers.set(sessionId, timer);
 }
 
 function agentEvent(envelope) { return envelope?.event?.type === "agent" ? envelope.event.event : null; }

--- a/crates/nac-server/assets/app.test.js
+++ b/crates/nac-server/assets/app.test.js
@@ -53,7 +53,9 @@ function loadApp(overrides = {}) {
       applySessionExecutionLocation, sessionReorderControlLabel, reorderAnnouncement,
       commitSessionReorder, mergeSnapshotMessageWindow, prependMessageWindow,
       workspaceSummaryPresentation, applyWorkspaceSummaryMetric, renderPicker, loadStoreInfo,
-      renderSessionInfo, loadSessions, loadSnapshot, acceptSnapshot, loadOlderOrchestratorMessages,
+      renderSessionInfo, loadSessions, loadSnapshot, acceptSnapshot,
+      loadTranscriptMessages, acceptTranscriptPage, scheduleTranscriptRefresh,
+      loadOlderOrchestratorMessages,
       orchestratorHistoryNeedsFill, ensureOrchestratorScrollableHistory,
       notePendingEcho, displayPromptFromMessage, pendingEchoCoveredByCanonical,
       reconcilePendingEcho, effectivePendingMessages,
@@ -488,20 +490,23 @@ scenario("SSE", "replay-gap compaction reconciliation retries a snapshot invalid
   assert.equal(isolated.state.snapshots.get(sessionId).active_compaction, null);
 });
 
-scenario("SSE", "transcript_appended schedules a debounced refetch that renders mid-run messages", async () => {
+scenario("SSE", "transcript_appended refreshes only the paged transcript", async () => {
   const { FakeEventSource, instances } = eventSourceHarness();
   const requests = [];
   const timers = [];
   const isolated = loadApp({ EventSource: FakeEventSource,
     fetch: async (path) => { requests.push(path);
-      return jsonResponse(sessionSnapshot("live-session", {
+      return jsonResponse({
         messages: [{ role: "user", content: "prompt" }, { role: "assistant", content: "mid-run answer" }],
-        active_run: { run_id: "run-live", started_at_epoch_ms: 1 },
-      })); },
+        page: { start: 0, end: 2, total: 2, has_older: false },
+      }); },
     window: { setTimeout(callback, delay) { timers.push({ callback, delay }); return timers.length; },
       clearTimeout() {}, }, });
   const sessionId = "live-session";
   isolated.state.currentId = sessionId;
+  isolated.state.snapshots.set(sessionId, sessionSnapshot(sessionId, {
+    active_run: { run_id: "run-live", started_at_epoch_ms: 1 },
+  }));
   isolated.connectEventStream(sessionId);
   const source = instances[0];
   source.emit("replay_boundary", { replay_boundary_sequence_id: 1 });
@@ -509,21 +514,49 @@ scenario("SSE", "transcript_appended schedules a debounced refetch that renders 
   source.emit("session_event", { session_id: sessionId, sequence_id: 1,
     event: { type: "transcript_appended", transcript_len: 2 } });
   assert.equal(timers.filter(({ delay }) => delay === 120).length, 0);
-  // The live signal schedules the debounced snapshot refetch.
+  // The live signal schedules the debounced transcript refetch.
   source.emit("session_event", { session_id: sessionId, sequence_id: 2,
     event: { type: "transcript_appended", transcript_len: 3 } });
-  const snapshotTimers = timers.filter(({ delay }) => delay === 120);
-  assert.equal(snapshotTimers.length, 1, "transcript_appended reuses the 120ms snapshot debounce");
-  snapshotTimers[0].callback();
-  const refreshDrain = isolated.state.snapshotRefreshCoordinators.get(sessionId)?.promise;
+  const transcriptTimers = timers.filter(({ delay }) => delay === 120);
+  assert.equal(transcriptTimers.length, 1, "transcript_appended uses the 120ms transcript debounce");
+  transcriptTimers[0].callback();
+  const refreshDrain = isolated.state.transcriptRefreshCoordinators.get(sessionId)?.promise;
   assert.ok(refreshDrain);
   await refreshDrain;
-  assert.ok(requests.some((path) => path.startsWith(`/sessions/${sessionId}?`)),
-    "the live signal refetches the store-backed snapshot");
+  assert.deepEqual(requests, [`/sessions/${sessionId}/messages?limit=24`]);
   assert.deepEqual(
     plain(isolated.state.snapshots.get(sessionId).messages.map((message) => message.role)),
     ["user", "assistant"],
-    "mid-run messages from the refetched snapshot are the live transcript");
+    "mid-run messages from the lightweight page are the live transcript");
+  assert.equal(isolated.state.snapshots.get(sessionId).active_run.run_id, "run-live",
+    "transcript refresh preserves structural snapshot state");
+});
+
+scenario("SSE", "structural events supersede a pending transcript-only refresh", () => {
+  const { FakeEventSource, instances } = eventSourceHarness();
+  const cleared = [];
+  let nextTimer = 0;
+  const isolated = loadApp({ EventSource: FakeEventSource,
+    window: {
+      setTimeout() { nextTimer += 1; return nextTimer; },
+      clearTimeout(timer) { cleared.push(timer); },
+    }, });
+  const sessionId = "structural-session";
+  isolated.state.currentId = sessionId;
+  isolated.state.snapshots.set(sessionId, sessionSnapshot(sessionId));
+  isolated.connectEventStream(sessionId);
+  const source = instances[0];
+  source.emit("replay_boundary", { replay_boundary_sequence_id: 1 });
+  source.emit("session_event", { session_id: sessionId, sequence_id: 2,
+    event: { type: "transcript_appended", transcript_len: 2 } });
+  const transcriptTimer = isolated.state.transcriptTimers.get(sessionId);
+  assert.ok(transcriptTimer);
+  source.emit("session_event", { session_id: sessionId, sequence_id: 3,
+    event: { type: "snapshot_saved" } });
+  assert.equal(isolated.state.transcriptTimers.has(sessionId), false);
+  assert.equal(isolated.state.snapshotTimers.has(sessionId), true);
+  assert.deepEqual(cleared, [transcriptTimer],
+    "the authoritative snapshot cancels the weaker pending transcript request");
 });
 
 scenario("SSE", "initial replay hydrates chronology without replaying stale run-attention side effects", () => {
@@ -1189,6 +1222,52 @@ test("snapshot refreshes coalesce bursts, carry dirty state through trailing req
   assert.equal(isolated.el.sessionNavStatus.textContent, "Session refreshed", "queued announce intent reaches the final accepted request");
   assert.equal(isolated.state.snapshotRefreshCoordinators.has("snapshot-session"), false);
   assert.deepEqual(requests, Array(3).fill("/sessions/snapshot-session?message_limit=24&thread_event_limit=50&include_sessions=false"));
+});
+
+test("transcript refreshes coalesce bursts and preserve structural snapshot state", async () => {
+  const first = deferred();
+  const trailing = deferred();
+  const pending = [first, trailing];
+  const requests = [];
+  const isolated = loadApp({
+    fetch(path) {
+      requests.push(path);
+      return pending.shift().promise;
+    },
+  });
+  const sessionId = "transcript-coordinator";
+  isolated.state.currentId = sessionId;
+  isolated.state.snapshots.set(sessionId, sessionSnapshot(sessionId, {
+    active_run: { run_id: "run-1", started_at_epoch_ms: 1 },
+    messages: [{ role: "user", content: "old" }],
+  }));
+
+  const initialLoad = isolated.loadTranscriptMessages(sessionId);
+  const queuedLoad = isolated.loadTranscriptMessages(sessionId);
+  assert.equal(initialLoad, queuedLoad);
+  assert.equal(requests.length, 1, "a burst during the active page GET queues one trailing GET");
+
+  first.resolve(jsonResponse({
+    messages: [{ role: "assistant", content: "stale" }],
+    page: { start: 0, end: 1, total: 1, has_older: false },
+  }));
+  await flushPromises();
+  await flushPromises();
+  await flushPromises();
+  assert.equal(requests.length, 2);
+  assert.equal(isolated.state.snapshots.get(sessionId).messages[0].content, "old",
+    "the invalidated transcript response is not accepted");
+
+  trailing.resolve(jsonResponse({
+    messages: [{ role: "user", content: "old" }, { role: "assistant", content: "fresh" }],
+    page: { start: 0, end: 2, total: 2, has_older: false },
+  }));
+  const [initialResult, queuedResult] = await Promise.all([initialLoad, queuedLoad]);
+  assert.equal(initialResult.messages[1].content, "fresh");
+  assert.equal(queuedResult.messages[1].content, "fresh");
+  assert.equal(initialResult.active_run.run_id, "run-1");
+  assert.equal(isolated.state.transcriptRefreshCoordinators.has(sessionId), false);
+  assert.deepEqual(requests, Array(2).fill(`/sessions/${sessionId}/messages?limit=24`));
 });
 
 test("a failed invalidated snapshot GET yields to its successful trailing refresh while terminal errors remain visible", async () => {

--- a/crates/nac-server/assets/app.test.js
+++ b/crates/nac-server/assets/app.test.js
@@ -1270,6 +1270,70 @@ test("transcript refreshes coalesce bursts and preserve structural snapshot stat
   assert.deepEqual(requests, Array(2).fill(`/sessions/${sessionId}/messages?limit=24`));
 });
 
+test("authoritative snapshots invalidate in-flight transcript refreshes so stale /messages cannot overwrite newer commits", async () => {
+  const transcriptPage = deferred();
+  const snapshot = deferred();
+  const requests = [];
+  const cleared = [];
+  let nextTimer = 100;
+  const isolated = loadApp({
+    fetch(path) {
+      requests.push(path);
+      if (path.includes("/messages?")) return transcriptPage.promise;
+      return snapshot.promise;
+    },
+    window: {
+      setTimeout() { nextTimer += 1; return nextTimer; },
+      clearTimeout(timer) { cleared.push(timer); },
+    },
+  });
+  const sessionId = "snapshot-supersedes-transcript";
+  isolated.state.currentId = sessionId;
+  isolated.state.snapshots.set(sessionId, sessionSnapshot(sessionId, {
+    messages: [{ role: "user", content: "prompt" }],
+  }));
+  // A pending debounced transcript refresh must not fire after a direct snapshot.
+  isolated.state.transcriptTimers.set(sessionId, 42);
+
+  const transcriptLoad = isolated.loadTranscriptMessages(sessionId);
+  assert.equal(requests.length, 1);
+  assert.match(requests[0], /\/messages\?/);
+
+  const snapshotLoad = isolated.loadSnapshot(sessionId, false);
+  assert.deepEqual(cleared, [42], "loadSnapshot cancels a pending transcript timer");
+  assert.equal(isolated.state.transcriptTimers.has(sessionId), false);
+  assert.equal(requests.length, 2, "the authoritative snapshot starts without waiting on /messages");
+  assert.match(requests[1], new RegExp(`/sessions/${sessionId}\\?`));
+
+  // Newer commits arrive on the snapshot while the older transcript page is still buffered.
+  snapshot.resolve(jsonResponse(sessionSnapshot(sessionId, {
+    messages: [
+      { role: "user", content: "prompt" },
+      { role: "assistant", content: "latest commit" },
+      { role: "user", content: "follow-up" },
+    ],
+    message_page: { start: 0, end: 3, total: 3, has_older: false },
+  })));
+  assert.equal((await snapshotLoad).messages.length, 3);
+  assert.deepEqual(
+    plain(isolated.state.snapshots.get(sessionId).messages.map((message) => message.content)),
+    ["prompt", "latest commit", "follow-up"]);
+
+  transcriptPage.resolve(jsonResponse({
+    messages: [
+      { role: "user", content: "prompt" },
+      { role: "assistant", content: "stale mid-run page" },
+    ],
+    page: { start: 0, end: 2, total: 2, has_older: false },
+  }));
+  assert.equal(await transcriptLoad, null, "the superseded transcript coordinator yields null");
+  assert.deepEqual(
+    plain(isolated.state.snapshots.get(sessionId).messages.map((message) => message.content)),
+    ["prompt", "latest commit", "follow-up"],
+    "a slower /messages response must not clobber the authoritative snapshot transcript");
+  assert.equal(isolated.state.transcriptRefreshCoordinators.has(sessionId), false);
+});
+
 test("a failed invalidated snapshot GET yields to its successful trailing refresh while terminal errors remain visible", async () => {
   const failed = deferred();
   const recovered = deferred();


### PR DESCRIPTION
## Description

**What.** Refreshes live transcript appends through the paged messages endpoint instead of rebuilding the full session snapshot.

**Why.** A message-only SSE event previously reloaded steering, threads, episodes, worksets, and workspace metadata, including several git subprocesses, on the latency-sensitive chat update path.

- Routes live `transcript_appended` events through `GET /sessions/{id}/messages?limit=24`.
- Merges the fresh tail into the current snapshot so loaded history, active-run state, and structural projections remain intact.
- Gives transcript refreshes a per-session debounce/coordinator so bursts coalesce, invalidated responses are discarded, and requests do not overlap.
- Keeps full snapshots authoritative for run lifecycle, steering, compaction, snapshot saves, replay gaps, lag recovery, and explicit refreshes.
- Cancels pending transcript timers and invalidates in-flight transcript responses whenever an authoritative snapshot load begins.

This changes only frontend invalidation granularity. Transcript durability, pagination, and replay-gap recovery are unchanged.

## Usage

No user action is required. During a live run, newly committed transcript messages appear through the existing paged transcript API while structural events continue to trigger full session refreshes.

## Changelog

- Reduces live transcript refresh work and payload size by avoiding unrelated session projections.
- Prevents stale paged transcript responses from overwriting a newer authoritative snapshot.

## Performance

Measured on an Apple M5 Pro running macOS/Darwin 25.5.0 in the Rust debug test profile. A one-off harness timed service work plus JSON serialization for the two endpoints selected by the `origin/main` UI behavior and this PR's UI behavior. Both paths ran against the same rebased backend and synthetic session: 1,000 visible messages, 24 threads, 192 episodes, and a git workspace with 160 modified files. Results use 5 warmups followed by 40 alternating samples; network transfer and browser rendering are excluded.

| Behavior | Mean | p50 | p95 | JSON payload |
|---|---:|---:|---:|---:|
| `origin/main` UI path: full snapshot | 47.299 ms | 46.392 ms | 51.110 ms | 90,937 B |
| PR UI path: paged message refresh | 0.209 ms | 0.218 ms | 0.265 ms | 5,908 B |

For this fixture, the PR path is **213.2× faster at p50**, **193.1× faster at p95**, and sends a **93.5% smaller payload**. Absolute values depend on repository and session size; the structural reduction comes from avoiding episode/workset loads and git subprocesses when only transcript messages changed.

## Validation

After rebasing onto `origin/main` at `456eb70`, `node --test crates/nac-server/assets/app.test.js` passed all 117 tests and `cargo test --workspace` passed all 592 executed tests with 2 live tests ignored. `git diff --check origin/main...HEAD` passed. The rebased `nac-web` binary was also launched against an isolated store and the session picker loaded successfully in Chromium without a store error.

Review covered correctness, completeness, security, scope, YAGNI, idiom, and elegance; all seven reviews completed without findings. Tests specifically cover lightweight event routing, preservation of structural snapshot state and loaded history, burst coalescing, stale-response rejection, and authoritative snapshot refreshes superseding pending or in-flight transcript work.
