### PR TITLE
fix(model): complete Responses turns at terminal events

### DIFF
--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -917,16 +917,14 @@ async fn post_codex_json_with_retry(
             .map(str::to_string);
 
         if status.is_success() {
-            // Reading the body incrementally forfeits the retry: by the time a
-            // read fails the caller has already seen part of the answer.
+            // Codex responses are requested as streams even when nobody is
+            // observing live deltas. Stop at the protocol terminal event in
+            // both cases; waiting for EOF can otherwise delay the next tool
+            // round on a keep-alive SSE body.
             //
-            // Codex often omits Content-Type on streamed responses. We already
-            // asked for an event stream (`Accept` + `stream: true`), and the
-            // buffered fallback detects SSE from `data:` lines — so a missing
-            // header must not force the non-streaming path and drop live deltas.
-            if let Some(on_delta) = on_delta.filter(|_| {
-                content_type.is_none() || is_event_stream(content_type.as_deref())
-            }) {
+            // Codex often omits Content-Type on streamed responses. `Accept`
+            // and `stream: true` make a missing header an SSE response here.
+            if content_type.is_none() || is_event_stream(content_type.as_deref()) {
                 return stream_codex_responses(response, url, status, on_delta).await;
             }
             let response_body = read_codex_body(response, url, status).await?;
@@ -989,9 +987,9 @@ async fn stream_codex_responses(
     response: reqwest::Response,
     url: &str,
     status: StatusCode,
-    on_delta: &(dyn Fn(ModelStreamDelta) + Send + Sync),
+    on_delta: DeltaSink<'_>,
 ) -> std::result::Result<Value, CodexRequestError> {
-    read_sse_response(url, response, ResponsesStreamFold::new(Some(on_delta)))
+    read_sse_response(url, response, ResponsesStreamFold::new(on_delta))
         .await
         .map_err(|error| CodexRequestError {
             status: Some(status),
@@ -2032,5 +2030,65 @@ mod tests {
         assert_eq!(parsed["output"][0]["type"], "message");
         assert_eq!(parsed["output"][0]["content"][0]["text"], "hello");
         assert_eq!(parsed["usage"]["total_tokens"], 3);
+    }
+
+    #[tokio::test]
+    async fn codex_without_delta_sink_finishes_before_sse_body_closes() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+        use tokio::sync::oneshot;
+        use tokio::time::timeout;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (release_server, wait_for_release) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            let event = concat!(
+                "data: {\"type\":\"response.output_item.done\",\"output_index\":0,",
+                "\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",",
+                "\"call_id\":\"call_1\",\"name\":\"read\",\"arguments\":\"{}\",",
+                "\"status\":\"completed\"}}\n\n",
+                "data: {\"type\":\"response.completed\",\"response\":",
+                "{\"status\":\"completed\",\"output\":[]}}\n\n"
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                      Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            stream
+                .write_all(format!("{:X}\r\n{event}\r\n", event.len()).as_bytes())
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+
+            let _ = wait_for_release.await;
+            let _ = stream.write_all(b"0\r\n\r\n").await;
+        });
+
+        let result = timeout(
+            Duration::from_secs(1),
+            post_codex_json_with_retry(
+                &Client::new(),
+                &format!("http://{address}"),
+                &json!({"stream": true}),
+                &stored_codex_auth("access-token"),
+                None,
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let response = result
+            .expect("terminal event should finish an unobserved Codex stream")
+            .unwrap();
+        assert_eq!(response["output"][0]["type"], "function_call");
+        assert_eq!(response["output"][0]["call_id"], "call_1");
     }
 }

--- a/crates/nac-core/src/model/requests.rs
+++ b/crates/nac-core/src/model/requests.rs
@@ -264,6 +264,11 @@ pub(super) fn responses_input_items(messages: &[Message]) -> Vec<Value> {
                 tool_calls,
                 ..
             } => {
+                if let Some(output) = reasoning_details.as_ref().and_then(stored_responses_output) {
+                    items.extend(output.iter().cloned());
+                    continue;
+                }
+
                 if let Some(reasoning_details) = reasoning_details {
                     match reasoning_details {
                         Value::Array(values) => items.extend(values.clone()),

--- a/crates/nac-core/src/model/responses.rs
+++ b/crates/nac-core/src/model/responses.rs
@@ -1,5 +1,30 @@
 use super::*;
 
+const RESPONSES_OUTPUT_DETAILS_TYPE: &str = "openai_responses_output";
+const RESPONSES_OUTPUT_ITEMS_FIELD: &str = "items";
+
+fn responses_output_details(items: &[Value]) -> Value {
+    json!({
+        "type": RESPONSES_OUTPUT_DETAILS_TYPE,
+        "items": items,
+    })
+}
+
+/// Returns the exact output sequence retained for a stateless Responses
+/// continuation. Older transcripts stored only reasoning items as a bare array,
+/// so the tagged wrapper distinguishes the lossless format from that fallback.
+pub(super) fn stored_responses_output(details: &Value) -> Option<&[Value]> {
+    let object = details.as_object()?;
+    (object.get("type").and_then(Value::as_str) == Some(RESPONSES_OUTPUT_DETAILS_TYPE))
+        .then(|| {
+            object
+                .get(RESPONSES_OUTPUT_ITEMS_FIELD)
+                .and_then(Value::as_array)
+                .map(Vec::as_slice)
+        })
+        .flatten()
+}
+
 pub(super) fn parse_openai_responses_response(
     value: &Value,
     url: &str,
@@ -11,7 +36,6 @@ pub(super) fn parse_openai_responses_response(
 
     let mut message_text_parts = Vec::new();
     let mut tool_calls = Vec::new();
-    let mut reasoning_items = Vec::new();
 
     for item in output {
         match item.get("type").and_then(Value::as_str) {
@@ -59,7 +83,6 @@ pub(super) fn parse_openai_responses_response(
                     },
                 });
             }
-            Some("reasoning") => reasoning_items.push(item.clone()),
             _ => {}
         }
     }
@@ -72,12 +95,12 @@ pub(super) fn parse_openai_responses_response(
             .and_then(Value::as_str)
             .map(ToString::to_string)
     };
-    let reasoning_text = extract_reasoning_text(&reasoning_items);
-    let reasoning_details = if reasoning_items.is_empty() {
-        None
-    } else {
-        Some(Value::Array(reasoning_items))
-    };
+    let reasoning_text = extract_reasoning_text(output);
+    // `store: false` continuations must replay every output item in order.
+    // Keeping only the reasoning items loses function-call/message item IDs and
+    // reorders mixed output, forcing the model to reconstruct turn state.
+    let reasoning_details =
+        (!output.is_empty()).then(|| responses_output_details(output.as_slice()));
     let finish_reason = if value.get("status").and_then(Value::as_str) == Some("incomplete")
         && value
             .get("incomplete_details")
@@ -133,6 +156,9 @@ pub(super) fn extract_reasoning_text(items: &[Value]) -> Option<String> {
     let mut parts = Vec::new();
 
     for item in items {
+        if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+            continue;
+        }
         if let Some(summary) = item.get("summary").and_then(Value::as_array) {
             for entry in summary {
                 if let Some(text) = entry.get("text").and_then(Value::as_str) {

--- a/crates/nac-core/src/model/responses_stream.rs
+++ b/crates/nac-core/src/model/responses_stream.rs
@@ -82,6 +82,10 @@ impl StreamFold for ResponsesStreamFold<'_> {
         Ok(())
     }
 
+    fn is_complete(&self) -> bool {
+        self.final_response.is_some()
+    }
+
     fn finish(self) -> Result<Value, String> {
         self.final_response
             .ok_or_else(|| "SSE stream did not include a final response event".to_string())

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -24,6 +24,13 @@ pub(super) trait StreamFold {
     /// Fold one event. `Err` is terminal and carries a user-facing reason.
     fn push(&mut self, event: &Value) -> std::result::Result<(), String>;
 
+    /// Whether a protocol-level terminal event has been folded. Streaming
+    /// callers can stop here instead of waiting for the provider to close an
+    /// otherwise complete SSE body.
+    fn is_complete(&self) -> bool {
+        false
+    }
+
     fn finish(self) -> std::result::Result<Value, String>;
 }
 
@@ -37,13 +44,19 @@ pub(super) async fn read_sse_response<F: StreamFold>(
 
     while let Some(frame) = reader.next_frame().await {
         let frame = frame.with_context(|| format!("model stream from {url} failed"))?;
-        if frame.is_done() || frame.data.trim().is_empty() {
+        if frame.is_done() {
+            break;
+        }
+        if frame.data.trim().is_empty() {
             continue;
         }
         let event: Value = serde_json::from_str(&frame.data)
             .with_context(|| format!("invalid SSE event from {url}: {}", frame.data))?;
         fold.push(&event)
             .map_err(|message| anyhow!("model stream from {url} failed: {message}"))?;
+        if fold.is_complete() {
+            break;
+        }
     }
 
     fold.finish()
@@ -208,6 +221,12 @@ impl SseReader {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::responses_stream::ResponsesStreamFold;
+    use std::time::Instant;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::sync::oneshot;
+    use tokio::time::{timeout, Duration};
 
     /// Drive the line machine directly: it is the part that has to survive
     /// frames split across reads, and it is independent of the transport.
@@ -260,5 +279,171 @@ mod tests {
     #[test]
     fn returns_a_trailing_frame_the_server_left_unterminated() {
         assert_eq!(frames(&["data: [DONE]\n"]), vec!["[DONE]".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn responses_finish_on_terminal_event_before_body_closes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (release_server, wait_for_release) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            let event = concat!(
+                "data: {\"type\":\"response.output_item.done\",\"output_index\":0,",
+                "\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",",
+                "\"call_id\":\"call_1\",\"name\":\"read\",",
+                "\"arguments\":\"{\\\"path\\\":\\\"src/main.rs\\\"}\",",
+                "\"status\":\"completed\"}}\n\n",
+                "data: {\"type\":\"response.completed\",\"response\":",
+                "{\"status\":\"completed\",\"output\":[]}}\n\n"
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                      Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            stream
+                .write_all(format!("{:X}\r\n{event}\r\n", event.len()).as_bytes())
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+
+            let _ = wait_for_release.await;
+            let _ = stream.write_all(b"0\r\n\r\n").await;
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .unwrap();
+        let result = timeout(
+            Duration::from_secs(1),
+            read_sse_response(
+                "http://responses.test",
+                response,
+                ResponsesStreamFold::new(None),
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let response = result
+            .expect("terminal response event should finish before the body closes")
+            .unwrap();
+        assert_eq!(response["status"], "completed");
+        assert_eq!(response["output"][0]["type"], "function_call");
+        assert_eq!(response["output"][0]["id"], "fc_1");
+        assert_eq!(response["output"][0]["call_id"], "call_1");
+    }
+
+    async fn delayed_terminal_response(
+        post_terminal_delay: Duration,
+    ) -> (reqwest::Response, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            let event = concat!(
+                "data: {\"type\":\"response.completed\",\"response\":",
+                "{\"status\":\"completed\",\"output\":[]}}\n\n"
+            );
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                      Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            stream
+                .write_all(format!("{:X}\r\n{event}\r\n", event.len()).as_bytes())
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+            tokio::time::sleep(post_terminal_delay).await;
+            let _ = stream.write_all(b"0\r\n\r\n").await;
+        });
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .unwrap();
+        (response, server)
+    }
+
+    async fn measure_buffered_eof(post_terminal_delay: Duration) -> Duration {
+        let (response, server) = delayed_terminal_response(post_terminal_delay).await;
+        let started = Instant::now();
+        response.text().await.unwrap();
+        let elapsed = started.elapsed();
+        server.await.unwrap();
+        elapsed
+    }
+
+    async fn measure_terminal_event(post_terminal_delay: Duration) -> Duration {
+        let (response, server) = delayed_terminal_response(post_terminal_delay).await;
+        let started = Instant::now();
+        read_sse_response(
+            "http://responses.benchmark",
+            response,
+            ResponsesStreamFold::new(None),
+        )
+        .await
+        .unwrap();
+        let elapsed = started.elapsed();
+        server.await.unwrap();
+        elapsed
+    }
+
+    fn summarize_latency(mut samples: Vec<Duration>) -> (Duration, Duration) {
+        samples.sort_unstable();
+        (
+            samples[samples.len() / 2],
+            samples[(samples.len() * 95).div_ceil(100) - 1],
+        )
+    }
+
+    /// Manual comparison of the former EOF-buffered Codex path and terminal
+    /// Responses event completion.
+    ///
+    /// Run with:
+    /// `cargo test --release -p nac-core benchmark_responses_terminal_event_latency -- --ignored --nocapture`
+    #[tokio::test]
+    #[ignore = "manual Responses SSE latency benchmark"]
+    async fn benchmark_responses_terminal_event_latency() {
+        const SAMPLES: usize = 30;
+        const POST_TERMINAL_DELAY: Duration = Duration::from_millis(20);
+
+        let _ = measure_buffered_eof(POST_TERMINAL_DELAY).await;
+        let _ = measure_terminal_event(POST_TERMINAL_DELAY).await;
+
+        let mut buffered = Vec::with_capacity(SAMPLES);
+        let mut terminal = Vec::with_capacity(SAMPLES);
+        for sample in 0..SAMPLES {
+            if sample % 2 == 0 {
+                buffered.push(measure_buffered_eof(POST_TERMINAL_DELAY).await);
+                terminal.push(measure_terminal_event(POST_TERMINAL_DELAY).await);
+            } else {
+                terminal.push(measure_terminal_event(POST_TERMINAL_DELAY).await);
+                buffered.push(measure_buffered_eof(POST_TERMINAL_DELAY).await);
+            }
+        }
+
+        let (buffered_median, buffered_p95) = summarize_latency(buffered);
+        let (terminal_median, terminal_p95) = summarize_latency(terminal);
+        println!(
+            "Responses SSE completion latency ({SAMPLES} samples, \
+             {}ms post-terminal keep-alive):",
+            POST_TERMINAL_DELAY.as_millis()
+        );
+        println!("buffered EOF: median={buffered_median:?}, p95={buffered_p95:?}");
+        println!("terminal event: median={terminal_median:?}, p95={terminal_p95:?}");
     }
 }

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -222,6 +222,7 @@ impl SseReader {
 mod tests {
     use super::*;
     use crate::model::responses_stream::ResponsesStreamFold;
+    use crate::model::{anthropic_stream::AnthropicStreamFold, chat_stream::ChatStreamFold};
     use std::time::Instant;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -340,6 +341,122 @@ mod tests {
         assert_eq!(response["output"][0]["type"], "function_call");
         assert_eq!(response["output"][0]["id"], "fc_1");
         assert_eq!(response["output"][0]["call_id"], "call_1");
+    }
+
+    async fn held_open_sse_response(
+        events: &str,
+    ) -> (
+        reqwest::Response,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let events = events.to_string();
+        let (release_server, wait_for_release) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                      Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            stream
+                .write_all(format!("{:X}\r\n{events}\r\n", events.len()).as_bytes())
+                .await
+                .unwrap();
+            stream.flush().await.unwrap();
+            let _ = wait_for_release.await;
+            let _ = stream.write_all(b"0\r\n\r\n").await;
+        });
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}"))
+            .send()
+            .await
+            .unwrap();
+        (response, release_server, server)
+    }
+
+    #[tokio::test]
+    async fn openai_compatible_chat_finishes_at_done_sentinel() {
+        let events = concat!(
+            "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\",",
+            "\"content\":\"hello\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,",
+            "\"id\":\"call_1\",\"type\":\"function\",\"function\":",
+            "{\"name\":\"read\",\"arguments\":\"{}\"}}]},",
+            "\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":1,",
+            "\"completion_tokens\":2,\"total_tokens\":3}}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let (response, release_server, server) = held_open_sse_response(events).await;
+        let result = timeout(
+            Duration::from_secs(1),
+            read_sse_response(
+                "http://chat-compatible.test",
+                response,
+                ChatStreamFold::new(None, "reasoning_content"),
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let response = result
+            .expect("[DONE] should finish an OpenAI-compatible chat stream")
+            .unwrap();
+        assert_eq!(response["choices"][0]["message"]["content"], "hello");
+        assert_eq!(response["choices"][0]["finish_reason"], "tool_calls");
+        assert_eq!(
+            response["choices"][0]["message"]["tool_calls"][0]["id"],
+            "call_1"
+        );
+        assert_eq!(response["usage"]["total_tokens"], 3);
+    }
+
+    #[tokio::test]
+    async fn anthropic_stream_keeps_the_default_eof_policy() {
+        let events = concat!(
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":",
+            "{\"input_tokens\":1}}}\n\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,",
+            "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,",
+            "\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "data: {\"type\":\"message_delta\",\"delta\":",
+            "{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":2}}\n\n",
+            "data: {\"type\":\"message_stop\"}\n\n"
+        );
+        let (response, release_server, server) = held_open_sse_response(events).await;
+        let mut read = Box::pin(read_sse_response(
+            "http://anthropic.test",
+            response,
+            AnthropicStreamFold::new(None),
+        ));
+
+        assert!(
+            timeout(Duration::from_millis(20), read.as_mut())
+                .await
+                .is_err(),
+            "Responses terminal policy must not terminate Anthropic streams"
+        );
+        let _ = release_server.send(());
+        let response = timeout(Duration::from_secs(1), read)
+            .await
+            .expect("Anthropic stream should finish after EOF")
+            .unwrap();
+        server.await.unwrap();
+
+        assert_eq!(response["content"][0]["text"], "hello");
+        assert_eq!(response["stop_reason"], "end_turn");
+        assert_eq!(response["usage"]["input_tokens"], 1);
+        assert_eq!(response["usage"]["output_tokens"], 2);
     }
 
     async fn delayed_terminal_response(

--- a/crates/nac-core/src/model/tests/completions.rs
+++ b/crates/nac-core/src/model/tests/completions.rs
@@ -343,3 +343,60 @@ fn responses_input_items_expand_reasoning_and_tool_state() {
     assert_eq!(items[3]["role"], "assistant");
     assert_eq!(items[4]["type"], "function_call_output");
 }
+
+#[test]
+fn responses_input_items_replay_exact_output_sequence() {
+    let output = vec![
+        json!({
+            "type": "message",
+            "id": "msg_commentary",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "Checking that now."}]
+        }),
+        json!({
+            "type": "reasoning",
+            "id": "rs_1",
+            "encrypted_content": "encrypted",
+            "summary": [{"type": "summary_text", "text": "Need the file."}]
+        }),
+        json!({
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "read",
+            "arguments": "{\"path\":\"src/main.rs\"}",
+            "status": "completed"
+        }),
+    ];
+    let items = responses_input_items(&[
+        Message::Assistant {
+            content: Some("Checking that now.".to_string()),
+            reasoning_text: Some("Need the file.".to_string()),
+            reasoning_details: Some(json!({
+                "type": "openai_responses_output",
+                "items": output.clone()
+            })),
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".to_string(),
+                call_type: "function".to_string(),
+                function: FunctionCall {
+                    name: "read".to_string(),
+                    arguments: "{\"path\":\"src/main.rs\"}".to_string(),
+                },
+            }]),
+            model_origin: None,
+            reasoning_field: None,
+            duration_ms: None,
+        },
+        Message::Tool {
+            tool_call_id: "call_1".to_string(),
+            content: "tool output".to_string(),
+        },
+    ]);
+
+    assert_eq!(&items[..output.len()], output.as_slice());
+    assert_eq!(items.len(), output.len() + 1);
+    assert_eq!(items[3]["type"], "function_call_output");
+    assert_eq!(items[3]["call_id"], "call_1");
+}

--- a/crates/nac-core/src/model/tests/parsers.rs
+++ b/crates/nac-core/src/model/tests/parsers.rs
@@ -55,28 +55,34 @@ fn parses_deepseek_chat_output() {
 
 #[test]
 fn parses_openai_responses_output() {
+    let output = vec![
+        json!({
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [{"type": "summary_text", "text": "thought summary"}],
+            "encrypted_content": "encrypted"
+        }),
+        json!({
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "read",
+            "arguments": "{\"path\":\"src/main.rs\"}",
+            "status": "completed"
+        }),
+        json!({
+            "type": "message",
+            "id": "msg_1",
+            "status": "completed",
+            "content": [
+                {"type": "output_text", "text": "hello world"}
+            ]
+        }),
+    ];
     let parsed = parse_openai_responses_response(
         &json!({
             "status": "completed",
-            "output": [
-                {
-                    "type": "reasoning",
-                    "id": "rs_1",
-                    "summary": [{"type": "summary_text", "text": "thought summary"}]
-                },
-                {
-                    "type": "function_call",
-                    "call_id": "call_1",
-                    "name": "read",
-                    "arguments": "{\"path\":\"src/main.rs\"}"
-                },
-                {
-                    "type": "message",
-                    "content": [
-                        {"type": "output_text", "text": "hello world"}
-                    ]
-                }
-            ],
+            "output": output.clone(),
             "usage": {
                 "input_tokens": 10,
                 "output_tokens": 20,
@@ -103,6 +109,16 @@ fn parses_openai_responses_output() {
             .expect("tool calls should be parsed")
             .len(),
         1
+    );
+    assert_eq!(
+        stored_responses_output(
+            parsed
+                .assistant
+                .reasoning_details
+                .as_ref()
+                .expect("Responses output state should be retained")
+        ),
+        Some(output.as_slice())
     );
     let usage = parsed.usage.expect("usage should be parsed");
     assert_eq!(usage.input_tokens, 10);


### PR DESCRIPTION
## Description

**What.** Completes OpenAI Responses and ChatGPT Codex turns at the protocol terminal event, and preserves the exact ordered Responses output when continuing stateless tool calls.

**Why.** A model turn is complete when the stream emits `response.completed` (or another terminal Responses event), not when the HTTP body eventually reaches EOF. Waiting for transport closure adds avoidable idle time between tool rounds, while reconstructing prior output from separate reasoning, tool-call, and message fields can lose item IDs and reorder model state.

There are two related boundaries in this change.

First, the SSE reader now distinguishes semantic completion from transport completion:

```text
response.output_item.done
response.completed          <- the model turn is complete; continue the agent loop here
[DONE]                      <- optional wire sentinel
HTTP body EOF               <- transport lifecycle; may arrive later on keep-alive streams
```

`ResponsesStreamFold` exposes terminal state through `StreamFold::is_complete`, and the SSE reader returns as soon as that state is reached. ChatGPT Codex always requests streaming responses, so its success path now uses the incremental reader even when no UI delta subscriber exists; workers and background turns no longer fall back to `response.text()` and wait for EOF.

Second, `store: false` continuations now retain the complete ordered `response.output` sequence in tagged provider state. The next request replays those items verbatim before appending function outputs. This preserves reasoning items, encrypted reasoning state, message/function-call item IDs, statuses, and original ordering while keeping the existing generic `ToolCall` representation for local execution. Legacy transcripts that contain only a bare reasoning-item array continue through the existing reconstruction path.

## Bug Evidence

Before this change, a Codex response could emit a complete function call and `response.completed`, then leave its chunked SSE body open. Observed foreground calls streamed deltas, but unobserved calls awaited `response.text()`; both tool execution and the next model round remained blocked until the server closed the body.

The new loopback regressions deliberately hold the HTTP body open after `response.completed`. They verify that:

- the shared Responses reader returns the completed function call before body closure; and
- Codex does the same with `on_delta = None`, covering workers and sessions without assistant-delta subscribers.

## Performance

Environment: Apple M5 Pro, macOS Darwin 25.5.0, optimized Rust build. Workload: 30 alternating local-loopback samples per path. The fixture emits `response.completed` and intentionally keeps the chunked body open for 20 ms. Timing begins after response headers, so it isolates client-side post-terminal latency.

| Completion path | Median | p95 | Median delta |
| --- | ---: | ---: | ---: |
| Former buffered EOF path | 22.106 ms | 22.203 ms | baseline |
| Terminal Responses event | 0.0077 ms | 0.0119 ms | -99.97% |

Command:

```bash
cargo test --release -p nac-core benchmark_responses_terminal_event_latency -- --ignored --nocapture
```

This benchmark measures the avoidable wait after model completion, not model reasoning time. Real savings equal the provider-specific gap between the terminal event and body EOF; when a provider closes immediately, the difference is negligible.

## Usage

No configuration or API changes. Responses-backed agents transition from a completed model tool call to local tool execution without waiting for SSE connection teardown. Stateless tool continuations also retain the provider's exact reasoning/tool-call sequence automatically.

## Compatibility Guardrails

The early terminal-event hook is opt-in: only `ResponsesStreamFold` overrides `StreamFold::is_complete`. Other providers keep their existing completion contract.

- OpenAI-compatible Chat Completions providers—including Arcee, DeepSeek, Fireworks, and Together—continue to finish at the standard `[DONE]` sentinel. A held-open-body fixture verifies that content, function-call arguments, finish reason, and usage are folded before termination.
- Anthropic does not use `[DONE]` and retains the default EOF policy. A separate held-open-body fixture verifies that Anthropic's `message_stop` does not activate Responses-only completion and that text, stop reason, and usage survive through EOF.
- OpenAI Responses and ChatGPT Codex are the only adapters using the new protocol-terminal completion hook.

## Changelog

- Reduces avoidable inter-tool latency for OpenAI Responses and ChatGPT Codex streams.
- Preserves complete ordered Responses output for stateless reasoning/tool-call continuation.
- Adds deterministic keep-alive regressions and a reproducible release-mode latency benchmark.

## Validation

Ran `cargo test -p nac-core responses_`: 5 passed and the manual benchmark was correctly ignored. Ran the exact Codex no-delta keep-alive regression: 1 passed. Ran the exact OpenAI-compatible chat `[DONE]` and Anthropic EOF-policy guardrails: 1 passed each. Provider adapter suites passed: Anthropic 5, completions 5, and model client 29. Ran the release benchmark above: 1 passed with the metrics reported in the Performance section.

The broader `cargo test -p nac-core model::` run still hits `model::catalog::tests::effective_settings_resolve_catalog_metadata_at_construction` (`ProviderDefault` vs `Baseline`). The same failure reproduces on unchanged `main`; the test passes when run alone. No catalog code changes in this PR.

## References

- [OpenAI: continue after client-owned function calls](https://developers.openai.com/api/docs/guides/tools-programmatic-tool-calling#continue-after-client-owned-function-calls)
- [OpenAI Codex Responses request and stream handling](https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs)
