### PR TITLE
Add MCP server with 11 tools via streamable HTTP transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +410,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +435,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -458,6 +512,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "equivalent"
@@ -679,6 +739,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -923,6 +984,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1184,7 +1251,7 @@ dependencies = [
  "futures-util",
  "libc",
  "portable-pty",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "rmcp",
  "rusqlite",
@@ -1210,6 +1277,7 @@ dependencies = [
  "futures-core",
  "include_dir",
  "nac-core",
+ "rmcp",
  "serde",
  "serde_json",
  "tokio",
@@ -1270,6 +1338,12 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -1387,7 +1461,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1441,7 +1515,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1451,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1461,6 +1546,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1525,12 +1636,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
  "futures",
  "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
  "pin-project-lite",
  "process-wrap",
+ "rand 0.10.2",
  "reqwest",
+ "rmcp-macros",
+ "schemars",
  "serde",
  "serde_json",
  "sse-stream",
@@ -1538,7 +1656,22 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-service",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -1676,6 +1809,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1887,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1841,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 

--- a/crates/nac-core/src/lib.rs
+++ b/crates/nac-core/src/lib.rs
@@ -36,7 +36,7 @@ mod sandbox;
 pub mod session_service;
 pub mod sessions;
 mod skills;
-mod store;
+pub mod store;
 mod terminal;
 mod tools;
 pub mod types;

--- a/crates/nac-server/Cargo.toml
+++ b/crates/nac-server/Cargo.toml
@@ -21,6 +21,7 @@ include_dir = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
+rmcp = { version = "1.3", default-features = false, features = ["server", "macros", "transport-streamable-http-server"] }
 tower-http = { version = "0.6", features = ["compression-gzip"] }
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1,6 +1,7 @@
 mod compaction;
 mod filesystem;
 mod managed_auth;
+mod mcp;
 mod revert;
 
 pub use compaction::{CompactSessionError, CompactSessionResponse};
@@ -2105,6 +2106,7 @@ fn api_router(manager: SessionManager) -> Router {
             "/sessions/{session_id}/cancel-active-run",
             post(cancel_active_run),
         )
+        .nest_service("/mcp", mcp::streamable_http_service(manager.clone()))
         .with_state(manager)
 }
 

--- a/crates/nac-server/src/mcp.rs
+++ b/crates/nac-server/src/mcp.rs
@@ -40,12 +40,16 @@ pub struct NacMcpService {
 struct CreateSessionParams {
     #[schemars(description = "Working directory for the session")]
     cwd: Option<String>,
-    #[schemars(description = "Model id, e.g. \"claude-sonnet-4-20250514\"")]
+    #[schemars(description = "Model id, e.g. \"claude-sonnet-4-20250514\". Call list_models to see available ids.")]
     model: Option<String>,
-    #[schemars(description = "Backend kind: \"anthropic\", \"openai\", \"deepseek\", etc.")]
+    #[schemars(description = "Backend kind: \"anthropic\", \"openai\", \"deepseek\", etc. Auto-detected from the model id — pass only to override.")]
     backend: Option<String>,
-    #[schemars(description = "Reasoning effort: \"low\", \"medium\", or \"high\"")]
+    #[schemars(description = "Reasoning effort level. Valid values: none, minimal, low, medium, high, xhigh, max. Not all models support all levels — check list_models output.")]
     reasoning_effort: Option<String>,
+    #[schemars(description = "Custom API base URL (overrides the provider default)")]
+    base_url: Option<String>,
+    #[schemars(description = "Environment variable name holding the API key (overrides the provider conventional var)")]
+    api_key_env: Option<String>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -138,7 +142,7 @@ struct UpdateSessionParams {
 
 #[tool_router]
 impl NacMcpService {
-    #[tool(name = "create_session", description = "Create a new nac session with optional model, backend, and reasoning effort overrides.")]
+    #[tool(name = "create_session", description = "Create a new nac session. Call list_models first to see available model IDs and their supported reasoning efforts. You only need to pass model — the backend is auto-detected from the model ID. Pass reasoning_effort only if the model supports it. Valid efforts: none, minimal, low, medium, high, xhigh, max.")]
     async fn create_session(
         &self,
         Parameters(params): Parameters<CreateSessionParams>,
@@ -146,10 +150,10 @@ impl NacMcpService {
         let request = CreateSessionRequest {
             cwd: params.cwd.map(std::path::PathBuf::from),
             model: field(params.model),
-            base_url: RequestField::Omitted,
+            base_url: field(params.base_url),
             backend: field(params.backend),
             reasoning_effort: field(params.reasoning_effort),
-            api_key_env: RequestField::Omitted,
+            api_key_env: field(params.api_key_env),
             extra_headers: RequestField::Omitted,
             orchestrator_compaction_threshold: RequestField::Omitted,
             ssh_host: None,
@@ -208,7 +212,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "get_session_status", description = "Get the status of a session: active run, active threads, and thread summaries.")]
+    #[tool(name = "get_session_status", description = "Get a lightweight status snapshot: active_run, active_threads, and thread summaries. Use this for polling — it does not include messages or episode content. When active_run is null, the run is complete.")]
     async fn get_session_status(
         &self,
         Parameters(params): Parameters<GetSessionStatusParams>,
@@ -249,7 +253,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "send_message", description = "Submit a prompt to a session and start a run.")]
+    #[tool(name = "send_message", description = "Submit a prompt to a session and start a run. Returns immediately with a run_id — the run continues asynchronously. Poll get_session_status to check completion.")]
     async fn send_message(
         &self,
         Parameters(params): Parameters<SendMessageParams>,
@@ -274,7 +278,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "steer", description = "Queue a steering instruction for a session, optionally targeting a specific thread.")]
+    #[tool(name = "steer", description = "Inject guidance into a running session without stopping it. Target the orchestrator (omit thread_name) or a specific worker thread. The instruction is delivered on the next iteration.")]
     async fn steer(
         &self,
         Parameters(params): Parameters<SteerParams>,
@@ -371,7 +375,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "get_thread_episodes", description = "Get retained episodes for a thread (or all threads) in a session.")]
+    #[tool(name = "get_thread_episodes", description = "Get the retained output from worker threads. Each episode contains the thread's action (its task prompt) and content (its final response). Pass thread_name for one thread, or omit for all threads.")]
     async fn get_thread_episodes(
         &self,
         Parameters(params): Parameters<GetThreadEpisodesParams>,
@@ -427,7 +431,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "get_thread_events", description = "Get recent events for a thread (or all threads from the snapshot) in a session.")]
+    #[tool(name = "get_thread_events", description = "Get recent activity for worker threads: tool calls, tool results, errors, and completion status. Pass thread_name for one thread, or omit for all threads.")]
     async fn get_thread_events(
         &self,
         Parameters(params): Parameters<GetThreadEventsParams>,
@@ -479,7 +483,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "session_action", description = "Perform a lifecycle action on a session: compact, cancel, delete, or revert.")]
+    #[tool(name = "session_action", description = "Perform a lifecycle action: 'compact' (reduce context), 'cancel' (stop active run), 'delete' (remove session), or 'revert' (roll back to a message index, requires message_idx).")]
     async fn session_action(
         &self,
         Parameters(params): Parameters<SessionActionParams>,
@@ -560,7 +564,7 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "list_models", description = "List available model providers and their models.")]
+    #[tool(name = "list_models", description = "List available model providers and their models. Each model includes supported reasoning efforts and context window. Use the model id when calling create_session — the backend is auto-detected.")]
     async fn list_models(&self) -> Result<CallToolResult, ErrorData> {
         let listing = nac_core::model::api_listing();
         let providers: Vec<_> = listing
@@ -571,27 +575,34 @@ impl NacMcpService {
                     .models
                     .iter()
                     .map(|m| {
+                        let efforts: Vec<_> = m
+                            .supported_efforts
+                            .iter()
+                            .map(|e| e.as_str().to_string())
+                            .collect();
                         json!({
                             "id": m.id,
                             "display_name": m.display_name,
                             "context_window": m.context_window,
+                            "reasoning": m.reasoning,
+                            "supported_efforts": efforts,
                         })
                     })
                     .collect();
                 json!({
-                    "id": p.id,
+                    "provider": p.id.as_str(),
                     "models": models,
                 })
             })
             .collect();
