### PR TITLE
Invalidate in-flight transcript refreshes when loading snapshots

### DIFF
--- a/crates/nac-server/assets/app.js
+++ b/crates/nac-server/assets/app.js
@@ -1059,8 +1059,26 @@ function showPicker(updateHash = true) {
   });
 }
 
+function cancelTranscriptRefresh(sessionId) {
+  const timer = state.transcriptTimers.get(sessionId);
+  if (timer != null) {
+    window.clearTimeout(timer);
+    state.transcriptTimers.delete(sessionId);
+  }
+  const coordinator = state.transcriptRefreshCoordinators.get(sessionId);
+  if (!coordinator) return;
+  // Authoritative snapshots supersede transcript pages: discard the in-flight
+  // request and do not schedule a trailing /messages retry.
+  coordinator.invalidation += 1;
+  coordinator.dirty = false;
+}
+
 function loadSnapshot(sessionId, announce = false) {
   if (!sessionId) return Promise.resolve(null);
+  // Full snapshots and transcript pages are mutually exclusive. Invalidate any
+  // in-flight /messages refresh so a slower response cannot overwrite newer
+  // messages after this authoritative snapshot is accepted.
+  cancelTranscriptRefresh(sessionId);
   const existing = state.snapshotRefreshCoordinators.get(sessionId);
   if (existing) {
     existing.invalidation += 1;
@@ -1638,6 +1656,8 @@ function eventNeedsSnapshot(envelope) {
 }
 
 function scheduleSnapshot(sessionId) {
+  // Pending transcript timers are cancelled inside loadSnapshot; clear early so
+  // scheduleTranscriptRefresh cannot race the debounce window.
   const transcriptTimer = state.transcriptTimers.get(sessionId);
   if (transcriptTimer != null) {
     window.clearTimeout(transcriptTimer);
@@ -1647,12 +1667,7 @@ function scheduleSnapshot(sessionId) {
   if (existing != null) window.clearTimeout(existing);
   const timer = window.setTimeout(() => {
     state.snapshotTimers.delete(sessionId);
-    const transcriptRefresh = state.transcriptRefreshCoordinators.get(sessionId);
-    if (transcriptRefresh) {
-      transcriptRefresh.promise.finally(() => loadSnapshot(sessionId, false));
-    } else {
-      loadSnapshot(sessionId, false);
-    }
+    loadSnapshot(sessionId, false);
   }, 120);
   state.snapshotTimers.set(sessionId, timer);
 }

--- a/crates/nac-server/assets/app.test.js
+++ b/crates/nac-server/assets/app.test.js
@@ -1270,6 +1270,70 @@ test("transcript refreshes coalesce bursts and preserve structural snapshot stat
   assert.deepEqual(requests, Array(2).fill(`/sessions/${sessionId}/messages?limit=24`));
 });
 
+test("authoritative snapshots invalidate in-flight transcript refreshes so stale /messages cannot overwrite newer commits", async () => {
+  const transcriptPage = deferred();
+  const snapshot = deferred();
+  const requests = [];
+  const cleared = [];
+  let nextTimer = 100;
+  const isolated = loadApp({
+    fetch(path) {
+      requests.push(path);
+      if (path.includes("/messages?")) return transcriptPage.promise;
+      return snapshot.promise;
+    },
+    window: {
+      setTimeout() { nextTimer += 1; return nextTimer; },
+      clearTimeout(timer) { cleared.push(timer); },
+    },
+  });
+  const sessionId = "snapshot-supersedes-transcript";
+  isolated.state.currentId = sessionId;
+  isolated.state.snapshots.set(sessionId, sessionSnapshot(sessionId, {
+    messages: [{ role: "user", content: "prompt" }],
+  }));
+  // A pending debounced transcript refresh must not fire after a direct snapshot.
+  isolated.state.transcriptTimers.set(sessionId, 42);
+
+  const transcriptLoad = isolated.loadTranscriptMessages(sessionId);
+  assert.equal(requests.length, 1);
+  assert.match(requests[0], /\/messages\?/);
+
+  const snapshotLoad = isolated.loadSnapshot(sessionId, false);
+  assert.deepEqual(cleared, [42], "loadSnapshot cancels a pending transcript timer");
+  assert.equal(isolated.state.transcriptTimers.has(sessionId), false);
+  assert.equal(requests.length, 2, "the authoritative snapshot starts without waiting on /messages");
+  assert.match(requests[1], new RegExp(`/sessions/${sessionId}\\?`));
+
+  // Newer commits arrive on the snapshot while the older transcript page is still buffered.
+  snapshot.resolve(jsonResponse(sessionSnapshot(sessionId, {
+    messages: [
+      { role: "user", content: "prompt" },
+      { role: "assistant", content: "latest commit" },
+      { role: "user", content: "follow-up" },
+    ],
+    message_page: { start: 0, end: 3, total: 3, has_older: false },
+  })));
+  assert.equal((await snapshotLoad).messages.length, 3);
+  assert.deepEqual(
+    plain(isolated.state.snapshots.get(sessionId).messages.map((message) => message.content)),
+    ["prompt", "latest commit", "follow-up"]);
+
+  transcriptPage.resolve(jsonResponse({
+    messages: [
+      { role: "user", content: "prompt" },
+      { role: "assistant", content: "stale mid-run page" },
+    ],
+    page: { start: 0, end: 2, total: 2, has_older: false },
+  }));
+  assert.equal(await transcriptLoad, null, "the superseded transcript coordinator yields null");
+  assert.deepEqual(
+    plain(isolated.state.snapshots.get(sessionId).messages.map((message) => message.content)),
+    ["prompt", "latest commit", "follow-up"],
+    "a slower /messages response must not clobber the authoritative snapshot transcript");
+  assert.equal(isolated.state.transcriptRefreshCoordinators.has(sessionId), false);
+});
+
 test("a failed invalidated snapshot GET yields to its successful trailing refresh while terminal errors remain visible", async () => {
   const failed = deferred();
   const recovered = deferred();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Transcript-only `/messages` refreshes and full-session snapshots were not mutually exclusive. `scheduleSnapshot` waited on an in-flight transcript coordinator, but direct `loadSnapshot` callers (`visibilitychange`, `replay_gap`, `lagged`, and others) did not invalidate or wait. A slower transcript page could still reach `acceptTranscriptPage` and overwrite newer `messages` from an authoritative snapshot, dropping later commits until another refresh.

## Fix

- Add `cancelTranscriptRefresh` to clear pending transcript timers and invalidate any in-flight transcript coordinator (`invalidation++`, `dirty = false` so it does not retry).
- Call it at the start of every `loadSnapshot`, so all authoritative snapshot paths supersede transcript pages.
- Simplify `scheduleSnapshot` to always call `loadSnapshot` directly; waiting on `/messages` is no longer required for correctness.

## Test plan

- [x] `node --test crates/nac-server/assets/app.test.js` (117 pass)
- [x] New regression: authoritative snapshot invalidates in-flight `/messages` and rejects the stale page after newer commits are accepted
- [x] Existing transcript coalesce + SSE transcript_appended scenarios still pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49ff54c1-c5fc-46ef-97ab-5e599129884c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49ff54c1-c5fc-46ef-97ab-5e599129884c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

