### PR TITLE
feat: add make dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ dev:
 			printf 'error: make dev requires %s\n' "$$BROWSER_OPEN"; \
 			exit 1; \
 		}; \
-		if curl -fsS -- "$${DEV_URL}health" >/dev/null 2>&1; then \
+		if curl -fsS --noproxy '*' --connect-timeout 1 --max-time 2 -- "$${DEV_URL}health" >/dev/null 2>&1; then \
 			printf 'error: NAC is already responding at %s\n' "$$DEV_URL"; \
 			exit 1; \
 		fi; \
@@ -47,7 +47,7 @@ dev:
 		server_pid=$$!; \
 		trap 'kill "$$server_pid" 2>/dev/null || true' EXIT; \
 		trap 'exit 130' INT TERM; \
-		until curl -fsS -- "$${DEV_URL}health" >/dev/null 2>&1; do \
+		until curl -fsS --noproxy '*' --connect-timeout 1 --max-time 2 -- "$${DEV_URL}health" >/dev/null 2>&1; do \
 			if ! kill -0 "$$server_pid" 2>/dev/null; then \
 				wait "$$server_pid"; \
 				exit $$?; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
-.PHONY: all build release install test test-rust test-assets check fmt clippy clean help
+.PHONY: all build dev release install test test-rust test-assets check fmt clippy clean help
 
 CARGO ?= cargo
 PKG := nac-server
 BIN := nac-web
+
+DEV_BIND ?= 127.0.0.1:3210
+DEV_URL ?= http://$(DEV_BIND)/
+
+ifeq ($(shell uname -s),Darwin)
+BROWSER_OPEN ?= open
+else
+BROWSER_OPEN ?= xdg-open
+endif
+
+export DEV_BIND DEV_URL BROWSER_OPEN
 
 # The workspace is not clippy-clean yet, so lints are advisory by default.
 # Run `make clippy CLIPPY_ARGS='-D warnings'` to fail on them.
@@ -17,6 +28,34 @@ all: build
 ## Build the nac-web binary (debug)
 build:
 	$(CARGO) build --locked -p $(PKG) --bin $(BIN)
+
+## Build and run nac-web, then open it in the default browser
+dev:
+	@command -v curl >/dev/null 2>&1 || { \
+			printf '%s\n' 'error: make dev requires curl'; \
+			exit 1; \
+		}; \
+		command -v "$$BROWSER_OPEN" >/dev/null 2>&1 || { \
+			printf 'error: make dev requires %s\n' "$$BROWSER_OPEN"; \
+			exit 1; \
+		}; \
+		if curl -fsS -- "$${DEV_URL}health" >/dev/null 2>&1; then \
+			printf 'error: NAC is already responding at %s\n' "$$DEV_URL"; \
+			exit 1; \
+		fi; \
+		$(CARGO) run --locked -p $(PKG) --bin $(BIN) -- --bind "$$DEV_BIND" & \
+		server_pid=$$!; \
+		trap 'kill "$$server_pid" 2>/dev/null || true' EXIT; \
+		trap 'exit 130' INT TERM; \
+		until curl -fsS -- "$${DEV_URL}health" >/dev/null 2>&1; do \
+			if ! kill -0 "$$server_pid" 2>/dev/null; then \
+				wait "$$server_pid"; \
+				exit $$?; \
+			fi; \
+			sleep 0.1; \
+		done; \
+		"$$BROWSER_OPEN" "$$DEV_URL" || exit $$?; \
+		wait "$$server_pid"
 
 ## Build the nac-web binary (release)
 release:
@@ -59,6 +98,7 @@ help:
 		'' \
 		'Targets:' \
 		'  build        Build nac-web (debug) [default]' \
+		'  dev          Build and run nac-web, then open it in the default browser' \
 		'  release      Build nac-web (release)' \
 		'  install      Install nac-web into $$INSTALL_ROOT/bin (~/.local)' \
 		'  test         Run Rust tests and web asset checks' \


### PR DESCRIPTION
## Description

**What.** Adds a `make dev` target that builds and runs `nac-web`, waits for the frontend to become healthy, and opens it in the OS-default browser.

**Why.** Contributors currently need separate build, launch, readiness, and browser steps to start the NAC frontend locally.

The target uses `cargo run` so Cargo remains the source of truth for artifact placement, selects `open` on macOS and `xdg-open` elsewhere, and cleans up the launched server when the command exits. It fails clearly when required host tools are unavailable or another NAC instance already answers at the configured address.

## Usage

```bash
make dev
```

The default frontend URL is `http://127.0.0.1:3210/`. Override the bind address when needed:

```bash
make dev DEV_BIND=127.0.0.1:33210
```

Stop the development server with Ctrl-C.

## Changelog

- Adds a one-command local development workflow for the NAC frontend.
- No end-user runtime behavior change.

## Validation

Ran `make help` and `make -n dev` successfully. On macOS, `make dev DEV_BIND=127.0.0.1:33210` built and launched `nac-web`, invoked the default `open` command, returned `{"status":"ok"}` from `/health`, and served `/` with HTTP 200 before Ctrl-C stopped the server.

Also ran the target with `CARGO_TARGET_DIR=/tmp/nac-make-dev-target`; Cargo launched the relocated `/tmp/nac-make-dev-target/debug/nac-web` artifact and the health check passed. Confirmed the default-port preflight exits before launch when NAC is already responding, a missing browser opener produces a clear error, and shell metacharacters in `DEV_BIND` are passed as one rejected bind argument rather than executed. The full workspace test suite was not run because this change only adds a Makefile development target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only developer ergonomics; no application or runtime behavior changes.
> 
> **Overview**
> Adds a **`make dev`** target so contributors can build and run **`nac-web`**, wait until **`/health`** responds, and open the UI in the default browser in one step.
> 
> Configurable **`DEV_BIND`** (default `127.0.0.1:3210`) and **`DEV_URL`** drive the bind address and health check. **`BROWSER_OPEN`** is **`open`** on macOS and **`xdg-open`** elsewhere. The recipe uses **`cargo run`** with **`--bind`**, runs the server in the background, polls health with **`curl`**, and tears down the process on exit or Ctrl-C.
> 
> It fails fast if **`curl`** or the browser opener is missing, or if something is already serving at the configured URL. **`make help`** documents the new target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 198f8c92eb9fcfbaa4e3f0b73e5a093b0b8c8a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->