-        let result = json!({ "providers": providers });
+        let result = json!(providers);
         Ok(CallToolResult::success(vec![Content::text(
             serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
         )]))
     }
 }
 
-#[tool_handler]
+#[tool_handler(instructions = "nac is an AI coding agent orchestrator. It manages coding sessions where an orchestrator agent receives your prompt, plans the work, and dispatches worker threads to execute tasks autonomously. Each worker operates independently — reading files, writing code, running commands, and calling tools — then reports back with its results. The orchestrator reviews thread output, compacts context when approaching the model's context window limit, and either dispatches more threads or produces a final response. Each worker's final output is retained as an episode you can inspect.\n\nSessions are asynchronous: send_message returns immediately with a run_id and the work continues in the background. Poll get_session_status to check completion, use steer to guide running tasks mid-flight, and inspect results with get_messages, get_thread_episodes, and get_thread_events. Sessions persist across server restarts and you can manage multiple simultaneously.")]
 impl ServerHandler for NacMcpService {}
 
 // ---------------------------------------------------------------------------

--- a/crates/nac-server/src/mcp.rs
+++ b/crates/nac-server/src/mcp.rs
@@ -1,0 +1,644 @@
+//! MCP (Model Context Protocol) server module.
+//!
+//! Exposes nac session management as 11 MCP tools served over the
+//! streamable-http transport at `/mcp`.
+
+use crate::{
+    CreateSessionRequest, OrchestratorSteeringRequest, RequestField, SessionManager,
+    SubmitPromptRequest, ThreadSteeringRequest, UpdateConfigRequest,
+};
+
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::schemars;
+use rmcp::tool;
+use rmcp::tool_handler;
+use rmcp::tool_router;
+use rmcp::ErrorData;
+use rmcp::ServerHandler;
+use rmcp::transport::StreamableHttpServerConfig;
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::tower::StreamableHttpService;
+
+use serde::Deserialize;
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct NacMcpService {
+    manager: SessionManager,
+}
+
+// ---------------------------------------------------------------------------
+// Parameter structs
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct CreateSessionParams {
+    #[schemars(description = "Working directory for the session")]
+    cwd: Option<String>,
+    #[schemars(description = "Model id, e.g. \"claude-sonnet-4-20250514\"")]
+    model: Option<String>,
+    #[schemars(description = "Backend kind: \"anthropic\", \"openai\", \"deepseek\", etc.")]
+    backend: Option<String>,
+    #[schemars(description = "Reasoning effort: \"low\", \"medium\", or \"high\"")]
+    reasoning_effort: Option<String>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct ListSessionsParams {
+    #[schemars(description = "Include workspace diff stats (slower)")]
+    include_workspace_stats: Option<bool>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetSessionStatusParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SendMessageParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Prompt text to submit")]
+    prompt: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SteerParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Steering instruction")]
+    instruction: String,
+    #[schemars(description = "Thread name to steer; omit for orchestrator-level steering")]
+    thread_name: Option<String>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetMessagesParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Maximum messages to return (default 24)")]
+    limit: Option<usize>,
+    #[schemars(description = "Return messages before this index (cursor)")]
+    before: Option<usize>,
+    #[schemars(description = "Include system messages")]
+    include_system: Option<bool>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetThreadEpisodesParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Thread name; omit for all threads")]
+    thread_name: Option<String>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetThreadEventsParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Thread name; omit for all threads from snapshot")]
+    thread_name: Option<String>,
+    #[schemars(description = "Maximum events to return (default 24)")]
+    limit: Option<usize>,
+    #[schemars(description = "Return events before this id (cursor)")]
+    before_id: Option<i64>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SessionActionParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "Action: \"compact\", \"cancel\", \"delete\", or \"revert\"")]
+    action: String,
+    #[schemars(description = "Message index (required for \"revert\")")]
+    message_idx: Option<usize>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct UpdateSessionParams {
+    #[schemars(description = "Session id")]
+    session_id: String,
+    #[schemars(description = "New model id")]
+    model: Option<String>,
+    #[schemars(description = "New backend kind")]
+    backend: Option<String>,
+    #[schemars(description = "New reasoning effort")]
+    reasoning_effort: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Tool router — 11 tools
+// ---------------------------------------------------------------------------
+
+#[tool_router]
+impl NacMcpService {
+    #[tool(name = "create_session", description = "Create a new nac session with optional model, backend, and reasoning effort overrides.")]
+    async fn create_session(
+        &self,
+        Parameters(params): Parameters<CreateSessionParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let request = CreateSessionRequest {
+            cwd: params.cwd.map(std::path::PathBuf::from),
+            model: field(params.model),
+            base_url: RequestField::Omitted,
+            backend: field(params.backend),
+            reasoning_effort: field(params.reasoning_effort),
+            api_key_env: RequestField::Omitted,
+            extra_headers: RequestField::Omitted,
+            orchestrator_compaction_threshold: RequestField::Omitted,
+            ssh_host: None,
+            ssh_port: None,
+            ssh_identity_file: None,
+            sandbox: Default::default(),
+        };
+        match self.manager.create_session(request).await {
+            Ok(snapshot) => {
+                let session_id = snapshot.metadata.session_id.clone();
+                let model = snapshot.metadata.model.clone();
+                let result = json!({
+                    "session_id": session_id,
+                    "model": model,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+                )]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "list_sessions", description = "List all nac sessions with their id, title, active status, and active run prompt.")]
+    async fn list_sessions(
+        &self,
+        Parameters(params): Parameters<ListSessionsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match self
+            .manager
+            .list_sessions(params.include_workspace_stats.unwrap_or(false))
+            .await
+        {
+            Ok(sessions) => {
+                let entries: Vec<_> = sessions
+                    .into_iter()
+                    .map(|s| {
+                        json!({
+                            "session_id": s.summary.session_id,
+                            "title": s.summary.title,
+                            "active": s.active,
+                            "active_run_prompt": s.active_run.as_ref().map(|r| &r.prompt_preview),
+                        })
+                    })
+                    .collect();
+                let result = json!(entries);
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+                )]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "get_session_status", description = "Get the status of a session: active run, active threads, and thread summaries.")]
+    async fn get_session_status(
+        &self,
+        Parameters(params): Parameters<GetSessionStatusParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match self.manager.snapshot(&params.session_id).await {
+            Ok(snapshot) => {
+                let active_run = snapshot.active_run.as_ref().map(|r| {
+                    json!({
+                        "run_id": r.run_id.to_string(),
+                        "prompt_preview": r.prompt_preview,
+                        "started_at_epoch_ms": r.started_at_epoch_ms,
+                    })
+                });
+                let threads: Vec<_> = snapshot
+                    .threads
+                    .iter()
+                    .map(|t| {
+                        json!({
+                            "name": t.name,
+                            "episode_count": t.episode_count,
+                            "latest_action": t.latest_action,
+                        })
+                    })
+                    .collect();
+                let result = json!({
+                    "session_id": snapshot.metadata.session_id,
+                    "active_run": active_run,
+                    "active_threads": snapshot.active_threads,
+                    "threads": threads,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+                )]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "send_message", description = "Submit a prompt to a session and start a run.")]
+    async fn send_message(
+        &self,
+        Parameters(params): Parameters<SendMessageParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match self
+            .manager
+            .submit_prompt(&params.session_id, SubmitPromptRequest { prompt: params.prompt })
+            .await
+        {
+            Ok(response) => {
+                let result = json!({
+                    "run_id": response.run_id,
+                    "display_prompt": response.display_prompt,
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+                )]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "steer", description = "Queue a steering instruction for a session, optionally targeting a specific thread.")]
+    async fn steer(
+        &self,
+        Parameters(params): Parameters<SteerParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let result = if let Some(thread_name) = params.thread_name {
+            self.manager
+                .queue_thread_steering(
+                    &params.session_id,
+                    &thread_name,
+                    ThreadSteeringRequest {
+                        instruction: params.instruction,
+                    },
+                )
+                .await
+                .map(|r| {
+                    json!({
+                        "steering_id": r.steering_id,
+                        "status": r.status,
+                    })
+                })
+        } else {
+            self.manager
+                .queue_orchestrator_steering(
+                    &params.session_id,
+                    OrchestratorSteeringRequest {
+                        instruction: params.instruction,
+                    },
+                )
+                .await
+                .map(|r| {
+                    json!({
+                        "steering_id": r.steering_id,
+                        "status": r.status,
+                    })
+                })
+        };
+        match result {
+            Ok(value) => Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("Error serializing: {e}")),
+            )])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "get_messages", description = "Get a page of messages from a session transcript.")]
+    async fn get_messages(
+        &self,
+        Parameters(params): Parameters<GetMessagesParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        use nac_core::session_service::MessagePageRequest;
+        match self
+            .manager
+            .messages_page(
+                &params.session_id,
+                MessagePageRequest {
+                    before: params.before,
+                    limit: params.limit.unwrap_or(24),
+                    include_system: params.include_system.unwrap_or(false),
+                },
+            )
+            .await
+        {
+            Ok(page) => {
+                let messages: Vec<_> = page
+                    .messages
+                    .iter()
+                    .enumerate()
+                    .map(|(i, msg)| {
+                        json!({
+                            "role": message_role(msg),
+                            "content": message_content(msg),
+                            "created_at": page.created_at.get(i).and_then(|c| c.as_ref()),
+                        })
+                    })
+                    .collect();
+                let result = json!({
+                    "messages": messages,
+                    "page": {
+                        "start": page.page.start,
+                        "end": page.page.end,
+                        "total": page.page.total,
+                        "has_older": page.page.has_older,
+                    },
+                });
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+                )]))
+            }
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "get_thread_episodes", description = "Get retained episodes for a thread (or all threads) in a session.")]
+    async fn get_thread_episodes(
+        &self,
+        Parameters(params): Parameters<GetThreadEpisodesParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let store_path = self.manager.store_info().store_path;
+        let session_id = params.session_id;
+        let thread_name = params.thread_name;
+        let result = tokio::task::spawn_blocking(move || {
+            if let Some(thread_name) = thread_name {
+                nac_core::store::thread_read(&store_path, &session_id, &thread_name)
+                    .map(|episodes| {
+                        let entries: Vec<_> = episodes
+                            .iter()
+                            .map(|e| {
+                                json!({
+                                    "thread_name": e.thread_name,
+                                    "action": e.action,
+                                    "content": e.content,
+                                    "created_at": e.created_at,
+                                })
+                            })
+                            .collect();
+                        json!({ "episodes": entries })
+                    })
+            } else {
+                nac_core::store::load_all_episodes(&store_path, &session_id).map(|grouped| {
+                    let mut all: Vec<_> = Vec::new();
+                    for (_thread, episodes) in &grouped {
+                        for e in episodes {
+                            all.push(json!({
+                                "thread_name": e.thread_name,
+                                "action": e.action,
+                                "content": e.content,
+                                "created_at": e.created_at,
+                            }));
+                        }
+                    }
+                    json!({ "episodes": all })
+                })
+            }
+        })
+        .await;
+        match result {
+            Ok(Ok(value)) => Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("Error serializing: {e}")),
+            )])),
+            Ok(Err(e)) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "get_thread_events", description = "Get recent events for a thread (or all threads from the snapshot) in a session.")]
+    async fn get_thread_events(
+        &self,
+        Parameters(params): Parameters<GetThreadEventsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let result = if let Some(thread_name) = params.thread_name {
+            self.manager
+                .thread_events(
+                    &params.session_id,
+                    &thread_name,
+                    params.before_id,
+                    params.limit.unwrap_or(24),
+                )
+                .await
+                .map(|page| {
+                    let events: Vec<_> = page
+                        .events
+                        .iter()
+                        .map(|item| {
+                            json!({
+                                "id": item.id,
+                                "created_at": item.created_at,
+                                "event": item.event,
+                            })
+                        })
+                        .collect();
+                    json!({
+                        "events": events,
+                        "has_older": page.has_older,
+                        "next_before_id": page.next_before_id,
+                    })
+                })
+        } else {
+            self.manager
+                .snapshot(&params.session_id)
+                .await
+                .map(|snapshot| {
+                    json!({
+                        "thread_events": snapshot.thread_events,
+                    })
+                })
+        };
+        match result {
+            Ok(value) => Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("Error serializing: {e}")),
+            )])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "session_action", description = "Perform a lifecycle action on a session: compact, cancel, delete, or revert.")]
+    async fn session_action(
+        &self,
+        Parameters(params): Parameters<SessionActionParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let result = match params.action.as_str() {
+            "compact" => self
+                .manager
+                .compact_session(&params.session_id)
+                .await
+                .map(|r| serde_json::to_value(&r).unwrap_or(json!({"status": "done"})))
+                .map_err(|e| anyhow::anyhow!("{e}")),
+            "cancel" => self
+                .manager
+                .cancel_active_run(&params.session_id)
+                .await
+                .map(|_| json!({"status": "cancelled"}))
+                .map_err(|e| anyhow::anyhow!("{e}")),
+            "delete" => self
+                .manager
+                .delete_session(&params.session_id)
+                .await
+                .map(|_| json!({"status": "deleted"}))
+                .map_err(|e| anyhow::anyhow!("{e}")),
+            "revert" => {
+                let message_idx = params.message_idx.ok_or_else(|| {
+                    anyhow::anyhow!("message_idx is required for revert action")
+                });
+                match message_idx {
+                    Ok(idx) => self
+                        .manager
+                        .revert_session(&params.session_id, idx)
+                        .await
+                        .map(|r| serde_json::to_value(&r).unwrap_or(json!({"status": "reverted"})))
+                        .map_err(|e| anyhow::anyhow!("{e}")),
+                    Err(e) => Err(e),
+                }
+            }
+            other => Err(anyhow::anyhow!(
+                "unknown action '{other}': expected compact, cancel, delete, or revert"
+            )),
+        };
+        match result {
+            Ok(value) => Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&value).unwrap_or_else(|e| format!("Error serializing: {e}")),
+            )])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "update_session", description = "Update model configuration for an inactive session.")]
+    async fn update_session(
+        &self,
+        Parameters(params): Parameters<UpdateSessionParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let request = UpdateConfigRequest {
+            model: field(params.model),
+            base_url: RequestField::Omitted,
+            backend: field(params.backend),
+            reasoning_effort: field(params.reasoning_effort),
+            api_key_env: RequestField::Omitted,
+            extra_headers: RequestField::Omitted,
+            orchestrator_compaction_threshold: RequestField::Omitted,
+        };
+        match self
+            .manager
+            .update_session_config(&params.session_id, request)
+            .await
+        {
+            Ok(()) => Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&json!({"status": "ok"}))
+                    .unwrap_or_else(|e| format!("Error serializing: {e}")),
+            )])),
+            Err(e) => Ok(CallToolResult::error(vec![Content::text(format!(
+                "Error: {e}"
+            ))])),
+        }
+    }
+
+    #[tool(name = "list_models", description = "List available model providers and their models.")]
+    async fn list_models(&self) -> Result<CallToolResult, ErrorData> {
+        let listing = nac_core::model::api_listing();
+        let providers: Vec<_> = listing
+            .providers
+            .iter()
+            .map(|p| {
+                let models: Vec<_> = p
+                    .models
+                    .iter()
+                    .map(|m| {
+                        json!({
+                            "id": m.id,
+                            "display_name": m.display_name,
+                            "context_window": m.context_window,
+                        })
+                    })
+                    .collect();
+                json!({
+                    "id": p.id,
+                    "models": models,
+                })
+            })
+            .collect();
+        let result = json!({ "providers": providers });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_else(|e| format!("Error serializing: {e}")),
+        )]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for NacMcpService {}
+
+// ---------------------------------------------------------------------------
+// Service factory
+// ---------------------------------------------------------------------------
+
+pub fn streamable_http_service(
+    manager: SessionManager,
+) -> StreamableHttpService<NacMcpService, LocalSessionManager> {
+    StreamableHttpService::new(
+        move || Ok(NacMcpService { manager: manager.clone() }),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default(),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Converts an `Option<String>` into a `RequestField<String>`:
+/// `Some(v)` → `Value(v)`, `None` → `Omitted`.
+fn field(v: Option<String>) -> RequestField<String> {
+    match v {
+        Some(v) => RequestField::Value(v),
+        None => RequestField::Omitted,
+    }
+}
+
+/// Returns the role label for a `Message`.
+fn message_role(msg: &nac_core::types::Message) -> &'static str {
+    match msg {
+        nac_core::types::Message::System { .. } => "system",
+        nac_core::types::Message::User { .. } => "user",
+        nac_core::types::Message::Assistant { .. } => "assistant",
+        nac_core::types::Message::Tool { .. } => "tool",
+    }
+}
+
+/// Returns the primary text content of a `Message`.
+fn message_content(msg: &nac_core::types::Message) -> String {
+    match msg {
+        nac_core::types::Message::System { content } => content.clone(),
+        nac_core::types::Message::User { content } => content.clone(),
+        nac_core::types::Message::Assistant { content, .. } => {
+            content.clone().unwrap_or_default()
+        }
+        nac_core::types::Message::Tool { content, .. } => content.clone(),
+    }
+}

--- a/crates/nac-server/src/mcp.rs
+++ b/crates/nac-server/src/mcp.rs
@@ -90,7 +90,7 @@ struct GetMessagesParams {
     limit: Option<usize>,
     #[schemars(description = "Return messages before this index (cursor)")]
     before: Option<usize>,
-    #[schemars(description = "Include system messages")]
+    #[schemars(description = "Include system messages (default true). When true, transcript_index values are raw transcript positions usable directly with session_action(revert). Setting false breaks the transcript_index ↔ revert mapping.")]
     include_system: Option<bool>,
 }
 
@@ -325,12 +325,13 @@ impl NacMcpService {
         }
     }
 
