### PR TITLE
Serialize same-file tool mutations across workers

### DIFF
--- a/crates/nac-core/src/sandbox/backend.rs
+++ b/crates/nac-core/src/sandbox/backend.rs
@@ -10,7 +10,7 @@ use portable_pty::CommandBuilder as PtyCommandBuilder;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 
-use super::SandboxSession;
+use super::{HostMountPath, SandboxSession};
 use crate::paths::PathContext;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -81,6 +81,17 @@ impl ExecutionBackend {
         }
     }
 
+    /// Returns the host-visible identity for a sandbox path backed by a mount.
+    ///
+    /// File mutation tools use this to coordinate locks on the host rather than
+    /// relying on advisory-lock propagation through a VM or container mount.
+    pub(crate) fn host_path_for_remote_file(&self, resolved_path: &Path) -> Option<HostMountPath> {
+        match self {
+            Self::Sandbox(session) => session.host_path_for_guest(resolved_path),
+            Self::Local { .. } | Self::Ssh(_) => None,
+        }
+    }
+
     pub fn resolve_terminal_cwd(&self, requested: Option<&str>) -> Result<Option<PathBuf>> {
         match self {
             Self::Local { workspace_cwd } => match requested {
@@ -98,7 +109,7 @@ impl ExecutionBackend {
         &self,
         program: &str,
         args: &[String],
-        stdin: Option<Vec<u8>>,
+        stdin: Option<&[u8]>,
     ) -> Result<std::process::Output> {
         match self {
             Self::Local { workspace_cwd } => {
@@ -110,6 +121,7 @@ impl ExecutionBackend {
                     command.stdin(Stdio::null());
                 }
                 command.stdout(Stdio::piped()).stderr(Stdio::piped());
+                command.kill_on_drop(true);
 
                 let mut child = command
                     .spawn()
@@ -117,7 +129,7 @@ impl ExecutionBackend {
 
                 if let Some(input) = stdin {
                     if let Some(mut stdin_pipe) = child.stdin.take() {
-                        stdin_pipe.write_all(&input).await?;
+                        stdin_pipe.write_all(input).await?;
                     }
                 }
 
@@ -455,7 +467,7 @@ mod tests {
         };
         let args = vec!["-c".to_string(), "cat".to_string()];
         let output = backend
-            .exec("sh", &args, Some(b"hello-backend".to_vec()))
+            .exec("sh", &args, Some(b"hello-backend"))
             .await
             .unwrap();
         assert!(output.status.success());

--- a/crates/nac-core/src/sandbox/mod.rs
+++ b/crates/nac-core/src/sandbox/mod.rs
@@ -61,6 +61,13 @@ pub struct MountSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HostMountPath {
+    pub root: PathBuf,
+    pub relative: PathBuf,
+    pub read_only: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SandboxSpec {
     pub backend: SandboxBackendType,
     pub image: String,
@@ -171,11 +178,35 @@ impl SandboxSession {
         Ok(requested)
     }
 
+    pub(crate) fn host_path_for_guest(&self, guest_path: &Path) -> Option<HostMountPath> {
+        let guest_path = normalize_guest_path(guest_path)?;
+        let (mount, mount_guest) = self
+            .spec()
+            .mounts
+            .iter()
+            .filter_map(|mount| {
+                let normalized = normalize_guest_path(&mount.guest)?;
+                guest_path
+                    .starts_with(&normalized)
+                    .then_some((mount, normalized))
+            })
+            .max_by_key(|(_, guest)| guest.components().count())?;
+        let relative = guest_path.strip_prefix(&mount_guest).ok()?.to_path_buf();
+        if host_path_contains_symlink(&mount.host, &relative) {
+            return None;
+        }
+        Some(HostMountPath {
+            root: mount.host.clone(),
+            relative,
+            read_only: mount.read_only,
+        })
+    }
+
     pub async fn exec(
         &self,
         program: &str,
         args: &[String],
-        stdin: Option<Vec<u8>>,
+        stdin: Option<&[u8]>,
     ) -> Result<std::process::Output> {
         match self {
             Self::Podman(inner) => inner.exec(program, args, stdin).await,
@@ -345,6 +376,25 @@ fn join_host_path(base: &Path, suffix: &Path) -> PathBuf {
     join_path(base, suffix)
 }
 
+fn normalize_guest_path(path: &Path) -> Option<PathBuf> {
+    if !path.is_absolute() {
+        return None;
+    }
+
+    let mut normalized = PathBuf::from("/");
+    for component in path.components() {
+        match component {
+            std::path::Component::RootDir | std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            std::path::Component::Normal(part) => normalized.push(part),
+            std::path::Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
+}
+
 fn join_path(base: &Path, suffix: &Path) -> PathBuf {
     if suffix.as_os_str().is_empty() {
         return base.to_path_buf();
@@ -356,6 +406,23 @@ fn join_path(base: &Path, suffix: &Path) -> PathBuf {
         }
     }
     out
+}
+
+fn host_path_contains_symlink(root: &Path, relative: &Path) -> bool {
+    let mut current = root.to_path_buf();
+    for component in relative.components() {
+        let std::path::Component::Normal(part) = component else {
+            return true;
+        };
+        current.push(part);
+        match std::fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => return true,
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return false,
+            Err(_) => return true,
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -402,5 +469,98 @@ mod tests {
                 .unwrap(),
             PathBuf::from("/workspace/Cargo.toml")
         );
+        assert_eq!(
+            session.host_path_for_guest(Path::new("/workspace/src/lib.rs")),
+            Some(HostMountPath {
+                root: cwd.clone(),
+                relative: PathBuf::from("src/lib.rs"),
+                read_only: false,
+            })
+        );
+        assert_eq!(
+            session.host_path_for_guest(Path::new("/tmp/unmounted")),
+            None
+        );
+        assert_eq!(
+            session.host_path_for_guest(Path::new("/workspace/../workspace/src/lib.rs")),
+            Some(HostMountPath {
+                root: cwd,
+                relative: PathBuf::from("src/lib.rs"),
+                read_only: false,
+            })
+        );
+    }
+
+    #[test]
+    fn host_mapping_prefers_the_most_specific_mount_and_preserves_read_only() {
+        let session = SandboxSession::new_for_test(SandboxSpec {
+            backend: SandboxBackendType::Podman,
+            image: DEFAULT_SANDBOX_IMAGE.to_string(),
+            mounts: vec![
+                MountSpec {
+                    host: PathBuf::from("/host/workspace"),
+                    guest: PathBuf::from("/workspace"),
+                    read_only: false,
+                },
+                MountSpec {
+                    host: PathBuf::from("/host/vendor"),
+                    guest: PathBuf::from("/workspace/vendor"),
+                    read_only: true,
+                },
+            ],
+            workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+            gpu_devices: Vec::new(),
+            shm_size: Some("0".to_string()),
+            cpus: 2,
+            memory_mib: 2048,
+        });
+
+        assert_eq!(
+            session.host_path_for_guest(Path::new("/workspace/vendor/lib.rs")),
+            Some(HostMountPath {
+                root: PathBuf::from("/host/vendor"),
+                relative: PathBuf::from("lib.rs"),
+                read_only: true,
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn host_mapping_falls_back_for_symlinked_mount_paths() {
+        use std::os::unix::fs::symlink;
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "nac_sandbox_symlink_mapping_{}_{unique}",
+            std::process::id()
+        ));
+        let mount_root = root.join("mount");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&mount_root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, mount_root.join("escape")).unwrap();
+
+        let session = SandboxSession::new_for_test(SandboxSpec {
+            backend: SandboxBackendType::Podman,
+            image: DEFAULT_SANDBOX_IMAGE.to_string(),
+            mounts: vec![MountSpec {
+                host: mount_root,
+                guest: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+                read_only: false,
+            }],
+            workdir: PathBuf::from(DEFAULT_SANDBOX_WORKDIR),
+            gpu_devices: Vec::new(),
+            shm_size: Some("0".to_string()),
+            cpus: 2,
+            memory_mib: 2048,
+        });
+
+        let mapped = session.host_path_for_guest(Path::new("/workspace/escape/file.txt"));
+        let _ = std::fs::remove_dir_all(root);
+        assert_eq!(mapped, None);
     }
 }

--- a/crates/nac-core/src/sandbox/podman.rs
+++ b/crates/nac-core/src/sandbox/podman.rs
@@ -151,7 +151,7 @@ impl PodmanSession {
         &self,
         program: &str,
         args: &[String],
-        stdin: Option<Vec<u8>>,
+        stdin: Option<&[u8]>,
     ) -> Result<std::process::Output> {
         let mut command = Command::new("podman");
         command.args(self.exec_args(program, args, true, false, None, &[]));
@@ -162,6 +162,7 @@ impl PodmanSession {
             command.stdin(Stdio::null());
         }
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command.kill_on_drop(true);
 
         let mut child = command
             .spawn()
@@ -169,7 +170,7 @@ impl PodmanSession {
 
         if let Some(input) = stdin {
             if let Some(mut stdin_pipe) = child.stdin.take() {
-                stdin_pipe.write_all(&input).await?;
+                stdin_pipe.write_all(input).await?;
             }
         }
 

--- a/crates/nac-core/src/sandbox/smolvm.rs
+++ b/crates/nac-core/src/sandbox/smolvm.rs
@@ -102,7 +102,7 @@ impl SmolVmSession {
         &self,
         program: &str,
         args: &[String],
-        stdin: Option<Vec<u8>>,
+        stdin: Option<&[u8]>,
     ) -> Result<std::process::Output> {
         let mut command = Command::new("smolvm");
         command.args(self.exec_args(program, args, true, false, None, &[]));
@@ -113,6 +113,7 @@ impl SmolVmSession {
             command.stdin(Stdio::null());
         }
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command.kill_on_drop(true);
 
         let mut child = command
             .spawn()
@@ -120,7 +121,7 @@ impl SmolVmSession {
 
         if let Some(input) = stdin {
             if let Some(mut stdin_pipe) = child.stdin.take() {
-                stdin_pipe.write_all(&input).await?;
+                stdin_pipe.write_all(input).await?;
             }
         }
 
@@ -372,11 +373,7 @@ impl Drop for SmolVmSession {
 
 fn volume_arg(mount: &MountSpec) -> String {
     if mount.read_only {
-        format!(
-            "{}:{}:ro",
-            mount.host.display(),
-            mount.guest.display()
-        )
+        format!("{}:{}:ro", mount.host.display(), mount.guest.display())
     } else {
         format!("{}:{}", mount.host.display(), mount.guest.display())
     }

--- a/crates/nac-core/src/sandbox/ssh.rs
+++ b/crates/nac-core/src/sandbox/ssh.rs
@@ -163,7 +163,7 @@ impl SshBackend {
         &self,
         program: &str,
         args: &[String],
-        stdin: Option<Vec<u8>>,
+        stdin: Option<&[u8]>,
     ) -> Result<std::process::Output> {
         let words = Self::quoted_program_and_args(program, args);
         let remote = self.remote_command_in_dir(&self.remote_cwd, &[], &words);
@@ -174,6 +174,7 @@ impl SshBackend {
             command.stdin(Stdio::null());
         }
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
+        command.kill_on_drop(true);
 
         let mut child = command
             .spawn()
@@ -181,7 +182,7 @@ impl SshBackend {
 
         if let Some(input) = stdin {
             if let Some(mut stdin_pipe) = child.stdin.take() {
-                stdin_pipe.write_all(&input).await?;
+                stdin_pipe.write_all(input).await?;
             }
         }
 

--- a/crates/nac-core/src/tools/edit.rs
+++ b/crates/nac-core/src/tools/edit.rs
@@ -1,13 +1,18 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use serde_json::Value;
 
 use crate::sandbox::FileIoMode;
 use crate::tools::{
-    acquire_write_lock, require_str, resolve_workspace_path, ToolResult, ToolRuntime,
+    open_locked_file, open_locked_file_beneath, remote_file_lock_busy, require_str,
+    resolve_workspace_path, FileLockAccess, ToolResult, ToolRuntime,
+    REMOTE_FILE_LOCK_RETRY_INTERVAL,
 };
 
 const REMOTE_EDIT_SCRIPT: &str = r#"
+import fcntl
 from pathlib import Path
 import json
 import sys
@@ -18,30 +23,33 @@ payload = json.load(sys.stdin)
 old_text = payload["old_text"]
 new_text = payload["new_text"]
 
-if not path.exists():
+try:
+    with path.open("r+", encoding="utf-8") as target:
+        try:
+            fcntl.flock(target.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("NAC_FILE_LOCK_BUSY")
+            sys.exit(75)
+        content = target.read()
+
+        count = content.count(old_text)
+        if count == 0:
+            print(f"old_text not found in {orig}")
+            sys.exit(2)
+        if count > 1:
+            print(f"old_text appears {count} times — provide more context to make it unique")
+            sys.exit(2)
+
+        new_content = content.replace(old_text, new_text, 1)
+        target.seek(0)
+        target.truncate()
+        target.write(new_content)
+    print("ok")
+except FileNotFoundError:
     print(f"File not found: {orig}")
     sys.exit(2)
-
-try:
-    content = path.read_text(encoding="utf-8")
 except Exception as exc:
-    print(f"Error reading {orig}: {exc}")
-    sys.exit(2)
-
-count = content.count(old_text)
-if count == 0:
-    print(f"old_text not found in {orig}")
-    sys.exit(2)
-if count > 1:
-    print(f"old_text appears {count} times — provide more context to make it unique")
-    sys.exit(2)
-
-new_content = content.replace(old_text, new_text, 1)
-try:
-    path.write_text(new_content, encoding="utf-8")
-    print("ok")
-except Exception as exc:
-    print(f"Error writing {orig}: {exc}")
+    print(f"Error editing {orig}: {exc}")
     sys.exit(2)
 "#;
 
@@ -69,6 +77,35 @@ pub async fn execute(args: Value, runtime: &ToolRuntime) -> ToolResult {
                 }
             }
         };
+        if let Some(host_path) = runtime.backend.host_path_for_remote_file(&guest_path) {
+            if host_path.read_only {
+                return ToolResult {
+                    content: format!("Error editing {path}: sandbox mount is read-only"),
+                    is_error: true,
+                };
+            }
+            match open_locked_file_beneath(
+                host_path.root,
+                host_path.relative,
+                false,
+                false,
+                FileLockAccess::ReadWrite,
+            )
+            .await
+            {
+                Ok(Some(file)) => {
+                    return edit_locked_file(file, path.clone(), old_text, new_text).await;
+                }
+                Ok(None) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return ToolResult {
+                        content: format!("Error opening or locking {path}: {error}"),
+                        is_error: true,
+                    };
+                }
+            }
+        }
         let payload = serde_json::json!({
             "old_text": old_text,
             "new_text": new_text,
@@ -79,76 +116,121 @@ pub async fn execute(args: Value, runtime: &ToolRuntime) -> ToolResult {
             path.clone(),
             guest_path.display().to_string(),
         ];
-        let _guard = acquire_write_lock().await;
-        return match runtime
-            .backend
-            .exec("python3", &args, Some(payload.to_string().into_bytes()))
-            .await
-        {
-            Ok(output) if output.status.success() => ToolResult {
-                content: "ok".to_string(),
-                is_error: false,
-            },
-            Ok(output) => ToolResult {
-                content: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-                is_error: true,
-            },
-            Err(error) => ToolResult {
-                content: format!(
-                    "Error editing {} in {}: {}",
-                    path,
-                    runtime.backend.remote_io_label(),
-                    error
-                ),
-                is_error: true,
-            },
-        };
+        let payload = payload.to_string().into_bytes();
+        loop {
+            match runtime
+                .backend
+                .exec("python3", &args, Some(payload.as_slice()))
+                .await
+            {
+                Ok(output) if remote_file_lock_busy(&output) => {
+                    tokio::time::sleep(REMOTE_FILE_LOCK_RETRY_INTERVAL).await;
+                }
+                Ok(output) if output.status.success() => {
+                    return ToolResult {
+                        content: "ok".to_string(),
+                        is_error: false,
+                    };
+                }
+                Ok(output) => {
+                    return ToolResult {
+                        content: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                        is_error: true,
+                    };
+                }
+                Err(error) => {
+                    return ToolResult {
+                        content: format!(
+                            "Error editing {} in {}: {}",
+                            path,
+                            runtime.backend.remote_io_label(),
+                            error
+                        ),
+                        is_error: true,
+                    };
+                }
+            }
+        }
     }
 
     let path = resolve_workspace_path(runtime, PathBuf::from(path));
-    if !path.exists() {
-        return ToolResult {
-            content: format!("File not found: {}", path.display()),
-            is_error: true,
-        };
-    }
+    execute_local(path, old_text, new_text).await
+}
 
-    let content = match tokio::fs::read_to_string(&path).await {
-        Ok(c) => c,
-        Err(e) => {
+async fn execute_local(path: PathBuf, old_text: String, new_text: String) -> ToolResult {
+    let path_display = path.display().to_string();
+    let file = match open_locked_file(path, false, FileLockAccess::ReadWrite).await {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             return ToolResult {
-                content: format!("Error reading {}: {}", path.display(), e),
+                content: format!("File not found: {path_display}"),
                 is_error: true,
-            }
+            };
+        }
+        Err(error) => {
+            return ToolResult {
+                content: format!("Error opening or locking {path_display}: {error}"),
+                is_error: true,
+            };
         }
     };
+    edit_locked_file(file, path_display, old_text, new_text).await
+}
 
-    let count = content.matches(&old_text as &str).count();
-    if count == 0 {
-        return ToolResult {
-            content: format!("old_text not found in {}", path.display()),
-            is_error: true,
-        };
-    }
-    if count > 1 {
-        return ToolResult {
-            content: format!(
-                "old_text appears {} times — provide more context to make it unique",
-                count
-            ),
-            is_error: true,
-        };
-    }
+async fn edit_locked_file(
+    mut file: File,
+    path_display: String,
+    old_text: String,
+    new_text: String,
+) -> ToolResult {
+    match tokio::task::spawn_blocking(move || {
+        let mut content = String::new();
+        if let Err(error) = file.read_to_string(&mut content) {
+            return ToolResult {
+                content: format!("Error reading {path_display}: {error}"),
+                is_error: true,
+            };
+        }
 
-    let new_content = content.replacen(&old_text, &new_text, 1);
-    let _guard = acquire_write_lock().await;
-    match tokio::fs::write(&path, new_content.as_bytes()).await {
-        Ok(_) => ToolResult {
+        let count = content.matches(old_text.as_str()).count();
+        if count == 0 {
+            return ToolResult {
+                content: format!("old_text not found in {path_display}"),
+                is_error: true,
+            };
+        }
+        if count > 1 {
+            return ToolResult {
+                content: format!(
+                    "old_text appears {} times — provide more context to make it unique",
+                    count
+                ),
+                is_error: true,
+            };
+        }
+
+        let new_content = content.replacen(&old_text, &new_text, 1);
+        if let Err(error) = file
+            .seek(SeekFrom::Start(0))
+            .and_then(|_| file.set_len(0))
+            .and_then(|_| file.write_all(new_content.as_bytes()))
+        {
+            return ToolResult {
+                content: format!("Error writing {path_display}: {error}"),
+                is_error: true,
+            };
+        }
+
+        ToolResult {
             content: "ok".to_string(),
             is_error: false,
-        },
-        Err(e) => ToolResult {
-            content: format!("Error writing {}: {}", path.display(), e),
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(error) => ToolResult {
+            content: format!("Error editing file: blocking task failed: {error}"),
             is_error: true,
         },
     }
@@ -167,7 +249,8 @@ mod tests {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!("agent_edit_test_{}.txt", id));
+        let path =
+            std::env::temp_dir().join(format!("agent_edit_test_{}_{}.txt", std::process::id(), id));
         tokio::fs::write(&path, content).await.unwrap();
         path
     }
@@ -281,5 +364,141 @@ mod tests {
             result.content
         );
         let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn concurrent_edits_to_one_file_preserve_both_changes() {
+        let path = write_temp("alpha beta\n").await;
+        let runtime = local_runtime();
+        let path_arg = path.to_string_lossy().to_string();
+
+        let first = execute(
+            json!({
+                "path": path_arg,
+                "old_text": "alpha",
+                "new_text": "ALPHA"
+            }),
+            &runtime,
+        );
+        let second = execute(
+            json!({
+                "path": path.to_string_lossy(),
+                "old_text": "beta",
+                "new_text": "BETA"
+            }),
+            &runtime,
+        );
+        let (first_result, second_result) = tokio::join!(first, second);
+
+        assert!(
+            !first_result.is_error,
+            "first edit failed: {}",
+            first_result.content
+        );
+        assert!(
+            !second_result.is_error,
+            "second edit failed: {}",
+            second_result.content
+        );
+        assert_eq!(
+            tokio::fs::read_to_string(&path).await.unwrap(),
+            "ALPHA BETA\n"
+        );
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_blocked_edit_never_mutates_and_unrelated_write_progresses() {
+        let path = write_temp("before\n").await;
+        let held = crate::tools::open_locked_file(
+            path.clone(),
+            false,
+            crate::tools::FileLockAccess::ReadWrite,
+        )
+        .await
+        .unwrap();
+
+        let edit_path = path.clone();
+        let edit_runtime = local_runtime();
+        let blocked_edit = tokio::spawn(async move {
+            execute(
+                json!({
+                    "path": edit_path.to_string_lossy(),
+                    "old_text": "before",
+                    "new_text": "after"
+                }),
+                &edit_runtime,
+            )
+            .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        assert!(!blocked_edit.is_finished());
+
+        let unrelated = path.with_extension("unrelated");
+        let unrelated_runtime = local_runtime();
+        let write_result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            crate::tools::write::execute(
+                json!({
+                    "path": unrelated.to_string_lossy(),
+                    "content": "independent"
+                }),
+                &unrelated_runtime,
+            ),
+        )
+        .await
+        .expect("an unrelated write must not wait behind a blocked edit");
+        assert!(
+            !write_result.is_error,
+            "unrelated write failed: {}",
+            write_result.content
+        );
+
+        blocked_edit.abort();
+        assert!(blocked_edit.await.unwrap_err().is_cancelled());
+        drop(held);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(tokio::fs::read_to_string(&path).await.unwrap(), "before\n");
+
+        let _ = tokio::fs::remove_file(path).await;
+        let _ = tokio::fs::remove_file(unrelated).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remote_script_reports_contention_without_waiting() {
+        use fs2::FileExt;
+        use std::fs::OpenOptions;
+
+        let path = write_temp("before\n").await;
+        let held = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        FileExt::lock_exclusive(&held).unwrap();
+
+        let args = vec![
+            "-c".to_string(),
+            REMOTE_EDIT_SCRIPT.to_string(),
+            path.display().to_string(),
+            path.display().to_string(),
+        ];
+        let payload = serde_json::json!({
+            "old_text": "before",
+            "new_text": "after",
+        });
+        let payload = payload.to_string().into_bytes();
+        let runtime = local_runtime();
+        let output = runtime
+            .backend
+            .exec("python3", &args, Some(payload.as_slice()))
+            .await
+            .unwrap();
+
+        assert!(remote_file_lock_busy(&output));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "before\n");
+        drop(held);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/nac-core/src/tools/file_lock_benchmark.rs
+++ b/crates/nac-core/src/tools/file_lock_benchmark.rs
@@ -1,0 +1,270 @@
+use std::io::{Seek, SeekFrom, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use tokio::sync::{Barrier, Mutex};
+
+use super::{open_locked_file, FileLockAccess};
+
+const TASKS: usize = 8;
+const OPERATIONS_PER_TASK: usize = 100;
+const PAYLOAD_BYTES: usize = 64 * 1024;
+const SAMPLES: usize = 30;
+const SIMULATED_IO_LATENCY: Duration = Duration::from_millis(2);
+const LATENCY_OPERATIONS_PER_TASK: usize = 20;
+
+async fn benchmark_global_lock(paths: &[PathBuf], payload: Arc<Vec<u8>>) -> Duration {
+    let lock = Arc::new(Mutex::new(()));
+    let barrier = Arc::new(Barrier::new(TASKS + 1));
+    let mut handles = Vec::with_capacity(TASKS);
+
+    for path in paths {
+        let path = path.clone();
+        let payload = payload.clone();
+        let lock = lock.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for _ in 0..OPERATIONS_PER_TASK {
+                let _guard = lock.lock().await;
+                tokio::fs::write(&path, payload.as_slice()).await.unwrap();
+            }
+        }));
+    }
+
+    let started = Instant::now();
+    barrier.wait().await;
+    for handle in handles {
+        handle.await.unwrap();
+    }
+    started.elapsed()
+}
+
+async fn benchmark_per_file_lock(paths: &[PathBuf], payload: Arc<Vec<u8>>) -> Duration {
+    let barrier = Arc::new(Barrier::new(TASKS + 1));
+    let mut handles = Vec::with_capacity(TASKS);
+
+    for path in paths {
+        let path = path.clone();
+        let payload = payload.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for _ in 0..OPERATIONS_PER_TASK {
+                let mut file = open_locked_file(path.clone(), true, FileLockAccess::Write)
+                    .await
+                    .unwrap();
+                let payload = payload.clone();
+                tokio::task::spawn_blocking(move || {
+                    file.set_len(0).unwrap();
+                    file.seek(SeekFrom::Start(0)).unwrap();
+                    file.write_all(payload.as_slice()).unwrap();
+                })
+                .await
+                .unwrap();
+            }
+        }));
+    }
+
+    let started = Instant::now();
+    barrier.wait().await;
+    for handle in handles {
+        handle.await.unwrap();
+    }
+    started.elapsed()
+}
+
+#[derive(Clone, Copy)]
+struct Summary {
+    median: Duration,
+    p95: Duration,
+}
+
+fn summarize(mut samples: Vec<Duration>) -> Summary {
+    samples.sort_unstable();
+    Summary {
+        median: samples[samples.len() / 2],
+        p95: samples[(samples.len() * 95).div_ceil(100) - 1],
+    }
+}
+
+async fn benchmark_global_lock_with_latency(paths: &[PathBuf]) -> Duration {
+    let lock = Arc::new(Mutex::new(()));
+    let barrier = Arc::new(Barrier::new(TASKS + 1));
+    let mut handles = Vec::with_capacity(TASKS);
+
+    for _ in paths {
+        let lock = lock.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for _ in 0..LATENCY_OPERATIONS_PER_TASK {
+                let _guard = lock.lock().await;
+                tokio::task::spawn_blocking(move || {
+                    std::thread::sleep(SIMULATED_IO_LATENCY);
+                })
+                .await
+                .unwrap();
+            }
+        }));
+    }
+
+    let started = Instant::now();
+    barrier.wait().await;
+    for handle in handles {
+        handle.await.unwrap();
+    }
+    started.elapsed()
+}
+
+async fn benchmark_per_file_lock_with_latency(paths: &[PathBuf]) -> Duration {
+    let barrier = Arc::new(Barrier::new(TASKS + 1));
+    let mut handles = Vec::with_capacity(TASKS);
+
+    for path in paths {
+        let path = path.clone();
+        let barrier = barrier.clone();
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for _ in 0..LATENCY_OPERATIONS_PER_TASK {
+                let file = open_locked_file(path.clone(), true, FileLockAccess::Write)
+                    .await
+                    .unwrap();
+                tokio::task::spawn_blocking(move || {
+                    let _file = file;
+                    std::thread::sleep(SIMULATED_IO_LATENCY);
+                })
+                .await
+                .unwrap();
+            }
+        }));
+    }
+
+    let started = Instant::now();
+    barrier.wait().await;
+    for handle in handles {
+        handle.await.unwrap();
+    }
+    started.elapsed()
+}
+
+/// Manual comparison of the former process-global lock and the per-file lock.
+///
+/// Run with:
+/// `cargo test --release -p nac-core benchmark_global_vs_per_file_lock -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "manual filesystem benchmark"]
+async fn benchmark_global_vs_per_file_lock() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!(
+        "nac_file_lock_benchmark_{}_{unique}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&root).unwrap();
+
+    let same_path = root.join("shared.txt");
+    let same_paths = vec![same_path; TASKS];
+    let distinct_paths = (0..TASKS)
+        .map(|index| root.join(format!("independent-{index}.txt")))
+        .collect::<Vec<_>>();
+    let payload = Arc::new(vec![b'x'; PAYLOAD_BYTES]);
+
+    // Warm filesystem caches and the blocking pool before collecting samples.
+    let _ = benchmark_global_lock(&distinct_paths, payload.clone()).await;
+    let _ = benchmark_per_file_lock(&distinct_paths, payload.clone()).await;
+
+    let mut global_same = Vec::with_capacity(SAMPLES);
+    let mut per_file_same = Vec::with_capacity(SAMPLES);
+    let mut global_distinct = Vec::with_capacity(SAMPLES);
+    let mut per_file_distinct = Vec::with_capacity(SAMPLES);
+    for sample in 0..SAMPLES {
+        if sample % 2 == 0 {
+            global_same.push(benchmark_global_lock(&same_paths, payload.clone()).await);
+            per_file_same.push(benchmark_per_file_lock(&same_paths, payload.clone()).await);
+            global_distinct.push(benchmark_global_lock(&distinct_paths, payload.clone()).await);
+            per_file_distinct.push(benchmark_per_file_lock(&distinct_paths, payload.clone()).await);
+        } else {
+            per_file_distinct.push(benchmark_per_file_lock(&distinct_paths, payload.clone()).await);
+            global_distinct.push(benchmark_global_lock(&distinct_paths, payload.clone()).await);
+            per_file_same.push(benchmark_per_file_lock(&same_paths, payload.clone()).await);
+            global_same.push(benchmark_global_lock(&same_paths, payload.clone()).await);
+        }
+    }
+
+    let global_same = summarize(global_same);
+    let per_file_same = summarize(per_file_same);
+    let global_distinct = summarize(global_distinct);
+    let per_file_distinct = summarize(per_file_distinct);
+
+    let mut global_latency_same = Vec::with_capacity(SAMPLES);
+    let mut per_file_latency_same = Vec::with_capacity(SAMPLES);
+    let mut global_latency_distinct = Vec::with_capacity(SAMPLES);
+    let mut per_file_latency_distinct = Vec::with_capacity(SAMPLES);
+    for sample in 0..SAMPLES {
+        if sample % 2 == 0 {
+            global_latency_same.push(benchmark_global_lock_with_latency(&same_paths).await);
+            per_file_latency_same.push(benchmark_per_file_lock_with_latency(&same_paths).await);
+            global_latency_distinct.push(benchmark_global_lock_with_latency(&distinct_paths).await);
+            per_file_latency_distinct
+                .push(benchmark_per_file_lock_with_latency(&distinct_paths).await);
+        } else {
+            per_file_latency_distinct
+                .push(benchmark_per_file_lock_with_latency(&distinct_paths).await);
+            global_latency_distinct.push(benchmark_global_lock_with_latency(&distinct_paths).await);
+            per_file_latency_same.push(benchmark_per_file_lock_with_latency(&same_paths).await);
+            global_latency_same.push(benchmark_global_lock_with_latency(&same_paths).await);
+        }
+    }
+
+    let global_latency_same = summarize(global_latency_same);
+    let per_file_latency_same = summarize(per_file_latency_same);
+    let global_latency_distinct = summarize(global_latency_distinct);
+    let per_file_latency_distinct = summarize(per_file_latency_distinct);
+
+    println!(
+        "64 KiB cached writes, {TASKS} tasks × {OPERATIONS_PER_TASK} operations, {SAMPLES} alternating samples:"
+    );
+    println!(
+        "same file:      global median={:?} p95={:?}, per-file median={:?} p95={:?}, median ratio={:.2}x",
+        global_same.median,
+        global_same.p95,
+        per_file_same.median,
+        per_file_same.p95,
+        global_same.median.as_secs_f64() / per_file_same.median.as_secs_f64()
+    );
+    println!(
+        "distinct files: global median={:?} p95={:?}, per-file median={:?} p95={:?}, median ratio={:.2}x",
+        global_distinct.median,
+        global_distinct.p95,
+        per_file_distinct.median,
+        per_file_distinct.p95,
+        global_distinct.median.as_secs_f64() / per_file_distinct.median.as_secs_f64()
+    );
+    println!(
+        "simulated 2 ms mutation latency, {TASKS} tasks × {LATENCY_OPERATIONS_PER_TASK} operations:"
+    );
+    println!(
+        "same file:      global median={:?} p95={:?}, per-file median={:?} p95={:?}, median ratio={:.2}x",
+        global_latency_same.median,
+        global_latency_same.p95,
+        per_file_latency_same.median,
+        per_file_latency_same.p95,
+        global_latency_same.median.as_secs_f64()
+            / per_file_latency_same.median.as_secs_f64()
+    );
+    println!(
+        "distinct files: global median={:?} p95={:?}, per-file median={:?} p95={:?}, median ratio={:.2}x",
+        global_latency_distinct.median,
+        global_latency_distinct.p95,
+        per_file_latency_distinct.median,
+        per_file_latency_distinct.p95,
+        global_latency_distinct.median.as_secs_f64()
+            / per_file_latency_distinct.median.as_secs_f64()
+    );
+
+    let _ = std::fs::remove_dir_all(root);
+}

--- a/crates/nac-core/src/tools/mod.rs
+++ b/crates/nac-core/src/tools/mod.rs
@@ -1,7 +1,19 @@
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::CString;
+use std::fs::{File, OpenOptions};
+use std::io;
+#[cfg(unix)]
+use std::os::fd::{AsRawFd, FromRawFd};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 
+use fs2::FileExt;
 use serde_json::Value;
 use tokio::sync::Mutex;
 
@@ -12,12 +24,20 @@ use crate::skills::SkillRegistry;
 use crate::terminal::TerminalManager;
 use crate::types::ToolDefinition;
 
+const FILE_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(1);
+pub(crate) const REMOTE_FILE_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(10);
+const REMOTE_FILE_LOCK_BUSY_EXIT_CODE: i32 = 75;
+const REMOTE_FILE_LOCK_BUSY_MARKER: &str = "NAC_FILE_LOCK_BUSY";
+
 pub mod edit;
 pub mod exec_command;
 pub mod read;
 pub mod thread;
 pub mod workset;
 pub mod write;
+
+#[cfg(test)]
+mod file_lock_benchmark;
 
 #[derive(Debug)]
 pub struct ToolResult {
@@ -138,8 +158,6 @@ pub struct ToolRuntime {
     pub worker_usage: Arc<Mutex<crate::model::TokenUsage>>,
 }
 
-static WRITE_LOCK: Mutex<()> = Mutex::const_new(());
-
 pub(crate) fn resolve_workspace_path(runtime: &ToolRuntime, path: impl AsRef<Path>) -> PathBuf {
     let path = path.as_ref();
     if path.is_absolute() {
@@ -149,8 +167,219 @@ pub(crate) fn resolve_workspace_path(runtime: &ToolRuntime, path: impl AsRef<Pat
     }
 }
 
-pub async fn acquire_write_lock() -> tokio::sync::MutexGuard<'static, ()> {
-    WRITE_LOCK.lock().await
+#[derive(Clone, Copy)]
+pub(crate) enum FileLockAccess {
+    Write,
+    ReadWrite,
+}
+
+/// Opens and exclusively locks a target file for a complete mutation.
+///
+/// The advisory lock belongs to the file and is therefore shared by all NAC
+/// sessions and worker processes that access the same filesystem object.
+/// Acquisition is polled so cancellation drops the file handle instead of
+/// leaving a blocking-pool task that can acquire the lock and mutate later.
+pub(crate) async fn open_locked_file(
+    path: PathBuf,
+    create: bool,
+    access: FileLockAccess,
+) -> io::Result<File> {
+    let file = tokio::task::spawn_blocking(move || {
+        let mut options = OpenOptions::new();
+        options.write(true).create(create);
+        if matches!(access, FileLockAccess::ReadWrite) {
+            options.read(true);
+        }
+        options.open(path)
+    })
+    .await
+    .map_err(|error| io::Error::other(format!("file-open task failed: {error}")))??;
+    lock_file(file).await
+}
+
+/// Opens a mounted host file without following symlinks beneath the mount root.
+///
+/// `None` asks the caller to preserve guest symlink semantics by using remote
+/// execution instead. Directory descriptors keep the traversal confined even
+/// if a sandbox process swaps a later path component during the open.
+pub(crate) async fn open_locked_file_beneath(
+    root: PathBuf,
+    relative: PathBuf,
+    create_parents: bool,
+    create_file: bool,
+    access: FileLockAccess,
+) -> io::Result<Option<File>> {
+    let file = tokio::task::spawn_blocking(move || {
+        open_file_beneath(root, relative, create_parents, create_file, access)
+    })
+    .await
+    .map_err(|error| io::Error::other(format!("mounted file-open task failed: {error}")))??;
+    match file {
+        Some(file) => lock_file(file).await.map(Some),
+        None => Ok(None),
+    }
+}
+
+async fn lock_file(file: File) -> io::Result<File> {
+    loop {
+        match FileExt::try_lock_exclusive(&file) {
+            Ok(()) => return Ok(file),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                tokio::time::sleep(FILE_LOCK_POLL_INTERVAL).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn open_file_beneath(
+    root: PathBuf,
+    relative: PathBuf,
+    create_parents: bool,
+    create_file: bool,
+    access: FileLockAccess,
+) -> io::Result<Option<File>> {
+    if relative.as_os_str().is_empty() {
+        return open_mount_root(root, access);
+    }
+
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    let mut directory = options.open(root)?;
+    let mut components = relative.components().peekable();
+
+    while let Some(component) = components.next() {
+        let std::path::Component::Normal(part) = component else {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mounted file path must be relative",
+            ));
+        };
+        let name = CString::new(part.as_bytes()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mounted file path contains a NUL byte",
+            )
+        })?;
+
+        if components.peek().is_none() {
+            return open_file_at(&directory, &name, create_file, access);
+        }
+
+        match open_directory_at(&directory, &name) {
+            Ok(next) => directory = next,
+            Err(error) if is_symlink_or_non_directory(&error) => return Ok(None),
+            Err(error) if error.kind() == io::ErrorKind::NotFound && create_parents => {
+                let result = unsafe { libc::mkdirat(directory.as_raw_fd(), name.as_ptr(), 0o777) };
+                if result == -1 {
+                    let error = io::Error::last_os_error();
+                    if error.kind() != io::ErrorKind::AlreadyExists {
+                        return Err(error);
+                    }
+                }
+                match open_directory_at(&directory, &name) {
+                    Ok(next) => directory = next,
+                    Err(error) if is_symlink_or_non_directory(&error) => return Ok(None),
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "mounted file path does not name a file",
+    ))
+}
+
+#[cfg(unix)]
+fn open_mount_root(root: PathBuf, access: FileLockAccess) -> io::Result<Option<File>> {
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_CLOEXEC);
+    if matches!(access, FileLockAccess::ReadWrite) {
+        options.read(true);
+    }
+    match options.open(root) {
+        Ok(file) => Ok(Some(file)),
+        Err(error) if is_symlink_or_non_directory(&error) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn open_directory_at(directory: &File, name: &CString) -> io::Result<File> {
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(unsafe { File::from_raw_fd(descriptor) })
+}
+
+#[cfg(unix)]
+fn open_file_at(
+    directory: &File,
+    name: &CString,
+    create: bool,
+    access: FileLockAccess,
+) -> io::Result<Option<File>> {
+    let access_flag = match access {
+        FileLockAccess::Write => libc::O_WRONLY,
+        FileLockAccess::ReadWrite => libc::O_RDWR,
+    };
+    let create_flag = if create { libc::O_CREAT } else { 0 };
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            access_flag | create_flag | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            0o666,
+        )
+    };
+    if descriptor == -1 {
+        let error = io::Error::last_os_error();
+        return if is_symlink_or_non_directory(&error) {
+            Ok(None)
+        } else {
+            Err(error)
+        };
+    }
+    Ok(Some(unsafe { File::from_raw_fd(descriptor) }))
+}
+
+#[cfg(unix)]
+fn is_symlink_or_non_directory(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(code) if code == libc::ELOOP || code == libc::ENOTDIR
+    )
+}
+
+#[cfg(not(unix))]
+fn open_file_beneath(
+    _root: PathBuf,
+    _relative: PathBuf,
+    _create_parents: bool,
+    _create_file: bool,
+    _access: FileLockAccess,
+) -> io::Result<Option<File>> {
+    Ok(None)
+}
+
+pub(crate) fn remote_file_lock_busy(output: &std::process::Output) -> bool {
+    output.status.code() == Some(REMOTE_FILE_LOCK_BUSY_EXIT_CODE)
+        && String::from_utf8_lossy(&output.stdout).trim() == REMOTE_FILE_LOCK_BUSY_MARKER
 }
 
 pub fn worker_tool_definitions() -> Vec<ToolDefinition> {
@@ -341,5 +570,189 @@ pub(crate) fn test_runtime() -> ToolRuntime {
         terminal_manager: TerminalManager::new(),
         thread_timeout_secs: thread::DEFAULT_THREAD_TIMEOUT_SECS,
         worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+    }
+}
+
+#[cfg(test)]
+mod file_lock_tests {
+    use super::*;
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn file_lock_process_helper() {
+        let Some(target) = std::env::var_os("NAC_TEST_FILE_LOCK_TARGET") else {
+            return;
+        };
+        let ready = PathBuf::from(std::env::var_os("NAC_TEST_FILE_LOCK_READY").unwrap());
+        let locked = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(Path::new(&target))
+            .unwrap();
+        FileExt::lock_exclusive(&locked).unwrap();
+        std::fs::write(ready, b"ready").unwrap();
+        thread::sleep(Duration::from_secs(30));
+    }
+
+    #[tokio::test]
+    async fn mutation_locks_are_cross_process_and_per_file() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "nac_file_mutation_lock_{}_{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("target.txt");
+        let unrelated = dir.join("unrelated.txt");
+        let ready = dir.join("ready");
+
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "tools::file_lock_tests::file_lock_process_helper",
+                "--nocapture",
+            ])
+            .env("NAC_TEST_FILE_LOCK_TARGET", &target)
+            .env("NAC_TEST_FILE_LOCK_READY", &ready)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+
+        for _ in 0..200 {
+            if ready.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "file-lock helper exited early"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert!(ready.exists(), "file-lock helper never became ready");
+
+        let same_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&target)
+            .unwrap();
+        let contention = FileExt::try_lock_exclusive(&same_file);
+        assert!(
+            matches!(contention, Err(error) if error.kind() == io::ErrorKind::WouldBlock),
+            "same file should be locked by the other process"
+        );
+
+        let unrelated_file = open_locked_file(unrelated, true, FileLockAccess::Write)
+            .await
+            .expect("an unrelated file must remain independently lockable");
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        FileExt::try_lock_exclusive(&same_file)
+            .expect("the target lock should be released when its process exits");
+
+        drop(same_file);
+        drop(unrelated_file);
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_waiter_releases_it_without_delayed_acquisition() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nac_cancelled_file_lock_{}_{unique}",
+            std::process::id()
+        ));
+        let held = open_locked_file(path.clone(), true, FileLockAccess::Write)
+            .await
+            .unwrap();
+
+        let waiter_path = path.clone();
+        let waiter = tokio::spawn(async move {
+            open_locked_file(waiter_path, true, FileLockAccess::Write).await
+        });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+        drop(held);
+
+        let reacquired = tokio::time::timeout(
+            Duration::from_secs(1),
+            open_locked_file(path.clone(), true, FileLockAccess::Write),
+        )
+        .await
+        .expect("a cancelled waiter must not acquire the lock later")
+        .unwrap();
+        drop(reacquired);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mounted_file_open_never_follows_a_symlinked_parent() {
+        use std::os::unix::fs::symlink;
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "nac_mounted_file_open_{}_{unique}",
+            std::process::id()
+        ));
+        let mount_root = root.join("mount");
+        let outside = root.join("outside");
+        std::fs::create_dir_all(&mount_root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        symlink(&outside, mount_root.join("escape")).unwrap();
+
+        let opened = open_locked_file_beneath(
+            mount_root,
+            PathBuf::from("escape/file.txt"),
+            true,
+            true,
+            FileLockAccess::Write,
+        )
+        .await
+        .unwrap();
+
+        assert!(opened.is_none());
+        assert!(!outside.join("file.txt").exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn mounted_file_open_supports_a_single_file_mount_root() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nac_single_file_mount_{}_{unique}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, "before").unwrap();
+
+        let opened = open_locked_file_beneath(
+            path.clone(),
+            PathBuf::new(),
+            true,
+            true,
+            FileLockAccess::Write,
+        )
+        .await;
+
+        let _ = std::fs::remove_file(path);
+        assert!(matches!(opened, Ok(Some(_))));
     }
 }

--- a/crates/nac-core/src/tools/write.rs
+++ b/crates/nac-core/src/tools/write.rs
@@ -1,22 +1,37 @@
+use std::fs::File;
+use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use serde_json::Value;
 
 use crate::sandbox::FileIoMode;
 use crate::tools::{
-    acquire_write_lock, require_str, resolve_workspace_path, ToolResult, ToolRuntime,
+    open_locked_file, open_locked_file_beneath, remote_file_lock_busy, require_str,
+    resolve_workspace_path, FileLockAccess, ToolResult, ToolRuntime,
+    REMOTE_FILE_LOCK_RETRY_INTERVAL,
 };
 
 const REMOTE_WRITE_SCRIPT: &str = r#"
+import fcntl
 from pathlib import Path
 import sys
 
 orig = sys.argv[1]
 path = Path(sys.argv[2]).expanduser()
+content = sys.stdin.buffer.read()
 
 try:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(sys.stdin.buffer.read())
+    # Opening in append mode avoids truncating before the per-file lock is held.
+    with path.open("ab") as target:
+        try:
+            fcntl.flock(target.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            print("NAC_FILE_LOCK_BUSY")
+            sys.exit(75)
+        target.seek(0)
+        target.truncate()
+        target.write(content)
     print("ok")
 except Exception as exc:
     print(f"Error writing {orig}: {exc}")
@@ -43,39 +58,82 @@ pub async fn execute(args: Value, runtime: &ToolRuntime) -> ToolResult {
                 }
             }
         };
+        if let Some(host_path) = runtime.backend.host_path_for_remote_file(&guest_path) {
+            if host_path.read_only {
+                return ToolResult {
+                    content: format!("Error writing {path}: sandbox mount is read-only"),
+                    is_error: true,
+                };
+            }
+            match open_locked_file_beneath(
+                host_path.root,
+                host_path.relative,
+                true,
+                true,
+                FileLockAccess::Write,
+            )
+            .await
+            {
+                Ok(Some(file)) => {
+                    return write_locked_file(file, path.clone(), content).await;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    return ToolResult {
+                        content: format!("Error opening or locking {path}: {error}"),
+                        is_error: true,
+                    };
+                }
+            }
+        }
         let args = vec![
             "-c".to_string(),
             REMOTE_WRITE_SCRIPT.to_string(),
             path.clone(),
             guest_path.display().to_string(),
         ];
-        let _guard = acquire_write_lock().await;
-        return match runtime
-            .backend
-            .exec("python3", &args, Some(content.into_bytes()))
-            .await
-        {
-            Ok(output) if output.status.success() => ToolResult {
-                content: "ok".to_string(),
-                is_error: false,
-            },
-            Ok(output) => ToolResult {
-                content: String::from_utf8_lossy(&output.stdout).trim().to_string(),
-                is_error: true,
-            },
-            Err(error) => ToolResult {
-                content: format!(
-                    "Error writing {} in {}: {}",
-                    path,
-                    runtime.backend.remote_io_label(),
-                    error
-                ),
-                is_error: true,
-            },
-        };
+        let content = content.into_bytes();
+        loop {
+            match runtime
+                .backend
+                .exec("python3", &args, Some(content.as_slice()))
+                .await
+            {
+                Ok(output) if remote_file_lock_busy(&output) => {
+                    tokio::time::sleep(REMOTE_FILE_LOCK_RETRY_INTERVAL).await;
+                }
+                Ok(output) if output.status.success() => {
+                    return ToolResult {
+                        content: "ok".to_string(),
+                        is_error: false,
+                    };
+                }
+                Ok(output) => {
+                    return ToolResult {
+                        content: String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                        is_error: true,
+                    };
+                }
+                Err(error) => {
+                    return ToolResult {
+                        content: format!(
+                            "Error writing {} in {}: {}",
+                            path,
+                            runtime.backend.remote_io_label(),
+                            error
+                        ),
+                        is_error: true,
+                    };
+                }
+            }
+        }
     }
 
     let path = resolve_workspace_path(runtime, PathBuf::from(path));
+    execute_local(path, content).await
+}
+
+async fn execute_local(path: PathBuf, content: String) -> ToolResult {
     if let Some(parent) = path.parent() {
         if let Err(e) = tokio::fs::create_dir_all(parent).await {
             return ToolResult {
@@ -85,15 +143,37 @@ pub async fn execute(args: Value, runtime: &ToolRuntime) -> ToolResult {
         }
     }
 
-    let _guard = crate::tools::acquire_write_lock().await;
+    let path_display = path.display().to_string();
+    let file = match open_locked_file(path, true, FileLockAccess::Write).await {
+        Ok(file) => file,
+        Err(error) => {
+            return ToolResult {
+                content: format!("Error opening or locking {path_display}: {error}"),
+                is_error: true,
+            };
+        }
+    };
+    write_locked_file(file, path_display, content).await
+}
 
-    match tokio::fs::write(&path, content.as_bytes()).await {
-        Ok(_) => ToolResult {
+async fn write_locked_file(mut file: File, path_display: String, content: String) -> ToolResult {
+    match tokio::task::spawn_blocking(move || {
+        file.set_len(0)?;
+        file.seek(SeekFrom::Start(0))?;
+        file.write_all(content.as_bytes())
+    })
+    .await
+    {
+        Ok(Ok(())) => ToolResult {
             content: "ok".to_string(),
             is_error: false,
         },
-        Err(e) => ToolResult {
-            content: format!("Error writing {}: {}", path.display(), e),
+        Ok(Err(error)) => ToolResult {
+            content: format!("Error writing {path_display}: {error}"),
+            is_error: true,
+        },
+        Err(error) => ToolResult {
+            content: format!("Error writing {path_display}: blocking task failed: {error}"),
             is_error: true,
         },
     }
@@ -117,6 +197,39 @@ mod tests {
         ToolRuntime {
             config_cwd: workspace_cwd.clone(),
             workspace_cwd,
+            store_path: PathBuf::new(),
+            session_id: None,
+            worker_executable: None,
+            active_threads: Arc::new(crate::tools::ActiveThreadRegistry::default()),
+            event_sink: EventSink::none(),
+            backend,
+            mcp: None,
+            skills: None,
+            terminal_manager: crate::terminal::TerminalManager::new(),
+            thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+            worker_usage: Arc::new(Mutex::new(crate::model::TokenUsage::default())),
+        }
+    }
+
+    fn sandbox_runtime_at(host_cwd: PathBuf, read_only: bool) -> ToolRuntime {
+        let sandbox = crate::sandbox::SandboxSession::new_for_test(crate::sandbox::SandboxSpec {
+            backend: crate::sandbox::SandboxBackendType::Podman,
+            image: crate::sandbox::DEFAULT_SANDBOX_IMAGE.to_string(),
+            mounts: vec![crate::sandbox::MountSpec {
+                host: host_cwd.clone(),
+                guest: PathBuf::from(crate::sandbox::DEFAULT_SANDBOX_WORKDIR),
+                read_only,
+            }],
+            workdir: PathBuf::from(crate::sandbox::DEFAULT_SANDBOX_WORKDIR),
+            gpu_devices: Vec::new(),
+            shm_size: Some("0".to_string()),
+            cpus: 2,
+            memory_mib: 2048,
+        });
+        let backend = crate::sandbox::execution_backend_from_sandbox(Some(sandbox), &host_cwd);
+        ToolRuntime {
+            config_cwd: host_cwd.clone(),
+            workspace_cwd: host_cwd,
             store_path: PathBuf::new(),
             session_id: None,
             worker_executable: None,
@@ -176,5 +289,114 @@ mod tests {
         assert_eq!(written, "hello from test");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn writable_sandbox_mount_mutates_the_host_path_directly() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("nac_sandbox_host_write_{unique}"));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = execute(
+            json!({ "path": "nested/out.txt", "content": "host write" }),
+            &sandbox_runtime_at(dir.clone(), false),
+        )
+        .await;
+
+        assert!(!result.is_error, "Write failed: {}", result.content);
+        assert_eq!(
+            std::fs::read_to_string(dir.join("nested/out.txt")).unwrap(),
+            "host write"
+        );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn read_only_sandbox_mount_never_mutates_the_host() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("nac_sandbox_read_only_{unique}"));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = execute(
+            json!({ "path": "nested/out.txt", "content": "must not exist" }),
+            &sandbox_runtime_at(dir.clone(), true),
+        )
+        .await;
+
+        assert!(result.is_error);
+        assert!(result.content.contains("read-only"));
+        assert!(!dir.join("nested").exists());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_does_not_require_read_permission() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nac_write_only_{}_{unique}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, "before").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o200)).unwrap();
+
+        let result = execute(
+            json!({ "path": path.to_string_lossy(), "content": "after" }),
+            &local_runtime(),
+        )
+        .await;
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(!result.is_error, "Write failed: {}", result.content);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "after");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remote_script_reports_contention_without_waiting() {
+        use fs2::FileExt;
+        use std::fs::OpenOptions;
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nac_remote_write_lock_{}_{unique}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&path, "before").unwrap();
+        let held = OpenOptions::new().write(true).open(&path).unwrap();
+        FileExt::lock_exclusive(&held).unwrap();
+
+        let args = vec![
+            "-c".to_string(),
+            REMOTE_WRITE_SCRIPT.to_string(),
+            path.display().to_string(),
+            path.display().to_string(),
+        ];
+        let runtime = local_runtime();
+        let output = runtime
+            .backend
+            .exec("python3", &args, Some(b"after"))
+            .await
+            .unwrap();
+
+        assert!(remote_file_lock_busy(&output));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "before");
+        drop(held);
+        let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Description

**What.** Serializes NAC `write` and `edit` mutations by file identity across sessions and worker processes while allowing unrelated files to progress independently.

**Why.** The previous process-global `WRITE_LOCK` serialized unrelated writes but still allowed cross-process same-file races, and local `edit` read before acquiring the lock.

Local mutations now use cancellable advisory OS file-lock polling and hold the lock across the complete edit transaction. SSH and unmounted sandbox paths use nonblocking remote `flock` attempts. Writable sandbox mounts share the host file identity without changing guest symlink semantics: symlinked paths fall back to guest execution, while the host fast path uses descriptor-relative, no-follow traversal beneath the mount root. Read-only mounts fail before host-side creation. Backend helper processes are kill-on-drop.

These locks coordinate NAC `write` and `edit` operations. Shell commands and unrelated external writers remain outside the advisory-lock guarantee.

## Usage

No tool schema or operator workflow changes. Existing `write` and `edit` calls gain same-file exclusivity automatically.

## Bug Evidence

Before this change, concurrent local edits could both read the same pre-mutation content and lose one update; separate NAC worker processes were not coordinated at all. The regression coverage now holds a target lock in a separate process, verifies simultaneous edits preserve both changes, aborts a blocked waiter and proves it cannot mutate later, and confirms unrelated files remain independently lockable.

Review also found that the first host-mounted implementation could follow a guest-controlled symlink in the host namespace. The final implementation falls back to guest execution for existing symlinks and uses `openat`/`mkdirat` with `O_NOFOLLOW` and retained directory descriptors to prevent component-swap escapes. Regression tests cover symlinked parents and single-file mount roots.

## Changelog

- Serialize same-file `write` and `edit` mutations across NAC processes.
- Allow mutations of distinct files to run concurrently.
- Preserve write-only-file support, cancellation safety, read-only sandbox mounts, guest symlink semantics, and single-file mounts.

## Performance

Measured on an Apple M5 Pro running macOS 25.5/APFS and Rust 1.97.0. The ignored release benchmark alternates 30 samples with 8 tasks:

```bash
cargo test --release -p nac-core benchmark_global_vs_per_file_lock -- --ignored --nocapture
```

| Workload | Global median / p95 | Per-file median / p95 | Median result |
| --- | ---: | ---: | ---: |
| 64 KiB cached writes, same file, 100 ops/task | 38.503 / 42.399 ms | 40.516 / 43.374 ms | 5.2% overhead |
| 64 KiB cached writes, distinct files, 100 ops/task | 39.919 / 53.202 ms | 32.139 / 37.055 ms | 1.24x faster |
| Simulated 2 ms mutation latency, same file, 20 ops/task | 399.467 / 401.001 ms | 411.389 / 416.325 ms | 3.0% overhead |
| Simulated 2 ms mutation latency, distinct files, 20 ops/task | 399.257 / 400.920 ms | 51.097 / 51.980 ms | 7.81x faster |

The simulated workload isolates lock topology from filesystem speed; it is not an end-to-end filesystem benchmark.

## Validation

Rebased onto `origin/main` without conflicts. `node --check crates/nac-server/assets/app.js` and `node --test crates/nac-server/assets/app.test.js` passed with 117 tests. `cargo test --workspace --locked` passed with 608 tests and 3 ignored. The release lock benchmark passed after the final review fixes. Seven focused review personas covered elegance, idiom, correctness, completeness, security, YAGNI, and scope; the accepted sandbox-symlink, single-file-mount, and retry-allocation findings were fixed and their originating reviewers reported no remaining finding.