### PR TITLE
Make session polling independent of transcript size

### DIFF
--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -338,7 +338,7 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
 }
 
 pub fn list_sessions(path: &Path) -> Result<Vec<SessionSummary>> {
-    let conn = crate::store::open_connection(path)?;
+    let conn = crate::store::open_runtime_connection(path)?;
     query_session_summaries(&conn, None)
 }
 
@@ -563,58 +563,51 @@ fn normalize_presentation_title(
     Ok((!title.is_empty()).then(|| title.to_string()))
 }
 
+const SESSION_SUMMARY_QUERY_HEAD: &str = r#"
+SELECT s.session_id, s.cwd, s.model, s.backend, s.reasoning_effort,
+       s.extra_headers_json, s.sandbox_json, s.created_at, s.updated_at, s.host_id,
+       p.title, COALESCE(p.pinned, 0), COALESCE(p.sort_order, 0),
+       COALESCE(p.version, 0), s.visible_message_count, s.last_user_prompt
+FROM sessions s
+LEFT JOIN session_presentations p ON p.session_id = s.session_id
+"#;
+
 fn query_session_summary(
     conn: &rusqlite::Connection,
     session_id: &str,
 ) -> Result<Option<SessionSummary>> {
+    let sql = format!("{SESSION_SUMMARY_QUERY_HEAD} WHERE s.session_id = ?1");
     let row = conn
         .query_row(
-            "SELECT s.session_id, s.cwd, s.model, s.backend, s.reasoning_effort,
-                    s.extra_headers_json, s.sandbox_json, s.messages_json, s.created_at,
-                    s.updated_at, s.host_id, p.title, COALESCE(p.pinned, 0),
-                    COALESCE(p.sort_order, 0), COALESCE(p.version, 0)
-             FROM sessions s
-             LEFT JOIN session_presentations p ON p.session_id = s.session_id
-             WHERE s.session_id = ?1",
+            &sql,
             params![session_id],
             map_session_summary_row,
         )
         .optional()?;
-    row.map(|row| row.into_summary(conn)).transpose()
+    row.map(SessionSummaryRow::into_summary).transpose()
 }
 
 fn query_session_summaries(
     conn: &rusqlite::Connection,
     pinned: Option<bool>,
 ) -> Result<Vec<SessionSummary>> {
-    let sql = match pinned {
+    let suffix = match pinned {
         Some(_) => {
-            "SELECT s.session_id, s.cwd, s.model, s.backend, s.reasoning_effort,
-                    s.extra_headers_json, s.sandbox_json, s.messages_json, s.created_at,
-                    s.updated_at, s.host_id, p.title, COALESCE(p.pinned, 0),
-                    COALESCE(p.sort_order, 0), COALESCE(p.version, 0)
-             FROM sessions s
-             LEFT JOIN session_presentations p ON p.session_id = s.session_id
-             WHERE COALESCE(p.pinned, 0) = ?1
+            "WHERE COALESCE(p.pinned, 0) = ?1
              ORDER BY COALESCE(p.pinned, 0) DESC,
                       COALESCE(p.sort_order, 0) ASC,
                       s.created_at DESC,
                       s.session_id DESC"
         }
         None => {
-            "SELECT s.session_id, s.cwd, s.model, s.backend, s.reasoning_effort,
-                    s.extra_headers_json, s.sandbox_json, s.messages_json, s.created_at,
-                    s.updated_at, s.host_id, p.title, COALESCE(p.pinned, 0),
-                    COALESCE(p.sort_order, 0), COALESCE(p.version, 0)
-             FROM sessions s
-             LEFT JOIN session_presentations p ON p.session_id = s.session_id
-             ORDER BY COALESCE(p.pinned, 0) DESC,
+            "ORDER BY COALESCE(p.pinned, 0) DESC,
                       COALESCE(p.sort_order, 0) ASC,
                       s.created_at DESC,
                       s.session_id DESC"
         }
     };
-    let mut stmt = conn.prepare(sql)?;
+    let sql = format!("{SESSION_SUMMARY_QUERY_HEAD} {suffix}");
+    let mut stmt = conn.prepare(&sql)?;
     let rows = match pinned {
         Some(pinned) => stmt
             .query_map(params![i64::from(pinned)], map_session_summary_row)?
@@ -623,7 +616,9 @@ fn query_session_summaries(
             .query_map([], map_session_summary_row)?
             .collect::<rusqlite::Result<Vec<_>>>()?,
     };
-    rows.into_iter().map(|row| row.into_summary(conn)).collect()
+    rows.into_iter()
+        .map(SessionSummaryRow::into_summary)
+        .collect()
 }
 
 fn map_session_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionSummaryRow> {
@@ -635,14 +630,15 @@ fn map_session_summary_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionS
         reasoning_effort_raw: row.get(4)?,
         extra_headers_json: row.get(5)?,
         sandbox_json: row.get(6)?,
-        messages_json: row.get(7)?,
-        created_at: row.get(8)?,
-        updated_at: row.get(9)?,
-        ssh_host: row.get(10)?,
-        title: row.get(11)?,
-        pinned: row.get::<_, i64>(12)? != 0,
-        sort_order: row.get(13)?,
-        presentation_version: row.get(14)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+        ssh_host: row.get(9)?,
+        title: row.get(10)?,
+        pinned: row.get::<_, i64>(11)? != 0,
+        sort_order: row.get(12)?,
+        presentation_version: row.get(13)?,
+        visible_message_count: row.get(14)?,
+        last_user_prompt: row.get(15)?,
     })
 }
 
