### PR TITLE
feat(server): add custom launch port

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Run the web dashboard from the project you want to work in:
 nac-web
 ```
 
-It confirms the current working directory as the project folder (`Y` to accept, `n` to type another path), then listens on `http://127.0.0.1:3210` and opens that URL in your browser. Pass `-C /path/to/project` to skip the prompt, or `-y` to accept cwd non-interactively. The dashboard is a React app whose build output is committed under `crates/nac-server/assets/dist` and embedded in the binary, so a release never needs Node. `nac-web` exposes a central session manager for web clients. It resolves one server store at startup, then can create, resume, inspect, submit prompts to, and stream events from multiple sessions at once.
+It confirms the current working directory as the project folder (`Y` to accept, `n` to type another path), then listens on `http://127.0.0.1:3210` and opens that URL in your browser. Pass `-C /path/to/project` to skip the prompt, or `-y` to accept cwd non-interactively. Pass `-p 4321` or `--port 4321` to choose a custom loopback port in the range `1..=65535`; use `--bind` instead to specify a full IPv4 or IPv6 loopback address. `--port` and `--bind` cannot be combined. The dashboard is a React app whose build output is committed under `crates/nac-server/assets/dist` and embedded in the binary, so a release never needs Node. `nac-web` exposes a central session manager for web clients. It resolves one server store at startup, then can create, resume, inspect, submit prompts to, and stream events from multiple sessions at once.
 
 Server and session lifecycle:
 

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -28,6 +28,18 @@ struct ServerCli {
     #[arg(long, default_value = "127.0.0.1:3210")]
     bind: SocketAddr,
 
+    /// Port to listen on at 127.0.0.1 (1-65535; default: 3210).
+    ///
+    /// Cannot be used with --bind.
+    #[arg(
+        short,
+        long,
+        value_name = "PORT",
+        value_parser = clap::value_parser!(u16).range(1..),
+        conflicts_with = "bind"
+    )]
+    port: Option<u16>,
+
     /// Project directory (skips the interactive confirmation).
     ///
     /// Without this flag an interactive terminal confirms the current working
@@ -57,6 +69,16 @@ struct ServerCli {
     /// Do not open a browser window.
     #[arg(long = "no-open", action = clap::ArgAction::SetTrue)]
     no_open: bool,
+}
+
+impl ServerCli {
+    fn bind_addr(&self) -> SocketAddr {
+        let mut bind = self.bind;
+        if let Some(port) = self.port {
+            bind.set_port(port);
+        }
+        bind
+    }
 }
 
 #[derive(Parser)]
