### PR TITLE
Reduce dashboard snapshot churn and runtime stalls

### DIFF
--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -283,6 +283,17 @@ struct DecodedThreadEvents {
     diagnostics: Vec<ThreadEventDecodeDiagnostic>,
 }
 
+struct FrontendSnapshotBlockingLoad {
+    sessions: Vec<SessionSummarySnapshot>,
+    threads: Vec<ThreadSnapshot>,
+    thread_episodes: HashMap<String, Vec<EpisodeSnapshot>>,
+    thread_events: DecodedThreadEvents,
+    thread_event_boundary: SessionEventBoundary,
+    thread_steering: Vec<crate::store::ThreadSteeringRecord>,
+    worksets: WorksetsSnapshot,
+    workspace: WorkspaceSnapshot,
+}
+
 pub struct SessionServiceParts {
     pub service: SessionService,
     pub init: SessionServiceInit,
@@ -856,8 +867,9 @@ impl SessionService {
         )
     }
 
-    fn load_all_thread_events_with_limit(
+    fn load_all_thread_events_with_connection(
         &self,
+        conn: &rusqlite::Connection,
         per_thread_limit: usize,
     ) -> Result<DecodedThreadEvents> {
         let Some(session_id) = self.metadata.session_id.as_deref() else {
@@ -866,28 +878,91 @@ impl SessionService {
                 diagnostics: Vec::new(),
             });
         };
-        let records = crate::store::load_all_thread_events(
-            &self.metadata.store_path,
+        let records = crate::store::load_all_thread_events_with_connection(
+            conn,
             session_id,
             per_thread_limit,
         )?;
-        let mut events = HashMap::new();
-        let mut diagnostics = Vec::new();
-        for (thread_name, records) in records {
-            let decoded = records
-                .into_iter()
-                .filter_map(|record| decode_thread_event(record, &mut diagnostics))
-                .collect::<Vec<_>>();
-            if !decoded.is_empty() {
-                events.insert(thread_name, decoded);
-            }
-        }
-        Ok(DecodedThreadEvents {
-            events,
-            diagnostics,
-        })
+        Ok(decode_thread_events(records))
     }
 
+    fn load_frontend_snapshot_blocking(
+        &self,
+        options: FrontendSnapshotLoadOptions,
+    ) -> Result<FrontendSnapshotBlockingLoad> {
+        let (
+            sessions,
+            threads,
+            thread_episodes,
+            thread_events,
+            thread_event_boundary,
+            thread_steering,
+            worksets,
+        ) = {
+            let conn = crate::store::open_runtime_connection(&self.metadata.store_path)?;
+            let session_id = self.metadata.session_id.as_deref();
+            let thread_steering = session_id
+                .map(|session_id| {
+                    crate::store::list_thread_steering_with_connection(&conn, session_id)
+                })
+                .transpose()?
+                .unwrap_or_default();
+            let (thread_event_boundary, thread_events) =
+                self.event_bus.thread_event_boundary(|| {
+                    self.load_all_thread_events_with_connection(&conn, options.thread_event_limit)
+                })?;
+            (
+                if options.include_sessions {
+                    view::list_sessions_with_connection(&conn)?
+                } else {
+                    Vec::new()
+                },
+                view::list_threads_with_connection(&conn, session_id)?,
+                view::load_all_thread_episodes_with_connection(&conn, session_id)?,
+                thread_events,
+                thread_event_boundary,
+                thread_steering,
+                view::worksets_snapshot_with_connection(&conn, session_id),
+            )
+        };
+        let workspace = view::workspace_snapshot(
+            &self.metadata.cwd,
+            self.metadata.workspace_host_path.as_deref(),
+        );
+        Ok(FrontendSnapshotBlockingLoad {
+            sessions,
+            threads,
+            thread_episodes,
+            thread_events,
+            thread_event_boundary,
+            thread_steering,
+            worksets,
+            workspace,
+        })
+    }
+}
+
+fn decode_thread_events(
+    records: HashMap<String, Vec<crate::store::ThreadEventRecord>>,
+) -> DecodedThreadEvents {
+    let mut events = HashMap::new();
+    let mut diagnostics = Vec::new();
+    for (thread_name, records) in records {
+        let decoded = records
+            .into_iter()
+            .filter_map(|record| decode_thread_event(record, &mut diagnostics))
+            .collect::<Vec<_>>();
+        if !decoded.is_empty() {
+            events.insert(thread_name, decoded);
+        }
+    }
+    DecodedThreadEvents {
+        events,
+        diagnostics,
+    }
+}
+
+impl SessionService {
     pub fn thread_events_page(
         &self,
         thread_name: &str,
@@ -990,24 +1065,24 @@ impl SessionService {
         &self,
         options: FrontendSnapshotLoadOptions,
     ) -> Result<SessionFrontendSnapshotLoad> {
-        let thread_steering = self
-            .metadata
-            .session_id
-            .as_deref()
-            .map(|session_id| {
-                crate::store::list_thread_steering(&self.metadata.store_path, session_id)
-            })
-            .transpose()?
-            .unwrap_or_default();
+        // SQLite and git are synchronous. Keep all dashboard storage reads on
+        // one connection and move that connection plus git subprocesses off
+        // the async runtime workers. Load steering before the transcript so a
+        // concurrently delivered record is either absent here or coverable by
+        // the subsequent transcript scan, never rendered twice.
+        let blocking_service = self.clone();
+        let blocking_task = tokio::task::spawn_blocking(move || {
+            blocking_service.load_frontend_snapshot_blocking(options)
+        });
+        let (active_threads, blocking) = tokio::join!(self.active_thread_names(), blocking_task);
+        let blocking = blocking
+            .map_err(|error| anyhow::anyhow!("frontend snapshot load task failed: {error}"))??;
+
         // Store-backed transcript reads (step 3): the snapshot blob (legacy
         // prefix) ++ the transcript log tail, ALWAYS. The agent-or-persisted
         // duality and the stale-during-run fallback are gone — mid-run
         // appends are visible as they commit to the log.
         self.update_transcript_scan().await?;
-        let covered_orchestrator_steering_ids = {
-            let scan = self.lock_transcript_scan();
-            covered_ids_from_scan(&thread_steering, &scan)
-        };
         let response_timing = {
             let snapshot = self.session_snapshot.lock().await;
             ResponseTimingSnapshot::from_session_snapshot(snapshot.as_ref())
@@ -1029,10 +1104,10 @@ impl SessionService {
             }
         };
 
-        let (thread_event_boundary, decoded_thread_events) =
-            self.event_bus.thread_event_boundary(|| {
-                self.load_all_thread_events_with_limit(options.thread_event_limit)
-            })?;
+        let covered_orchestrator_steering_ids = {
+            let scan = self.lock_transcript_scan();
+            covered_ids_from_scan(&blocking.thread_steering, &scan)
+        };
         let mut metadata = self.metadata();
         metadata.extra_headers.clear();
         let snapshot = SessionFrontendSnapshot {
@@ -1041,21 +1116,17 @@ impl SessionService {
             response_timing,
             active_run: self.active_run(),
             active_compaction: self.active_compaction(),
-            sessions: if options.include_sessions {
-                self.list_sessions()?
-            } else {
-                Vec::new()
-            },
-            active_threads: self.active_thread_names().await,
-            threads: self.list_threads()?,
-            thread_episodes: self.all_thread_episodes()?,
-            thread_events: decoded_thread_events.events,
-            thread_event_boundary,
-            thread_event_diagnostics: decoded_thread_events.diagnostics,
-            thread_steering,
+            sessions: blocking.sessions,
+            active_threads,
+            threads: blocking.threads,
+            thread_episodes: blocking.thread_episodes,
+            thread_events: blocking.thread_events.events,
+            thread_event_boundary: blocking.thread_event_boundary,
+            thread_event_diagnostics: blocking.thread_events.diagnostics,
+            thread_steering: blocking.thread_steering,
             covered_orchestrator_steering_ids,
-            worksets: self.worksets_snapshot(),
-            workspace: self.workspace_snapshot(),
+            worksets: blocking.worksets,
+            workspace: blocking.workspace,
         };
         Ok(SessionFrontendSnapshotLoad {
             snapshot,
@@ -2663,6 +2734,222 @@ pub(super) mod tests {
             resume_base_cwd: PathBuf::from("/repo"),
         });
         (parts, store_path)
+    }
+
+    #[tokio::test]
+    async fn frontend_snapshot_reuses_one_runtime_connection() {
+        let (parts, store_path) =
+            test_active_service("snapshot_connection_reuse", "connection-session");
+        for index in 0..3 {
+            crate::store::define_workset(
+                &store_path,
+                "connection-session",
+                &crate::store::WorksetDefinition {
+                    id: format!("workset-{index}"),
+                    goal: "verify connection reuse".to_string(),
+                    status: "active".to_string(),
+                    summary: String::new(),
+                    verification_recipe: None,
+                    items: Vec::new(),
+                },
+            )
+            .unwrap();
+        }
+        crate::store::append_episode(
+            &store_path,
+            "connection-session",
+            "worker",
+            "implementation",
+            "retained episode",
+        )
+        .unwrap();
+        let event_json = serde_json::to_string(&AgentEvent::AssistantMessage {
+            thread_name: Some("worker".to_string()),
+            content: "retained event".to_string(),
+            usage: None,
+        })
+        .unwrap();
+        crate::store::append_thread_event(
+            &store_path,
+            "connection-session",
+            "worker",
+            &event_json,
+        )
+        .unwrap();
+        crate::store::queue_thread_steering(
+            &store_path,
+            "connection-session",
+            "worker",
+            "dispatch",
+            "retained steering",
+        )
+        .unwrap();
+        crate::store::track_connection_opens(&store_path);
+
+        let snapshot = parts.service.frontend_snapshot().await.unwrap();
+
+        assert_eq!(snapshot.sessions.len(), 1);
+        assert_eq!(snapshot.threads.len(), 1);
+        assert_eq!(snapshot.thread_episodes["worker"].len(), 1);
+        assert_eq!(snapshot.thread_events["worker"].len(), 1);
+        assert_eq!(snapshot.thread_steering.len(), 1);
+        assert_eq!(snapshot.worksets.items.len(), 3);
+        assert_eq!(crate::store::tracked_connection_opens(&store_path), 1);
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore = "manual latency benchmark; run with --ignored --nocapture"]
+    async fn benchmark_frontend_snapshot_latency() {
+        use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+        const ITERATIONS: usize = 100;
+        let (mut parts, store_path) =
+            test_active_service("snapshot_benchmark", "benchmark-session");
+        let workspace = store_path.parent().unwrap().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .args(args)
+                .current_dir(&workspace)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        };
+        git(&["init", "--quiet"]);
+        for index in 0..64 {
+            std::fs::write(
+                workspace.join(format!("file-{index}.txt")),
+                format!("baseline {index}\n"),
+            )
+            .unwrap();
+        }
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.name=nac benchmark",
+            "-c",
+            "user.email=nac-benchmark@example.invalid",
+            "commit",
+            "--quiet",
+            "-m",
+            "benchmark fixture",
+        ]);
+        for index in 0..16 {
+            std::fs::write(
+                workspace.join(format!("file-{index}.txt")),
+                format!("modified {index}\n"),
+            )
+            .unwrap();
+        }
+        let metadata = Arc::make_mut(&mut parts.service.metadata);
+        metadata.cwd = workspace.display().to_string();
+        metadata.workspace_host_path = Some(workspace);
+        for thread_index in 0..16 {
+            let thread_name = format!("worker-{thread_index}");
+            for episode_index in 0..8 {
+                crate::store::append_episode(
+                    &store_path,
+                    "benchmark-session",
+                    &thread_name,
+                    "implementation",
+                    &format!("episode {episode_index}"),
+                )
+                .unwrap();
+            }
+            for event_index in 0..32 {
+                let event_json = serde_json::to_string(&AgentEvent::AssistantMessage {
+                    thread_name: Some(thread_name.clone()),
+                    content: format!("event {event_index}"),
+                    usage: None,
+                })
+                .unwrap();
+                crate::store::append_thread_event(
+                    &store_path,
+                    "benchmark-session",
+                    &thread_name,
+                    &event_json,
+                )
+                .unwrap();
+            }
+        }
+        for workset_index in 0..4 {
+            crate::store::define_workset(
+                &store_path,
+                "benchmark-session",
+                &crate::store::WorksetDefinition {
+                    id: format!("workset-{workset_index}"),
+                    goal: "measure dashboard reads".to_string(),
+                    status: "active".to_string(),
+                    summary: "benchmark fixture".to_string(),
+                    verification_recipe: None,
+                    items: (0..8)
+                        .map(|item_index| crate::store::WorksetItemDefinition {
+                            title: format!("item-{item_index}"),
+                            scope: "crates/nac-core".to_string(),
+                            description: "exercise workset detail reads".to_string(),
+                            role: "implementation".to_string(),
+                            depends_on: Vec::new(),
+                            acceptance: "snapshot includes this item".to_string(),
+                            notes: None,
+                        })
+                        .collect(),
+                },
+            )
+            .unwrap();
+        }
+        seed_store_transcript(
+            &parts,
+            (0..128)
+                .map(|index| Message::User {
+                    content: format!("benchmark message {index}"),
+                })
+                .collect(),
+        )
+        .await;
+
+        for _ in 0..10 {
+            parts.service.frontend_snapshot().await.unwrap();
+        }
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let max_scheduler_gap_us = Arc::new(AtomicU64::new(0));
+        let ticker_stop = Arc::clone(&stop);
+        let ticker_gap = Arc::clone(&max_scheduler_gap_us);
+        let ticker = tokio::spawn(async move {
+            let mut previous = Instant::now();
+            while !ticker_stop.load(Ordering::Relaxed) {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                let now = Instant::now();
+                let lateness_us =
+                    (now.duration_since(previous).as_micros() as u64).saturating_sub(1_000);
+                ticker_gap.fetch_max(lateness_us, Ordering::Relaxed);
+                previous = now;
+            }
+        });
+
+        let mut latency_us = Vec::with_capacity(ITERATIONS);
+        for _ in 0..ITERATIONS {
+            let started = Instant::now();
+            parts.service.frontend_snapshot().await.unwrap();
+            latency_us.push(started.elapsed().as_micros() as u64);
+        }
+        stop.store(true, Ordering::Relaxed);
+        ticker.await.unwrap();
+        latency_us.sort_unstable();
+        let p95_index = (ITERATIONS * 95).div_ceil(100) - 1;
+        eprintln!(
+            "frontend_snapshot_benchmark iterations={ITERATIONS} median_us={} p95_us={} max_scheduler_lateness_us={}",
+            latency_us[ITERATIONS / 2],
+            latency_us[p95_index],
+            max_scheduler_gap_us.load(Ordering::Relaxed)
+        );
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -2769,13 +2769,8 @@ pub(super) mod tests {
             usage: None,
         })
         .unwrap();
-        crate::store::append_thread_event(
-            &store_path,
-            "connection-session",
-            "worker",
-            &event_json,
-        )
-        .unwrap();
+        crate::store::append_thread_event(&store_path, "connection-session", "worker", &event_json)
+            .unwrap();
         crate::store::queue_thread_steering(
             &store_path,
             "connection-session",

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -438,6 +438,24 @@ impl SessionClientHandle {
     }
 }
 
+#[cfg(test)]
+#[derive(Default)]
+struct FrontendSnapshotAfterWorkspaceGate {
+    reached: std::sync::atomic::AtomicBool,
+    resume: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(test)]
+impl FrontendSnapshotAfterWorkspaceGate {
+    fn pause(&self) {
+        self.reached
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        while !self.resume.load(std::sync::atomic::Ordering::SeqCst) {
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SessionService {
     agent: Arc<Mutex<Agent>>,
@@ -456,6 +474,8 @@ pub struct SessionService {
     event_bus: SessionEventBus,
     active_operation: Arc<StdMutex<Option<ActiveSessionOperation>>>,
     active_threads: Arc<crate::tools::ActiveThreadRegistry>,
+    #[cfg(test)]
+    frontend_snapshot_after_workspace_gate: Option<Arc<FrontendSnapshotAfterWorkspaceGate>>,
 }
 
 enum ActiveSessionOperation {
@@ -629,6 +649,8 @@ impl SessionService {
             event_bus,
             active_operation: Arc::new(StdMutex::new(None)),
             active_threads,
+            #[cfg(test)]
+            frontend_snapshot_after_workspace_gate: None,
         };
         let init = SessionServiceInit {
             metadata,
@@ -890,6 +912,15 @@ impl SessionService {
         &self,
         options: FrontendSnapshotLoadOptions,
     ) -> Result<FrontendSnapshotBlockingLoad> {
+        let workspace = view::workspace_snapshot(
+            &self.metadata.cwd,
+            self.metadata.workspace_host_path.as_deref(),
+        );
+        #[cfg(test)]
+        if let Some(gate) = &self.frontend_snapshot_after_workspace_gate {
+            gate.pause();
+        }
+
         let (
             sessions,
             threads,
@@ -901,34 +932,38 @@ impl SessionService {
         ) = {
             let conn = crate::store::open_runtime_connection(&self.metadata.store_path)?;
             let session_id = self.metadata.session_id.as_deref();
+            let sessions = if options.include_sessions {
+                view::list_sessions_with_connection(&conn)?
+            } else {
+                Vec::new()
+            };
+            let threads = view::list_threads_with_connection(&conn, session_id)?;
+            let thread_episodes =
+                view::load_all_thread_episodes_with_connection(&conn, session_id)?;
+            let (thread_event_boundary, thread_events) =
+                self.event_bus.thread_event_boundary(|| {
+                    self.load_all_thread_events_with_connection(&conn, options.thread_event_limit)
+                })?;
+            let worksets = view::worksets_snapshot_with_connection(&conn, session_id);
+            // Keep this final storage read adjacent to the transcript scan so
+            // a delivery committed during slower workspace inspection has the
+            // current status needed to cover its canonical message.
             let thread_steering = session_id
                 .map(|session_id| {
                     crate::store::list_thread_steering_with_connection(&conn, session_id)
                 })
                 .transpose()?
                 .unwrap_or_default();
-            let (thread_event_boundary, thread_events) =
-                self.event_bus.thread_event_boundary(|| {
-                    self.load_all_thread_events_with_connection(&conn, options.thread_event_limit)
-                })?;
             (
-                if options.include_sessions {
-                    view::list_sessions_with_connection(&conn)?
-                } else {
-                    Vec::new()
-                },
-                view::list_threads_with_connection(&conn, session_id)?,
-                view::load_all_thread_episodes_with_connection(&conn, session_id)?,
+                sessions,
+                threads,
+                thread_episodes,
                 thread_events,
                 thread_event_boundary,
                 thread_steering,
-                view::worksets_snapshot_with_connection(&conn, session_id),
+                worksets,
             )
         };
-        let workspace = view::workspace_snapshot(
-            &self.metadata.cwd,
-            self.metadata.workspace_host_path.as_deref(),
-        );
         Ok(FrontendSnapshotBlockingLoad {
             sessions,
             threads,
@@ -3572,6 +3607,81 @@ pub(super) mod tests {
                 "incremental coverage must match the reference pairing"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn frontend_snapshot_reconciles_steering_delivered_during_workspace_load() {
+        let (mut parts, store_path) =
+            test_active_service("steering_workspace_race", "session-steering-workspace-race");
+        let queued = crate::store::queue_thread_steering(
+            &store_path,
+            "session-steering-workspace-race",
+            crate::store::ORCHESTRATOR_STEERING_TARGET,
+            "run-1",
+            "change direction",
+        )
+        .unwrap();
+        crate::store::claim_thread_steering(
+            &store_path,
+            "session-steering-workspace-race",
+            "run-1",
+        )
+        .unwrap();
+
+        let gate = Arc::new(FrontendSnapshotAfterWorkspaceGate::default());
+        parts.service.frontend_snapshot_after_workspace_gate = Some(Arc::clone(&gate));
+        let snapshot_service = parts.service.clone();
+        let snapshot_task =
+            tokio::spawn(async move { snapshot_service.frontend_snapshot().await.unwrap() });
+        let reached = tokio::time::timeout(Duration::from_secs(5), async {
+            while !gate.reached.load(std::sync::atomic::Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        if reached.is_err() {
+            gate.resume
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let _ = snapshot_task.await;
+            panic!("snapshot did not finish workspace inspection");
+        }
+
+        crate::store::acknowledge_thread_steering_batch(
+            &store_path,
+            &[queued.id],
+            "session-steering-workspace-race",
+            "run-1",
+        )
+        .unwrap();
+        seed_log_tail(
+            &parts,
+            vec![Message::User {
+                content: "change direction".to_string(),
+            }],
+        )
+        .await;
+        gate.resume
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let snapshot = snapshot_task.await.unwrap();
+        assert_eq!(snapshot.covered_orchestrator_steering_ids, vec![queued.id]);
+        assert_eq!(
+            snapshot
+                .thread_steering
+                .iter()
+                .find(|record| record.id == queued.id)
+                .map(|record| record.status.as_str()),
+            Some("delivered")
+        );
+        assert!(
+            matches!(
+                snapshot.messages.last(),
+                Some(Message::User { content }) if content == "change direction"
+            ),
+            "the canonical message must cover steering delivered during workspace inspection"
+        );
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -339,7 +339,13 @@ fn map_session_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
 
 pub fn list_sessions(path: &Path) -> Result<Vec<SessionSummary>> {
     let conn = crate::store::open_runtime_connection(path)?;
-    query_session_summaries(&conn, None)
+    list_sessions_with_connection(&conn)
+}
+
+pub(crate) fn list_sessions_with_connection(
+    conn: &rusqlite::Connection,
+) -> Result<Vec<SessionSummary>> {
+    query_session_summaries(conn, None)
 }
 
 pub fn update_session_presentation(

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -16,6 +16,7 @@ mod operation_lease;
 mod snapshot;
 mod summary;
 
+pub(crate) use db::list_sessions_with_connection;
 pub use db::{
     create_session, delete_session, list_sessions, load_last_session, load_session,
     load_session_config, reorder_sessions, save_session, save_session_run_state, session_exists,

--- a/crates/nac-core/src/store/mod.rs
+++ b/crates/nac-core/src/store/mod.rs
@@ -23,7 +23,13 @@ pub use transcript::*;
 pub use worksets::*;
 
 pub(crate) use schema::{open_connection, open_runtime_connection};
+#[cfg(test)]
+pub(crate) use schema::{track_connection_opens, tracked_connection_opens};
+pub(crate) use steering::list_thread_steering_with_connection;
+pub(crate) use thread_events::load_all_thread_events_with_connection;
+pub(crate) use threads::{list_threads_with_connection, load_all_episodes_with_connection};
 use time::now_utc;
+pub(crate) use worksets::{list_worksets_with_connection, read_workset_with_connection};
 
 #[cfg(test)]
 pub(crate) fn insert_test_session(path: &Path, session_id: &str) {

--- a/crates/nac-core/src/store/schema.rs
+++ b/crates/nac-core/src/store/schema.rs
@@ -2,6 +2,11 @@ use super::*;
 
 const STORE_SCHEMA_VERSION: i64 = 4;
 
+#[cfg(test)]
+static TRACKED_CONNECTION_OPENS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<PathBuf, usize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
 /// Default SQLite store path under the nac home, or `.nac/store.db` as fallback.
 pub fn default_store_path() -> PathBuf {
     crate::paths::nac_home_dir()
@@ -22,6 +27,15 @@ fn connect(path: &Path) -> Result<Connection> {
 
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open SQLite store {}", path.display()))?;
+    #[cfg(test)]
+    {
+        let mut tracked = TRACKED_CONNECTION_OPENS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(count) = tracked.get_mut(path) {
+            *count += 1;
+        }
+    }
     conn.busy_timeout(std::time::Duration::from_secs(5))?;
     Ok(conn)
 }
@@ -29,12 +43,36 @@ fn connect(path: &Path) -> Result<Connection> {
 pub(crate) fn open_runtime_connection(path: &Path) -> Result<Connection> {
     let conn = connect(path)?;
     conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    let journal_mode: String = conn.pragma_query_value(None, "journal_mode", |row| row.get(0))?;
+    if !journal_mode.eq_ignore_ascii_case("wal") {
+        // journal_mode is database-wide and persistent. Normal runtime opens
+        // only verify the initialized mode; recovery from external changes
+        // performs the transition once.
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+    }
     let schema_version: i64 = conn.pragma_query_value(None, "user_version", |row| row.get(0))?;
     if schema_version != STORE_SCHEMA_VERSION {
         drop(conn);
         return open_connection(path);
     }
     Ok(conn)
+}
+
+#[cfg(test)]
+pub(crate) fn track_connection_opens(path: &Path) {
+    TRACKED_CONNECTION_OPENS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path.to_path_buf(), 0);
+}
+
+#[cfg(test)]
+pub(crate) fn tracked_connection_opens(path: &Path) -> usize {
+    TRACKED_CONNECTION_OPENS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(path)
+        .unwrap_or(0)
 }
 
 pub(crate) fn open_connection(path: &Path) -> Result<Connection> {

--- a/crates/nac-core/src/store/schema_tests.rs
+++ b/crates/nac-core/src/store/schema_tests.rs
@@ -56,6 +56,25 @@ fn insert_legacy_session(conn: &Connection, session_id: &str) {
     .unwrap();
 }
 
+#[test]
+fn runtime_connections_restore_wal_mode() {
+    let path = temp_store_path("runtime_wal");
+    initialize(&path).unwrap();
+
+    let conn = Connection::open(&path).unwrap();
+    conn.pragma_update(None, "journal_mode", "DELETE").unwrap();
+    drop(conn);
+
+    let runtime = open_runtime_connection(&path).unwrap();
+    let journal_mode: String = runtime
+        .pragma_query_value(None, "journal_mode", |row| row.get(0))
+        .unwrap();
+    assert_eq!(journal_mode.to_ascii_lowercase(), "wal");
+
+    drop(runtime);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
 #[allow(clippy::too_many_arguments)]
 fn insert_raw_checkpoint(
     conn: &Connection,

--- a/crates/nac-core/src/store/steering.rs
+++ b/crates/nac-core/src/store/steering.rs
@@ -233,8 +233,16 @@ fn retry_busy<T>(mut operation: impl FnMut() -> Result<T>) -> Result<T> {
     operation()
 }
 
+#[cfg(test)]
 pub fn list_thread_steering(path: &Path, session_id: &str) -> Result<Vec<ThreadSteeringRecord>> {
     let conn = open_runtime_connection(path)?;
+    list_thread_steering_with_connection(&conn, session_id)
+}
+
+pub(crate) fn list_thread_steering_with_connection(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Vec<ThreadSteeringRecord>> {
     let mut statement = conn.prepare(&format!(
         "SELECT {RECORD_COLUMNS} FROM (
              SELECT {RECORD_COLUMNS} FROM thread_steering

--- a/crates/nac-core/src/store/thread_events.rs
+++ b/crates/nac-core/src/store/thread_events.rs
@@ -36,15 +36,24 @@ pub fn append_thread_event(
     ThreadEventWriter::new(path)?.append(session_id, thread_name, event_json)
 }
 
+#[cfg(test)]
 pub fn load_all_thread_events(
     path: &Path,
+    session_id: &str,
+    per_thread_limit: usize,
+) -> Result<HashMap<String, Vec<ThreadEventRecord>>> {
+    let conn = open_runtime_connection(path)?;
+    load_all_thread_events_with_connection(&conn, session_id, per_thread_limit)
+}
+
+pub(crate) fn load_all_thread_events_with_connection(
+    conn: &Connection,
     session_id: &str,
     per_thread_limit: usize,
 ) -> Result<HashMap<String, Vec<ThreadEventRecord>>> {
     if per_thread_limit == 0 {
         return Ok(HashMap::new());
     }
-    let conn = open_runtime_connection(path)?;
     // Transcript log rows live under the reserved orchestrator target
     // (store/transcript.rs); they must never enter the event/tile paths.
     let mut stmt = conn.prepare(

--- a/crates/nac-core/src/store/threads.rs
+++ b/crates/nac-core/src/store/threads.rs
@@ -57,6 +57,13 @@ pub fn load_all_episodes(
     session_id: &str,
 ) -> Result<HashMap<String, Vec<EpisodeRecord>>> {
     let conn = open_runtime_connection(store_path)?;
+    load_all_episodes_with_connection(&conn, session_id)
+}
+
+pub(crate) fn load_all_episodes_with_connection(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<HashMap<String, Vec<EpisodeRecord>>> {
     let mut stmt = conn.prepare(
         "SELECT e.id, e.thread_name, e.session_id, e.action, e.content, e.created_at
          FROM episodes e
@@ -79,6 +86,13 @@ pub fn load_all_episodes(
 
 pub fn list_threads(path: &Path, session_id: &str) -> Result<Vec<ThreadRecord>> {
     let conn = open_runtime_connection(path)?;
+    list_threads_with_connection(&conn, session_id)
+}
+
+pub(crate) fn list_threads_with_connection(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Vec<ThreadRecord>> {
     let mut stmt = conn.prepare(
         "SELECT t.name, t.session_id, t.created_at, t.updated_at,
                 (SELECT COUNT(*) FROM episodes e

--- a/crates/nac-core/src/store/worksets.rs
+++ b/crates/nac-core/src/store/worksets.rs
@@ -77,6 +77,14 @@ pub fn define_workset(path: &Path, session_id: &str, workset: &WorksetDefinition
 
 pub fn read_workset(path: &Path, session_id: &str, id: &str) -> Result<Option<WorksetRecord>> {
     let conn = open_runtime_connection(path)?;
+    read_workset_with_connection(&conn, session_id, id)
+}
+
+pub(crate) fn read_workset_with_connection(
+    conn: &Connection,
+    session_id: &str,
+    id: &str,
+) -> Result<Option<WorksetRecord>> {
     let Some(mut workset) = conn
         .query_row(
             "SELECT id, session_id, instruction, status, summary, verification_recipe, created_at, updated_at
@@ -89,12 +97,19 @@ pub fn read_workset(path: &Path, session_id: &str, id: &str) -> Result<Option<Wo
     else {
         return Ok(None);
     };
-    workset.items = load_workset_items(&conn, session_id, id)?;
+    workset.items = load_workset_items(conn, session_id, id)?;
     Ok(Some(workset))
 }
 
 pub fn list_worksets(path: &Path, session_id: &str) -> Result<Vec<WorksetSummary>> {
     let conn = open_runtime_connection(path)?;
+    list_worksets_with_connection(&conn, session_id)
+}
+
+pub(crate) fn list_worksets_with_connection(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Vec<WorksetSummary>> {
     let sql = "SELECT w.id, w.status, w.summary,
                (SELECT COUNT(*) FROM workset_items i
                 WHERE i.workset_id = w.id AND i.session_id = w.session_id) AS item_count,

--- a/crates/nac-core/src/view.rs
+++ b/crates/nac-core/src/view.rs
@@ -240,6 +240,13 @@ pub fn list_sessions(store_path: &Path) -> Result<Vec<SessionSummarySnapshot>> {
         .map(|sessions| sessions.into_iter().map(Into::into).collect())
 }
 
+pub(crate) fn list_sessions_with_connection(
+    conn: &rusqlite::Connection,
+) -> Result<Vec<SessionSummarySnapshot>> {
+    sessions::list_sessions_with_connection(conn)
+        .map(|sessions| sessions.into_iter().map(Into::into).collect())
+}
+
 pub fn delete_session(store_path: &Path, session_id: &str) -> Result<bool> {
     sessions::delete_session(store_path, session_id)
 }
@@ -249,6 +256,17 @@ pub fn list_threads(store_path: &Path, session_id: Option<&str>) -> Result<Vec<T
         return Ok(Vec::new());
     };
     store::list_threads(store_path, session_id)
+        .map(|threads| threads.into_iter().map(Into::into).collect())
+}
+
+pub(crate) fn list_threads_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: Option<&str>,
+) -> Result<Vec<ThreadSnapshot>> {
+    let Some(session_id) = session_id else {
+        return Ok(Vec::new());
+    };
+    store::list_threads_with_connection(conn, session_id)
         .map(|threads| threads.into_iter().map(Into::into).collect())
 }
 
@@ -272,6 +290,20 @@ pub fn load_all_thread_episodes(
         return Ok(HashMap::new());
     };
     let episodes = store::load_all_episodes(store_path, session_id)?;
+    Ok(episodes
+        .into_iter()
+        .map(|(thread, episodes)| (thread, episodes.into_iter().map(Into::into).collect()))
+        .collect())
+}
+
+pub(crate) fn load_all_thread_episodes_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: Option<&str>,
+) -> Result<HashMap<String, Vec<EpisodeSnapshot>>> {
+    let Some(session_id) = session_id else {
+        return Ok(HashMap::new());
+    };
+    let episodes = store::load_all_episodes_with_connection(conn, session_id)?;
     Ok(episodes
         .into_iter()
         .map(|(thread, episodes)| (thread, episodes.into_iter().map(Into::into).collect()))
@@ -317,11 +349,45 @@ pub fn worksets_snapshot(store_path: &Path, session_id: Option<&str>) -> Workset
     }
 }
 
+pub(crate) fn worksets_snapshot_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: Option<&str>,
+) -> WorksetsSnapshot {
+    let Some(session_id) = session_id else {
+        return WorksetsSnapshot {
+            items: Vec::new(),
+            error: Some("no active session".to_string()),
+        };
+    };
+
+    match load_workset_records_with_connection(conn, session_id) {
+        Ok(items) => WorksetsSnapshot { items, error: None },
+        Err(error) => WorksetsSnapshot {
+            items: Vec::new(),
+            error: Some(error.to_string()),
+        },
+    }
+}
+
 fn load_workset_records(store_path: &Path, session_id: &str) -> Result<Vec<WorksetSnapshot>> {
     let summaries = store::list_worksets(store_path, session_id)?;
     let mut worksets = Vec::with_capacity(summaries.len());
     for summary in summaries {
         if let Some(workset) = store::read_workset(store_path, session_id, &summary.id)? {
+            worksets.push(workset.into());
+        }
+    }
+    Ok(worksets)
+}
+
+fn load_workset_records_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> Result<Vec<WorksetSnapshot>> {
+    let summaries = store::list_worksets_with_connection(conn, session_id)?;
+    let mut worksets = Vec::with_capacity(summaries.len());
+    for summary in summaries {
+        if let Some(workset) = store::read_workset_with_connection(conn, session_id, &summary.id)? {
             worksets.push(workset.into());
         }
     }

--- a/crates/nac-core/src/view.rs
+++ b/crates/nac-core/src/view.rs
@@ -370,14 +370,8 @@ pub(crate) fn worksets_snapshot_with_connection(
 }
 
 fn load_workset_records(store_path: &Path, session_id: &str) -> Result<Vec<WorksetSnapshot>> {
-    let summaries = store::list_worksets(store_path, session_id)?;
-    let mut worksets = Vec::with_capacity(summaries.len());
-    for summary in summaries {
-        if let Some(workset) = store::read_workset(store_path, session_id, &summary.id)? {
-            worksets.push(workset.into());
-        }
-    }
-    Ok(worksets)
+    let conn = store::open_runtime_connection(store_path)?;
+    load_workset_records_with_connection(&conn, session_id)
 }
 
 fn load_workset_records_with_connection(


### PR DESCRIPTION
## Description

**What.** Reuses one runtime SQLite connection for each dashboard storage load and runs synchronous SQLite/Git snapshot work outside Tokio workers.

**Why.** Dashboard refreshes repeatedly reopened the same store and ran Git inspection directly on an async worker, creating connection churn and scheduler stalls.

The connection-taking store/view helpers preserve existing SQL, ordering, and path-based APIs. Runtime opens verify the persistent journal mode and restore WAL if an external tool changed it. The snapshot’s blocking bundle performs workspace inspection before opening the database, then reads steering last so a delivery committed during Git work has current status when the transcript scan computes coverage.

## Usage

No user-facing usage change. Dashboard refreshes use the optimized path automatically.

## Changelog

- Reuses one SQLite connection for storage-backed dashboard snapshot fields.
- Moves synchronous SQLite and Git inspection off Tokio runtime workers.
- Restores WAL mode during runtime opens when an initialized store was externally changed.
- Preserves steering/message deduplication across deliveries committed during workspace inspection.

## Performance

Measured on an Apple M5 Pro running Darwin 25.5.0 with the debug test profile. Each side used three independent runs of 100 measured snapshots after 10 warmups; the table reports the median of the three run-level values.

The deterministic fixture contains a Git repository with 64 tracked and 16 modified files, 128 transcript messages, 16 threads with 8 episodes and 32 events each, and 4 worksets with 8 items each.

| Metric | `origin/main` | This PR | Delta |
| --- | ---: | ---: | ---: |
| Median snapshot latency | 34.972 ms | 32.711 ms | 6.5% lower |
| p95 snapshot latency | 39.367 ms | 35.664 ms | 9.4% lower |
| Maximum Tokio scheduler lateness | 46.965 ms | 2.081 ms | 95.6% lower |

Reproduce the candidate measurement with:

```sh
cargo test -p nac-core benchmark_frontend_snapshot_latency -- --ignored --nocapture
```

Absolute wall-time gains vary with filesystem and Git state. The scheduler result is the primary async-runtime improvement.

## Bug Evidence

The initial rebased implementation loaded steering before the remaining SQLite reads and Git inspection. A delivery committed during that widened interval could leave stale `claimed` status beside its newly visible canonical transcript message, causing duplicate rendering.

`frontend_snapshot_reconciles_steering_delivered_during_workspace_load` deterministically pauses the snapshot after workspace inspection, commits the steering acknowledgement and transcript append, then verifies that the snapshot returns delivered status, the coverage id, and the canonical message. Steering is now the final query in the one-connection storage bundle.

## Validation

After rebasing onto `origin/main` at `016a6e05`, `cargo check --workspace --all-targets` completed successfully. `cargo test --workspace` passed 597 tests with 3 intentionally ignored. Targeted WAL restoration, one-connection snapshot, steering-coverage, and concurrent workspace-delivery regressions passed. `cargo clippy --workspace --all-targets` completed with the repository’s existing non-fatal warnings.

A seven-persona delegated review covered elegance, idiomatic Rust, correctness, completeness, security, YAGNI, and scope. It found the widened steering race and duplicated workset loading path; both were fixed, and the affected reviewers’ follow-ups reported no remaining findings. No security, scope, idiom, or YAGNI findings were reported.

`cargo fmt --check` was not used as a branch gate because the installed rustfmt proposes widespread formatting changes in untouched files outside this PR.