@@ -654,7 +650,6 @@ struct SessionSummaryRow {
     reasoning_effort_raw: Option<String>,
     extra_headers_json: Option<String>,
     sandbox_json: Option<String>,
-    messages_json: String,
     created_at: String,
     updated_at: String,
     ssh_host: Option<String>,
@@ -662,10 +657,12 @@ struct SessionSummaryRow {
     pinned: bool,
     sort_order: i64,
     presentation_version: i64,
+    visible_message_count: i64,
+    last_user_prompt: Option<String>,
 }
 
 impl SessionSummaryRow {
-    fn into_summary(self, conn: &rusqlite::Connection) -> Result<SessionSummary> {
+    fn into_summary(self) -> Result<SessionSummary> {
         let diagnostics = model_config_diagnostics(
             self.backend_raw.as_deref(),
             self.reasoning_effort_raw.as_deref(),
@@ -683,16 +680,8 @@ impl SessionSummaryRow {
                 None => Some(cwd.clone()),
             }
         };
-        let messages: Vec<Message> = serde_json::from_str(&self.messages_json)
-            .context("failed to parse stored session messages")?;
-        // Never-fold (step 4): messages_json is the write-once blob (system
-        // head ++ legacy prefix); the recent transcript is the orchestrator
-        // transcript log. Summary stats are blob stats ++ log stats (SQL
-        // aggregates over the log payload, no Message decode). A pre-log
-        // session has no log rows and gets exactly the pre-log numbers.
-        let log_visible =
-            crate::store::count_visible_transcript_log_messages(conn, &self.session_id)?;
-        let log_last_user = crate::store::last_transcript_log_user_prompt(conn, &self.session_id)?;
+        let visible_message_count = usize::try_from(self.visible_message_count)
+            .context("session visible message count overflowed")?;
         Ok(SessionSummary {
             session_id: self.session_id,
             cwd,
@@ -700,8 +689,8 @@ impl SessionSummaryRow {
             model: self.model,
             backend,
             model_config_error: (!diagnostics.is_empty()).then(|| diagnostics.join("; ")),
-            visible_message_count: visible_message_count(&messages) + log_visible,
-            last_user_prompt: log_last_user.or_else(|| last_user_prompt(&messages)),
+            visible_message_count,
+            last_user_prompt: self.last_user_prompt,
             sandboxed,
             ssh_host: self.ssh_host,
             title: self.title,
@@ -736,6 +725,9 @@ fn insert_or_replace_session(
     // transcript again.
     let messages_json = serde_json::to_string(&snapshot.messages)
         .context("failed to serialize session messages")?;
+    let summary_visible_message_count = i64::try_from(visible_message_count(&snapshot.messages))
+        .context("session visible message count overflowed")?;
+    let summary_last_user_prompt = last_user_prompt(&snapshot.messages);
     let response_durations_ms_json = snapshot
         .response_durations_ms
         .as_ref()
@@ -764,13 +756,23 @@ fn insert_or_replace_session(
     // actually opened for this write and is never read back.
     tx.execute(
         "INSERT INTO sessions (
-             session_id, cwd, store_path, model, base_url, backend, reasoning_effort, sandbox_json, messages_json, last_response_duration_ms, previous_response_duration_ms, response_durations_ms_json, created_at, updated_at, host_id, api_key_env, extra_headers_json, token_usages_json, config_version, orchestrator_compaction_threshold
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20)
+             session_id, cwd, store_path, model, base_url, backend, reasoning_effort,
+             sandbox_json, messages_json, visible_message_count, last_user_prompt,
+             last_response_duration_ms, previous_response_duration_ms,
+             response_durations_ms_json, created_at, updated_at, host_id, api_key_env,
+             extra_headers_json, token_usages_json, config_version,
+             orchestrator_compaction_threshold
+         ) VALUES (
+             ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+             ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+         )
          ON CONFLICT(session_id) DO UPDATE SET
              cwd = excluded.cwd,
              store_path = excluded.store_path,
              sandbox_json = excluded.sandbox_json,
              messages_json = excluded.messages_json,
+             visible_message_count = excluded.visible_message_count,
+             last_user_prompt = excluded.last_user_prompt,
              last_response_duration_ms = excluded.last_response_duration_ms,
              previous_response_duration_ms = excluded.previous_response_duration_ms,
              response_durations_ms_json = excluded.response_durations_ms_json,
@@ -787,6 +789,8 @@ fn insert_or_replace_session(
             snapshot.reasoning_effort.map(|effort| effort.as_str().to_string()),
             sandbox_json,
             messages_json,
+            summary_visible_message_count,
+            summary_last_user_prompt,
             snapshot.last_response_duration_ms,
             snapshot.previous_response_duration_ms,
             response_durations_ms_json,

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -30,7 +30,7 @@ pub type SessionRunLeaseError = SessionOperationLeaseError;
 pub use snapshot::{new_snapshot, refresh_snapshot, SessionRunState, SessionRunStateUpdate};
 
 use codec::*;
-use summary::*;
+pub(crate) use summary::{last_user_prompt, visible_message_count};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RawSessionConfig {

--- a/crates/nac-core/src/sessions/summary.rs
+++ b/crates/nac-core/src/sessions/summary.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub(super) fn visible_message_count(messages: &[Message]) -> usize {
+pub(crate) fn visible_message_count(messages: &[Message]) -> usize {
     messages
         .iter()
         .filter(|message| match message {
@@ -15,7 +15,7 @@ pub(super) fn visible_message_count(messages: &[Message]) -> usize {
         .count()
 }
 
-pub(super) fn last_user_prompt(messages: &[Message]) -> Option<String> {
+pub(crate) fn last_user_prompt(messages: &[Message]) -> Option<String> {
     messages.iter().rev().find_map(|message| match message {
         Message::User { content } => Some(content.clone()),
         _ => None,

--- a/crates/nac-core/src/store/schema.rs
+++ b/crates/nac-core/src/store/schema.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-const STORE_SCHEMA_VERSION: i64 = 3;
+const STORE_SCHEMA_VERSION: i64 = 4;
 
 /// Default SQLite store path under the nac home, or `.nac/store.db` as fallback.
 pub fn default_store_path() -> PathBuf {
@@ -47,6 +47,7 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
     let transaction = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
     let schema_version: i64 =
         transaction.pragma_query_value(None, "user_version", |row| row.get(0))?;
+    let needs_session_summary_backfill = schema_version < STORE_SCHEMA_VERSION;
     match schema_version {
         0 | 1 => {
             create_base_schema(&transaction)?;
@@ -89,10 +90,10 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
             migrate_thread_events(&transaction)?;
             transaction.execute_batch("DROP TABLE IF EXISTS session_overviews")?;
         }
-        2 | STORE_SCHEMA_VERSION => {}
+        2 | 3 | STORE_SCHEMA_VERSION => {}
         unsupported => {
             return Err(anyhow!(
-                "unsupported store schema version {unsupported}; this build supports versions 0, 1, 2, and {STORE_SCHEMA_VERSION}"
+                "unsupported store schema version {unsupported}; this build supports versions 0, 1, 2, 3, and {STORE_SCHEMA_VERSION}"
             ));
         }
     }
@@ -106,6 +107,16 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
             crate::MAX_SUPPORTED_TOKEN_COUNT
         ),
     )?;
+    ensure_column(
+        &transaction,
+        "sessions",
+        "visible_message_count",
+        "INTEGER NOT NULL DEFAULT 0 CHECK (visible_message_count >= 0)",
+    )?;
+    ensure_column(&transaction, "sessions", "last_user_prompt", "TEXT")?;
+    if needs_session_summary_backfill {
+        backfill_session_summaries(&transaction)?;
+    }
     create_orchestrator_compaction_checkpoints_table(&transaction)?;
     verify_auxiliary_foreign_keys(&transaction)?;
 
@@ -171,6 +182,9 @@ fn create_base_schema(conn: &Connection) -> Result<()> {
              reasoning_effort TEXT,
              sandbox_json TEXT,
              messages_json TEXT NOT NULL,
+             visible_message_count INTEGER NOT NULL DEFAULT 0
+                 CHECK (visible_message_count >= 0),
+             last_user_prompt TEXT,
              last_response_duration_ms INTEGER,
              previous_response_duration_ms INTEGER,
              response_durations_ms_json TEXT,
@@ -583,6 +597,45 @@ fn ensure_column(conn: &Connection, table: &str, column: &str, definition: &str)
     }
     let alter = format!("ALTER TABLE {table} ADD COLUMN {column} {definition}");
     conn.execute(&alter, [])?;
+    Ok(())
+}
+
+fn backfill_session_summaries(conn: &Connection) -> Result<()> {
+    let rows = {
+        let mut statement = conn.prepare("SELECT session_id, messages_json FROM sessions")?;
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+    for (session_id, messages_json) in rows {
+        let messages: Vec<crate::types::Message> = serde_json::from_str(&messages_json)
+            .with_context(|| {
+                format!("failed to parse stored messages for session '{session_id}'")
+            })?;
+        let blob_visible = crate::sessions::visible_message_count(&messages);
+        let log_from_idx =
+            u64::try_from(messages.len()).context("session transcript length overflowed")?;
+        let log_visible =
+            crate::store::count_visible_transcript_log_messages(conn, &session_id, log_from_idx)?;
+        let visible_count = i64::try_from(
+            blob_visible
+                .checked_add(log_visible)
+                .context("session visible message count overflowed")?,
+        )
+        .context("session visible message count overflowed")?;
+        let last_user_prompt =
+            crate::store::last_transcript_log_user_prompt(conn, &session_id, log_from_idx)?
+                .or_else(|| crate::sessions::last_user_prompt(&messages));
+        conn.execute(
+            "UPDATE sessions
+             SET visible_message_count = ?1, last_user_prompt = ?2
+             WHERE session_id = ?3",
+            params![visible_count, last_user_prompt, session_id],
+        )?;
+    }
     Ok(())
 }
 

--- a/crates/nac-core/src/store/schema_tests.rs
+++ b/crates/nac-core/src/store/schema_tests.rs
@@ -130,9 +130,14 @@ fn assert_session_cascade(conn: &Connection, table: &str) {
 }
 
 fn assert_current_schema(conn: &Connection) {
-    assert!(table_columns(conn, "sessions")
-        .iter()
-        .any(|column| column == "orchestrator_compaction_threshold"));
+    let session_columns = table_columns(conn, "sessions");
+    for expected in [
+        "orchestrator_compaction_threshold",
+        "visible_message_count",
+        "last_user_prompt",
+    ] {
+        assert!(session_columns.iter().any(|column| column == expected));
+    }
     assert_eq!(
         table_columns(conn, "thread_steering"),
         [
@@ -237,7 +242,7 @@ fn assert_current_schema(conn: &Connection) {
 }
 
 #[test]
-fn main_v0_store_migrates_directly_to_v3() {
+fn main_v0_store_migrates_directly_to_v4() {
     let path = temp_store_path("main_v0");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     let legacy = Connection::open(&path).unwrap();
@@ -315,7 +320,7 @@ fn partial_v1_tables_at_version_zero_are_rebuilt() {
 }
 
 #[test]
-fn v1_to_v3_preserves_owned_rows_drops_orphans_and_sequences() {
+fn v1_to_v4_preserves_owned_rows_drops_orphans_and_sequences() {
     let path = temp_store_path("v1");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     let legacy = Connection::open(&path).unwrap();
@@ -472,7 +477,7 @@ fn v1_to_v3_preserves_owned_rows_drops_orphans_and_sequences() {
 fn transcript_log_rows_survive_thread_events_rebuild_migration() {
     // Pins the invariant that the thread_events sanitize-drop rebuild (and any
     // future rebuild-migration) carries transcript log rows through verbatim.
-    // Current v3 DBs never re-run this migration, but the assertion keeps the
+    // Current v4 DBs never re-run this migration, but the assertion keeps the
     // pattern honest for future rebuilds.
     let path = temp_store_path("transcript_survival");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -565,7 +570,7 @@ fn transcript_log_rows_survive_thread_events_rebuild_migration() {
 }
 
 #[test]
-fn v2_to_v3_adds_threshold_and_empty_checkpoint_storage() {
+fn v2_to_v4_adds_threshold_and_empty_checkpoint_storage() {
     let path = temp_store_path("v2");
     initialize(&path).unwrap();
     let conn = open_runtime_connection(&path).unwrap();
@@ -640,6 +645,90 @@ fn v2_to_v3_adds_threshold_and_empty_checkpoint_storage() {
             [],
         )
         .unwrap();
+    drop(migrated);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
+fn v3_to_v4_backfills_materialized_session_summaries() {
+    let path = temp_store_path("v3_blob_summary");
+    initialize(&path).unwrap();
+    let conn = open_runtime_connection(&path).unwrap();
+    let messages = serde_json::to_string(&vec![
+        crate::types::Message::System {
+            content: "system".to_string(),
+        },
+        crate::types::Message::User {
+            content: "first prompt".to_string(),
+        },
+        crate::types::Message::Assistant {
+            content: Some("answer".to_string()),
+            reasoning_text: None,
+            reasoning_details: None,
+            tool_calls: None,
+        },
+        crate::types::Message::User {
+            content: "latest prompt".to_string(),
+        },
+    ])
+    .unwrap();
+    conn.execute(
+        "INSERT INTO sessions
+             (session_id, cwd, store_path, model, base_url, messages_json,
+              created_at, updated_at)
+         VALUES ('owned', '/tmp/project', '/tmp/store.db', 'model',
+                 'https://example.invalid', ?1, 'created', 'updated')",
+        params![messages],
+    )
+    .unwrap();
+    let covered_log_entry = encode_transcript_log_entry(
+        1,
+        &crate::types::Message::User {
+            content: "covered log prompt".to_string(),
+        },
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO thread_events (session_id, thread_name, event_json, created_at)
+         VALUES ('owned', ?1, ?2, 'created')",
+        params![ORCHESTRATOR_STEERING_TARGET, covered_log_entry],
+    )
+    .unwrap();
+    let log_entry = encode_transcript_log_entry(
+        4,
+        &crate::types::Message::User {
+            content: "log prompt".to_string(),
+        },
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO thread_events (session_id, thread_name, event_json, created_at)
+         VALUES ('owned', ?1, ?2, 'created')",
+        params![ORCHESTRATOR_STEERING_TARGET, log_entry],
+    )
+    .unwrap();
+    conn.execute_batch(
+        "ALTER TABLE sessions DROP COLUMN last_user_prompt;
+         ALTER TABLE sessions DROP COLUMN visible_message_count;
+         PRAGMA user_version = 3;",
+    )
+    .unwrap();
+    drop(conn);
+
+    initialize(&path).unwrap();
+
+    let migrated = open_runtime_connection(&path).unwrap();
+    assert_current_schema(&migrated);
+    let summary: (i64, Option<String>) = migrated
+        .query_row(
+            "SELECT visible_message_count, last_user_prompt
+             FROM sessions WHERE session_id = 'owned'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(summary, (4, Some("log prompt".to_string())));
+
     drop(migrated);
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
@@ -747,25 +836,25 @@ fn future_schema_version_is_rejected_without_changes() {
     let path = temp_store_path("future");
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     let future = Connection::open(&path).unwrap();
-    future.pragma_update(None, "user_version", 4).unwrap();
+    future.pragma_update(None, "user_version", 5).unwrap();
     drop(future);
 
     let error = initialize(&path).unwrap_err();
     assert!(error
         .to_string()
-        .contains("unsupported store schema version 4"));
+        .contains("unsupported store schema version 5"));
     let unchanged = Connection::open(&path).unwrap();
     let version: i64 = unchanged
         .pragma_query_value(None, "user_version", |row| row.get(0))
         .unwrap();
-    assert_eq!(version, 4);
+    assert_eq!(version, 5);
     assert!(!table_exists(&unchanged, "sessions").unwrap());
     drop(unchanged);
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
 
 #[test]
-fn opening_v3_store_is_idempotent() {
+fn opening_v4_store_is_idempotent() {
     let path = temp_store_path("idempotent");
     initialize(&path).unwrap();
     let conn = open_runtime_connection(&path).unwrap();

--- a/crates/nac-core/src/store/transcript.rs
+++ b/crates/nac-core/src/store/transcript.rs
@@ -85,13 +85,15 @@
 //! carried in) and the transcript lives here, appends-only forever. The
 //! run-end token/timing bookkeeping diffs store-backed visible-response
 //! counts (run start vs run end) and `sessions::save_session_run_state`
-//! UPDATEs only run-state columns. Session summaries (visible message
-//! count, last user prompt) are blob stats ++ the SQL log stats below —
-//! the blob alone is no longer the transcript. DOWNGRADE CAVEAT (accepted
-//! by the user): a build older than the transcript-log workset reads only
-//! `messages_json`, so it shows this store's history truncated to the
-//! head/legacy prefix — invisibility, not corruption; the log rows are
-//! untouched and a current build reads the full transcript again.
+//! UPDATEs only run-state columns. Session summaries (visible message count,
+//! last user prompt) are materialized on `sessions`: append updates them in
+//! the same transaction as the log rows, while tail truncation rebuilds them
+//! from blob ++ remaining log. The polling read path therefore never scans
+//! transcript history. DOWNGRADE CAVEAT (accepted by the user): a build older
+//! than the transcript-log workset reads only `messages_json`, so it shows
+//! this store's history truncated to the head/legacy prefix — invisibility,
+//! not corruption; the log rows are untouched and a current build reads the
+//! full transcript again.
 //!
 //! # Guards (landed with step 1)
 //!
@@ -194,21 +196,20 @@ pub fn decode_transcript_log_entry(event_json: &str) -> Option<TranscriptLogEntr
         .map(|payload| payload.nac_transcript_message)
 }
 
-/// Visible-message count over a session's transcript log, for session
-/// summaries (step 4, never-fold: the blob alone is no longer the
-/// transcript). The predicate is exactly `visible_message_count`
-/// (sessions/summary.rs) applied to log rows — User rows, plus Assistant
-/// rows with content and no tool calls — evaluated in SQL over the payload's
-/// kind tag and the canonical message bytes, so listing sessions never
-/// decodes `Message` values. Rows that are not transcript payloads (foreign
-/// rows under the reserved name) extract NULL kind and are not counted.
-/// Runs per session per list query: an indexed (session_id, thread_name)
-/// scan of that session's rows only, no row materialization.
-pub fn count_visible_transcript_log_messages(conn: &Connection, session_id: &str) -> Result<usize> {
+/// Visible-message count over one session's transcript-log tail beginning at
+/// `from_idx`; rows already covered by the snapshot blob are ignored.
+/// Session-summary migration and tail truncation use this to rebuild the
+/// materialized count; the polling read path never scans the log.
+pub fn count_visible_transcript_log_messages(
+    conn: &Connection,
+    session_id: &str,
+    from_idx: u64,
+) -> Result<usize> {
     let count = conn.query_row(
         "SELECT COUNT(*)
          FROM thread_events
          WHERE session_id = ?1 AND thread_name = ?2
+           AND json_extract(event_json, '$.nac_transcript_message.idx') >= ?3
            AND (
                json_extract(event_json, '$.nac_transcript_message.kind') = 'user'
                OR (
@@ -226,20 +227,18 @@ pub fn count_visible_transcript_log_messages(conn: &Connection, session_id: &str
                    ) = 0
                )
            )",
-        params![session_id, ORCHESTRATOR_STEERING_TARGET],
+        params![session_id, ORCHESTRATOR_STEERING_TARGET, from_idx],
         |row| row.get::<_, i64>(0),
     )?;
     usize::try_from(count).context("transcript log visible message count overflowed")
 }
 
-/// Most recent User message content in a session's transcript log, for
-/// session summaries (step 4). `None` when the log holds no User rows — the
-/// caller then falls back to the blob's last user prompt (pre-log sessions).
-/// Rowid order is append order under the module invariants, so the latest
-/// User row is a bounded backwards scan.
+/// Most recent User message content in one session's transcript-log tail
+/// beginning at `from_idx`; rows covered by the snapshot blob are ignored.
 pub fn last_transcript_log_user_prompt(
     conn: &Connection,
     session_id: &str,
+    from_idx: u64,
 ) -> Result<Option<String>> {
     conn.query_row(
         "SELECT json_extract(
@@ -249,9 +248,10 @@ pub fn last_transcript_log_user_prompt(
          FROM thread_events
          WHERE session_id = ?1 AND thread_name = ?2
            AND json_extract(event_json, '$.nac_transcript_message.kind') = 'user'
+           AND json_extract(event_json, '$.nac_transcript_message.idx') >= ?3
          ORDER BY id DESC
          LIMIT 1",
-        params![session_id, ORCHESTRATOR_STEERING_TARGET],
+        params![session_id, ORCHESTRATOR_STEERING_TARGET, from_idx],
         |row| row.get::<_, Option<String>>(0),
     )
     .optional()
@@ -296,6 +296,9 @@ impl TranscriptLogWriter {
         if messages.is_empty() {
             return Ok(());
         }
+        let visible_delta = i64::try_from(crate::sessions::visible_message_count(messages))
+            .context("transcript visible message count overflowed")?;
+        let last_user_prompt = crate::sessions::last_user_prompt(messages);
         let mut connection = self
             .connection
             .lock()
@@ -314,6 +317,18 @@ impl TranscriptLogWriter {
                     now_utc()
                 ],
             )?;
+        }
+        let updated = transaction.execute(
+            "UPDATE sessions
+             SET visible_message_count = visible_message_count + ?1,
+                 last_user_prompt = COALESCE(?2, last_user_prompt)
+             WHERE session_id = ?3",
+            params![visible_delta, last_user_prompt, session_id],
+        )?;
+        if updated != 1 {
+            return Err(anyhow!(
+                "transcript summary update expected one session row, updated {updated}"
+            ));
         }
         transaction.commit()?;
         Ok(())
@@ -506,9 +521,41 @@ impl TranscriptLogWriter {
         for id in &row_ids {
             transaction.execute("DELETE FROM thread_events WHERE id = ?1", params![id])?;
         }
+        if !row_ids.is_empty() {
+            refresh_session_summary(&transaction, session_id)?;
+        }
         transaction.commit()?;
         Ok(row_ids.len())
     }
+}
+
+fn refresh_session_summary(conn: &Connection, session_id: &str) -> Result<()> {
+    let messages_json: String = conn.query_row(
+        "SELECT messages_json FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+    )?;
+    let messages: Vec<Message> =
+        serde_json::from_str(&messages_json).context("failed to parse stored session messages")?;
+    let blob_visible = crate::sessions::visible_message_count(&messages);
+    let log_from_idx =
+        u64::try_from(messages.len()).context("session transcript length overflowed")?;
+    let log_visible = count_visible_transcript_log_messages(conn, session_id, log_from_idx)?;
+    let visible_count = i64::try_from(
+        blob_visible
+            .checked_add(log_visible)
+            .context("session visible message count overflowed")?,
+    )
+    .context("session visible message count overflowed")?;
+    let last_user_prompt = last_transcript_log_user_prompt(conn, session_id, log_from_idx)?
+        .or_else(|| crate::sessions::last_user_prompt(&messages));
+    conn.execute(
+        "UPDATE sessions
+         SET visible_message_count = ?1, last_user_prompt = ?2
+         WHERE session_id = ?3",
+        params![visible_count, last_user_prompt, session_id],
+    )?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -701,6 +748,9 @@ mod tests {
         let tail = writer.read_from("session-a", 8).unwrap();
         assert_eq!(tail.len(), 1);
         assert_eq!(tail[0].0, 8);
+        let summary = crate::sessions::list_sessions(&path).unwrap().remove(0);
+        assert_eq!(summary.visible_message_count, 2);
+        assert_eq!(summary.last_user_prompt.as_deref(), Some("tail"));
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
@@ -723,6 +773,13 @@ mod tests {
         assert_eq!(remaining.len(), 2);
         assert_eq!(remaining[0].0, 0);
         assert_eq!(remaining[1].0, 1);
+        let summary = crate::sessions::list_sessions(&path)
+            .unwrap()
+            .into_iter()
+            .find(|summary| summary.session_id == "session-a")
+            .unwrap();
+        assert_eq!(summary.visible_message_count, 1);
+        assert_eq!(summary.last_user_prompt.as_deref(), Some("prompt"));
 
         // Beyond-the-end truncation is a no-op; other sessions are untouched.
         assert_eq!(writer.delete_from("session-a", 99).unwrap(), 0);
@@ -730,6 +787,99 @@ mod tests {
 
         assert_eq!(writer.delete_from("session-a", 0).unwrap(), 2);
         assert!(writer.read_from("session-a", 0).unwrap().is_empty());
+        let summary = crate::sessions::list_sessions(&path)
+            .unwrap()
+            .into_iter()
+            .find(|summary| summary.session_id == "session-a")
+            .unwrap();
+        assert_eq!(summary.visible_message_count, 0);
+        assert_eq!(summary.last_user_prompt, None);
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+
+    #[test]
+    fn transcript_log_summary_refresh_ignores_blob_covered_rows() {
+        let path = temp_store_path("summary_covered_rows");
+        initialize(&path).unwrap();
+        let snapshot = crate::sessions::new_snapshot(
+            "session-a".to_string(),
+            PathBuf::from("/tmp/project"),
+            "test-model".to_string(),
+            "https://example.invalid".to_string(),
+            crate::model::BackendKind::OpenAiResponses,
+            None,
+            None,
+            None,
+            Vec::new(),
+            None,
+            std::collections::BTreeMap::new(),
+        );
+        crate::sessions::create_session(&path, &snapshot).unwrap();
+
+        let writer = TranscriptLogWriter::new(&path).unwrap();
+        writer
+            .append_batch(
+                "session-a",
+                0,
+                &[
+                    Message::User {
+                        content: "stale covered prompt".to_string(),
+                    },
+                    Message::Assistant {
+                        content: Some("stale covered answer".to_string()),
+                        reasoning_text: None,
+                        reasoning_details: None,
+                        tool_calls: None,
+                    },
+                ],
+            )
+            .unwrap();
+
+        let mut snapshot = crate::sessions::load_session(&path, "session-a").unwrap();
+        snapshot.messages = vec![
+            Message::User {
+                content: "blob replacement prompt".to_string(),
+            },
+            Message::Assistant {
+                content: Some("blob replacement answer".to_string()),
+                reasoning_text: None,
+                reasoning_details: None,
+                tool_calls: None,
+            },
+        ];
+        crate::sessions::save_session(&path, &snapshot).unwrap();
+
+        writer
+            .append_batch(
+                "session-a",
+                2,
+                &[
+                    Message::User {
+                        content: "live prompt".to_string(),
+                    },
+                    Message::Assistant {
+                        content: Some("live answer".to_string()),
+                        reasoning_text: None,
+                        reasoning_details: None,
+                        tool_calls: None,
+                    },
+                ],
+            )
+            .unwrap();
+
+        assert_eq!(writer.delete_from("session-a", 3).unwrap(), 1);
+        let summary = crate::sessions::list_sessions(&path).unwrap().remove(0);
+        assert_eq!(summary.visible_message_count, 3);
+        assert_eq!(summary.last_user_prompt.as_deref(), Some("live prompt"));
+
+        assert_eq!(writer.delete_from("session-a", 2).unwrap(), 1);
+        let summary = crate::sessions::list_sessions(&path).unwrap().remove(0);
+        assert_eq!(summary.visible_message_count, 2);
+        assert_eq!(
+            summary.last_user_prompt.as_deref(),
+            Some("blob replacement prompt")
+        );
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
@@ -947,12 +1097,12 @@ mod tests {
 
         let conn = open_connection(&path).unwrap();
         assert_eq!(
-            count_visible_transcript_log_messages(&conn, "session-a").unwrap(),
+            count_visible_transcript_log_messages(&conn, "session-a", 1).unwrap(),
             4,
             "user rows plus content-bearing, tool-call-free assistant rows"
         );
         assert_eq!(
-            last_transcript_log_user_prompt(&conn, "session-a")
+            last_transcript_log_user_prompt(&conn, "session-a", 1)
                 .unwrap()
                 .as_deref(),
             Some("latest prompt")
@@ -961,11 +1111,11 @@ mod tests {
         // A session with no log rows gets the empty stats (the caller falls
         // back to the blob's last user prompt).
         assert_eq!(
-            count_visible_transcript_log_messages(&conn, "session-b").unwrap(),
+            count_visible_transcript_log_messages(&conn, "session-b", 0).unwrap(),
             0
         );
         assert_eq!(
-            last_transcript_log_user_prompt(&conn, "session-b").unwrap(),
+            last_transcript_log_user_prompt(&conn, "session-b", 0).unwrap(),
             None
         );
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -545,7 +545,10 @@ impl SessionManager {
             return Ok(Vec::new());
         }
 
-        let summaries = view::list_sessions(&self.inner.store_path)?;
+        let store_path = self.inner.store_path.clone();
+        let summaries = tokio::task::spawn_blocking(move || view::list_sessions(&store_path))
+            .await
+            .context("session list task failed")??;
         let mut sessions = {
             let active = self.inner.active_sessions.read().await;
             summaries


### PR DESCRIPTION
## Description

**What.** Materializes session-list message counts and latest prompts so the five-second web poll reads scalar metadata instead of transcript history.

**Why.** Session-list latency previously grew with retained transcript size and performed synchronous SQLite work on the async executor.

- Derives `visible_message_count` and `last_user_prompt` when creating or replacing a session snapshot.
- Updates both fields in the same SQLite transaction as transcript appends.
- Rebuilds both fields atomically after tail truncation, excluding historical log rows already covered by the snapshot blob.
- Migrates v3 stores to schema v4 with a one-time snapshot-plus-uncovered-log backfill.
- Uses the lightweight runtime SQLite connection for steady-state listing and dispatches the synchronous read through Tokio's blocking pool.

## Usage

No user action or configuration change is required. The web UI continues polling the session list every five seconds, but polling cost is now governed by session-summary rows rather than retained transcript length.

## Changelog

- Reduces session-list polling latency for transcript-heavy stores.
- Preserves session-summary correctness across append, snapshot replacement, migration, and crash/cancel tail normalization.

## Performance

Measured on an Apple M5 Pro with release builds of current `origin/main` (`8a464d5`) and this PR. Each fixture used 200 sessions, 512-byte user/assistant bodies, 5 warmups, and 50 measured polls. The identical temporary benchmark harness was removed after measurement.

| Fixture | Metric | `origin/main` | This PR | Speedup |
| --- | --- | ---: | ---: | ---: |
| 101 blob messages/session | mean | 15.542 ms | 1.923 ms | 8.1x |
| 101 blob messages/session | p50 | 15.382 ms | 1.922 ms | 8.0x |
| 101 blob messages/session | p95 | 16.776 ms | 2.147 ms | 7.8x |
| 100 log messages/session | mean | 23.978 ms | 0.558 ms | 43.0x |
| 100 log messages/session | p50 | 23.720 ms | 0.531 ms | 44.7x |
| 100 log messages/session | p95 | 26.948 ms | 0.675 ms | 39.9x |

The log-backed fixture is the steady-state shape: the snapshot contains the system head and the transcript lives in the append-only log.

## Validation

Rebased the branch conflict-free onto `origin/main`; `git range-diff` confirmed the original patch was unchanged before review fixes. Ran `cargo test --workspace` successfully: 594 passed and 2 ignored across 5 suites. After formatting the review fix, reran the focused covered-row truncation and v3-to-v4 migration tests successfully, and `git diff --check` passed.

A seven-persona delegated review covered elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope. Correctness review found that migration and truncation rebuilds included log rows already covered by the snapshot blob. The fix now filters both aggregates at `messages.len()` and adds migration and two-step truncation regression coverage; the same correctness reviewer confirmed the finding resolved. No actionable findings remain.