-    #[tool(name = "get_messages", description = "Get a page of messages from a session transcript.")]
+    #[tool(name = "get_messages", description = "Get a page of messages from a session transcript. Each message includes a transcript_index — the raw transcript position that can be passed to session_action(action=\"revert\", message_idx=transcript_index) to roll back to that point. System messages are included by default so that transcript_index values match raw transcript positions used by revert.")]
     async fn get_messages(
         &self,
         Parameters(params): Parameters<GetMessagesParams>,
     ) -> Result<CallToolResult, ErrorData> {
         use nac_core::session_service::MessagePageRequest;
+        let include_system = params.include_system.unwrap_or(true);
         match self
             .manager
             .messages_page(
@@ -338,18 +339,20 @@ impl NacMcpService {
                 MessagePageRequest {
                     before: params.before,
                     limit: params.limit.unwrap_or(24),
-                    include_system: params.include_system.unwrap_or(false),
+                    include_system,
                 },
             )
             .await
         {
             Ok(page) => {
+                let base = page.page.start;
                 let messages: Vec<_> = page
                     .messages
                     .iter()
                     .enumerate()
                     .map(|(i, msg)| {
                         json!({
+                            "transcript_index": base + i,
                             "role": message_role(msg),
                             "content": message_content(msg),
                             "created_at": page.created_at.get(i).and_then(|c| c.as_ref()),
@@ -391,6 +394,7 @@ impl NacMcpService {
                             .iter()
                             .map(|e| {
                                 json!({
+                                    "id": e.id,
                                     "thread_name": e.thread_name,
                                     "action": e.action,
                                     "content": e.content,
@@ -406,6 +410,7 @@ impl NacMcpService {
                     for (_thread, episodes) in &grouped {
                         for e in episodes {
                             all.push(json!({
+                                "id": e.id,
                                 "thread_name": e.thread_name,
                                 "action": e.action,
                                 "content": e.content,
@@ -413,6 +418,13 @@ impl NacMcpService {
                             }));
                         }
                     }
+                    all.sort_by(|a, b| {
+                        let thread_a = a["thread_name"].as_str().unwrap_or("");
+                        let thread_b = b["thread_name"].as_str().unwrap_or("");
+                        let id_a = a["id"].as_i64().unwrap_or(0);
+                        let id_b = b["id"].as_i64().unwrap_or(0);
+                        thread_a.cmp(thread_b).then(id_a.cmp(&id_b))
+                    });
                     json!({ "episodes": all })
                 })
             }


### PR DESCRIPTION
Expose nac session management as MCP tools at /mcp endpoint using rmcp's StreamableHttpService. Enables async task offloading — other agents can create sessions, fire off tasks, poll for status, steer running tasks, and inspect results.

Tools:
- create_session: create a new nac session
- list_sessions: list all sessions with status
- get_session_status: lightweight polling (active_run, active_threads)
- send_message: fire-and-forget task submission (returns run_id)
- steer: inject guidance into orchestrator or specific thread
- get_messages: paginated transcript
- get_thread_episodes: retained episodes per thread
- get_thread_events: recent events per thread
- session_action: compact/cancel/delete/revert
- update_session: update model/backend/effort config
- list_models: available model catalog

Transport: streamable HTTP (JSON-RPC over POST, SSE on GET) Session: MCP sessions (Mcp-Session-Id) are connection-level, separate from nac sessions (session_id parameter in tool calls) Auth: none (loopback-only, covered by reject_foreign_host middleware)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New unauthenticated HTTP integration surface (loopback host middleware only) that can create sessions, submit prompts, delete, and revert transcripts; mistakes or mis-bound listeners could expose powerful agent control.
> 
> **Overview**
> Adds a **Model Context Protocol** server on **`/mcp`** so external MCP clients can drive nac the same way the HTTP API does, using **`rmcp`**’s streamable HTTP transport.
> 
> **`NacMcpService`** defines **11 tools** (create/list/status, send_message, steer, transcript and thread inspection, session_action, update_session, list_models) that delegate to **`SessionManager`** and return JSON text in **`CallToolResult`**. Episode reads use **`nac_core::store`** after making that module **`pub`**.
> 
> The API router **`nest_service`s** the MCP handler alongside existing session routes; **`Cargo.lock`** picks up **`rmcp`** and related crates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb777785559271106bcd72f4460b70109b6c515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->