### PR TITLE
fix(tools): truncate UTF-8 read output safely

### DIFF
--- a/crates/nac-core/src/tools/read.rs
+++ b/crates/nac-core/src/tools/read.rs
@@ -5,6 +5,8 @@ use serde_json::Value;
 use crate::sandbox::FileIoMode;
 use crate::tools::{require_str, resolve_workspace_path, ToolResult, ToolRuntime};
 
+const MAX_OUTPUT_BYTES: usize = 30_000;
+
 const REMOTE_READ_SCRIPT: &str = r#"
 from pathlib import Path
 import sys
@@ -116,8 +118,12 @@ pub async fn execute(args: Value, runtime: &ToolRuntime) -> ToolResult {
         output.push_str(&format!("{:4}| {}\n", offset + idx + 1, line));
     }
 
-    if output.len() > 30_000 {
-        output.truncate(30_000);
+    if output.len() > MAX_OUTPUT_BYTES {
+        let mut end = MAX_OUTPUT_BYTES;
+        while !output.is_char_boundary(end) {
+            end -= 1;
+        }
+        output.truncate(end);
         output.push_str(&format!("\n... (truncated, {} total lines)", total_lines));
     } else if offset + selected.len() < total_lines {
         output.push_str(&format!(
@@ -225,6 +231,35 @@ mod tests {
             "Got: {}",
             result.content
         );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn oversized_utf8_output_truncates_at_a_character_boundary() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("nac_read_utf8_{unique}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("unicode.txt"),
+            format!("{}€\n", "a".repeat(29_993)),
+        )
+        .unwrap();
+
+        let result = execute(
+            json!({ "path": "unicode.txt" }),
+            &local_runtime_at(dir.clone()),
+        )
+        .await;
+
+        assert!(!result.is_error, "Got error: {}", result.content);
+        assert!(result
+            .content
+            .starts_with(&format!("   1| {}", "a".repeat(29_993))));
+        assert!(!result.content.contains('€'));
+        assert!(result.content.ends_with("... (truncated, 1 total lines)"));
         let _ = std::fs::remove_dir_all(dir);
     }
 


### PR DESCRIPTION
## Description

**What.** Makes local read-tool output truncation safe for UTF-8 content.

**Why.** The previous byte-limit truncation could split a multibyte character and panic.

The local read path now moves the 30,000-byte truncation endpoint back to a character boundary before truncating. A regression test covers a euro sign crossing the prior cutoff.

## Usage

No user-facing usage change. Oversized local reads now return the existing truncation marker instead of panicking when the cutoff falls within a UTF-8 character.

## Changelog

- Fixes local read-tool truncation for multibyte UTF-8 output.

## Validation

- `cargo test -p nac-core tools::read::tests --lib` (4 passed)
- `rustfmt --check --edition 2021 crates/nac-core/src/tools/read.rs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to read-tool output formatting with a targeted test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a panic in the **local** read tool when oversized file output is capped at 30,000 bytes and the cutoff lands inside a multibyte UTF-8 character.
> 
> Truncation now steps the cut index back to the nearest `char` boundary before calling `truncate`, then appends the same `... (truncated, N total lines)` suffix. The byte limit is centralized as `MAX_OUTPUT_BYTES`.
> 
> Adds a regression test with a long ASCII line plus a trailing `€` so the old cutoff would have split the character.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f17c35c4f19507e45aa86276aa0fd0df464de0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->