@@ -397,6 +419,7 @@ async fn run() -> Result<()> {
 }
 
 async fn run_server(cli: ServerCli) -> Result<()> {
+    let bind = cli.bind_addr();
     let launch_cwd = std::env::current_dir()?;
     let root_cwd = resolve_project_directory(
         &launch_cwd,
@@ -418,7 +441,7 @@ async fn run_server(cli: ServerCli) -> Result<()> {
     // Open the browser only after bind succeeds — otherwise the first load can
     // hit connection-refused while the socket is still closed. Post-login
     // dashboard launch goes through this same path.
-    serve_with(cli.bind, manager, |bound| {
+    serve_with(bind, manager, |bound| {
         let url = dashboard_url(bound);
         eprintln!("nac-web listening on {url}");
         eprintln!("store: {store_path}");
@@ -814,5 +837,48 @@ thread_timeout_secs = 7200
             cli.install_dir.as_deref(),
             Some(std::path::Path::new("/tmp/test"))
         );
+    }
+
+    #[test]
+    fn server_cli_resolves_bind_address() {
+        let cases: &[(&[&str], &str)] = &[
+            (&["nac-web"], "127.0.0.1:3210"),
+            (&["nac-web", "--port", "4321"], "127.0.0.1:4321"),
+            (&["nac-web", "--bind", "[::1]:4322"], "[::1]:4322"),
+        ];
+
+        for (args, expected) in cases {
+            let cli = ServerCli::try_parse_from(*args).unwrap();
+            assert_eq!(cli.bind_addr(), expected.parse().unwrap());
+        }
+    }
+
+    #[test]
+    fn server_cli_rejects_bind_with_port() {
+        let error =
+            ServerCli::try_parse_from(["nac-web", "--bind", "127.0.0.1:4321", "--port", "4322"])
+                .err()
+                .expect("explicit --bind and --port must conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn server_cli_rejects_ports_outside_supported_range() {
+        for port in ["0", "65536"] {
+            let error = ServerCli::try_parse_from(["nac-web", "--port", port])
+                .err()
+                .expect("out-of-range port must be rejected");
+            assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        }
+    }
+
+    #[test]
+    fn server_cli_help_documents_port_contract() {
+        let help = ServerCli::command().render_long_help().to_string();
+        assert!(help.contains("-p, --port <PORT>"), "{help}");
+        assert!(help.contains("127.0.0.1"), "{help}");
+        assert!(help.contains("1-65535"), "{help}");
+        assert!(help.contains("default: 3210"), "{help}");
+        assert!(help.contains("Cannot be used with --bind"), "{help}");
     }
 }

--- a/start.sh
+++ b/start.sh
@@ -5,11 +5,13 @@
 # committed and embedded into the binary, so no Node install is involved.
 #
 #   ./start.sh                      # http://127.0.0.1:3210 (opens the browser)
+#   ./start.sh --port 4321          # choose a custom loopback port
 #   ./start.sh --bind 0.0.0.0:8080  # extra args go straight to nac-web
 #   ./start.sh --no-open            # keep the terminal-only workflow
 #
 # Environment:
-#   NAC_BIND      address to bind when --bind is not passed (default 127.0.0.1:3210)
+#   NAC_BIND      address to bind when neither --bind nor --port is passed
+#                 (default 127.0.0.1:3210)
 #   NAC_PROFILE   cargo profile: release (default) or debug
 #   BROWSER=none  same as passing --no-open to nac-web
 
@@ -50,16 +52,25 @@ echo "==> building nac-web ($PROFILE)"
 cargo build ${CARGO_PROFILE_ARGS[@]+"${CARGO_PROFILE_ARGS[@]}"} \
   -p nac-server --bin nac-web
 
-# An explicit --bind in the caller's arguments wins over NAC_BIND.
+# An explicit --bind or --port in the caller's arguments wins over NAC_BIND.
 BIND_ARGS=(--bind "$BIND")
 prev=""
 for arg in "$@"; do
   if [[ "$prev" == "--bind" ]]; then
     BIND="$arg"
+  elif [[ "$prev" == "--port" || "$prev" =~ ^-[yh]*p$ ]]; then
+    BIND="127.0.0.1:$arg"
   elif [[ "$arg" == --bind=* ]]; then
     BIND="${arg#--bind=}"
+  elif [[ "$arg" == --port=* ]]; then
+    BIND="127.0.0.1:${arg#--port=}"
+  elif [[ "$arg" =~ ^-[yh]*p.+$ ]]; then
+    port="${arg#*p}"
+    BIND="127.0.0.1:${port#=}"
   fi
-  if [[ "$arg" == "--bind" || "$arg" == --bind=* ]]; then
+  if [[ "$arg" == "--bind" || "$arg" == --bind=* ||
+        "$arg" == "--port" || "$arg" == --port=* ||
+        "$arg" =~ ^-[yh]*p ]]; then
     BIND_ARGS=()
   fi
   prev="$arg"
@@ -70,7 +81,8 @@ echo "==> nac-web on http://$BIND"
 YES_ARGS=(-y)
 prev=""
 for arg in "$@"; do
-  if [[ "$arg" == "-y" || "$arg" == "--yes" || "$arg" == "-C" || "$arg" == --directory=* ]]; then
+  if [[ "$arg" == "-y" || "$arg" == "--yes" || "$arg" == "-C" ||
+        "$arg" == --directory=* || "$arg" =~ ^-[yh]*y ]]; then
     YES_ARGS=()
     break
   fi


### PR DESCRIPTION
## Description

**What.** Adds `-p/--port <PORT>` to `nac-web` for selecting a custom loopback listener port.

**Why.** Users can choose a local server port without spelling a full `--bind <IP:PORT>` value.

The no-flag default remains `127.0.0.1:3210`. Ports are validated as `1..=65535`; explicit `--port` and `--bind` values conflict, while existing IPv4 and IPv6 `--bind` usage remains unchanged. The resolved address continues through the existing loopback validator and the current post-bind dashboard launch flow.

The root `start.sh` launcher recognizes forwarded long, short, and clustered port forms, suppresses its default injected `--bind`, and reports the requested loopback URL. The README documents the custom-port launch flow.

## Usage

```bash
nac-web -C /path/to/project --port 4321
# or from a source checkout:
./start.sh --port 4321
```

Then open `http://127.0.0.1:4321/`. Use `--bind` instead when a full loopback socket address is required; the two options cannot be combined.

## Changelog

- Adds `-p/--port` support for launching `nac-web` on a custom loopback port.
- Preserves custom-port forwarding through the repository `start.sh` launcher.
- Documents the accepted range, unchanged default, and interaction with `--bind`.

## Bug Evidence

Before the launcher fix, `NAC_PROFILE=debug ./start.sh --port 43220 --no-open -C /tmp` injected `--bind 127.0.0.1:3210`, printed the default URL, and exited with Clap's `--bind`/`--port` argument conflict. `start.sh` now recognizes the explicit port before constructing its default arguments and derives the displayed URL from that port.

## Validation

After rebasing onto `main`, `cargo test --locked -p nac-server --bin nac-web server_cli` passed all 4 focused CLI tests. `cargo test --locked -p nac-server --bin nac-web` passed all 10 binary tests, and `cargo build --locked -p nac-server --bin nac-web` succeeded.

For direct-binary integration, I launched the built server with an isolated temporary root and `--port 43219`. Startup reported `http://127.0.0.1:43219`, and `GET /health` returned exactly `{"status":"ok"}`. Generated `--help` output showed the short/long flag, loopback address, accepted range, default, and `--bind` conflict.

For launcher integration, `bash -n start.sh` passed under macOS Bash 3.2.57. I live-smoked `--port 43220` while `NAC_BIND` was set to a different port, `-p 43221`, `-yp43222`, and `-yp 43223`. Each launch reported and listened on the requested loopback port, and each `/health` request returned `{"status":"ok"}`.

`cargo fmt --all -- --check` remains non-clean on the current `main` baseline because rustfmt reports pre-existing drift across unrelated `nac-core` files and existing lines in `nac-server/src/main.rs`. `git diff --check` passed for this branch.
