### PR TITLE
fix(model): retry transient Codex stream failures

### DIFF
--- a/crates/nac-core/src/model/anthropic_stream.rs
+++ b/crates/nac-core/src/model/anthropic_stream.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-use super::sse::StreamFold;
+use super::sse::{StreamFold, StreamFoldError};
 use super::stream::{DeltaSink, ModelStreamDelta};
 
 /// Rebuilds an Anthropic Messages response out of its event stream.
@@ -57,7 +57,7 @@ impl<'sink> AnthropicStreamFold<'sink> {
 }
 
 impl StreamFold for AnthropicStreamFold<'_> {
-    fn push(&mut self, event: &Value) -> Result<(), String> {
+    fn push(&mut self, event: &Value) -> Result<(), StreamFoldError> {
         let event_type = event.get("type").and_then(Value::as_str);
         match event_type {
             Some("error") => {
@@ -66,7 +66,7 @@ impl StreamFold for AnthropicStreamFold<'_> {
                     .and_then(|error| error.get("message"))
                     .and_then(Value::as_str)
                     .unwrap_or("Anthropic stream reported an error");
-                return Err(message.to_string());
+                return Err(StreamFoldError::permanent(message));
             }
             Some("message_start") => {
                 self.saw_message = true;
@@ -143,10 +143,11 @@ impl StreamFold for AnthropicStreamFold<'_> {
         }
         Ok(())
     }
-
-    fn finish(self) -> Result<Value, String> {
+    fn finish(self) -> Result<Value, StreamFoldError> {
         if !self.saw_message {
-            return Err("stream ended without a message_start event".to_string());
+            return Err(StreamFoldError::permanent(
+                "stream ended without a message_start event",
+            ));
         }
 
         let content = self

--- a/crates/nac-core/src/model/chat_stream.rs
+++ b/crates/nac-core/src/model/chat_stream.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-use super::sse::StreamFold;
+use super::sse::{StreamFold, StreamFoldError};
 use super::stream::{DeltaSink, ModelStreamDelta};
 
 /// Rebuilds a chat-completions response out of its stream chunks, so the
@@ -76,13 +76,13 @@ impl<'sink> ChatStreamFold<'sink> {
 }
 
 impl StreamFold for ChatStreamFold<'_> {
-    fn push(&mut self, event: &Value) -> Result<(), String> {
+    fn push(&mut self, event: &Value) -> Result<(), StreamFoldError> {
         if let Some(message) = event
             .get("error")
             .and_then(|error| error.get("message"))
             .and_then(Value::as_str)
         {
-            return Err(message.to_string());
+            return Err(StreamFoldError::permanent(message));
         }
 
         if let Some(usage) = event.get("usage").filter(|usage| !usage.is_null()) {
@@ -123,10 +123,11 @@ impl StreamFold for ChatStreamFold<'_> {
 
         Ok(())
     }
-
-    fn finish(self) -> Result<Value, String> {
+    fn finish(self) -> Result<Value, StreamFoldError> {
         if !self.saw_choice {
-            return Err("stream ended without any completion chunk".to_string());
+            return Err(StreamFoldError::permanent(
+                "stream ended without any completion chunk",
+            ));
         }
 
         let mut message = json!({

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -1,6 +1,6 @@
 use super::auth_store::ensure_open_credential_file_is_safe;
 use super::responses_stream::ResponsesStreamFold;
-use super::sse::{read_sse_response, StreamFold};
+use super::sse::{read_sse_response, StreamFold, StreamFoldError};
 use super::*;
 use anyhow::Context;
 use fs2::FileExt;
@@ -96,6 +96,8 @@ struct AuthorizationCode {
 struct CodexRequestError {
     status: Option<StatusCode>,
     message: String,
+    retryable_stream: bool,
+    observable_delta: bool,
 }
 
 impl fmt::Display for CodexRequestError {
@@ -105,6 +107,12 @@ impl fmt::Display for CodexRequestError {
 }
 
 impl std::error::Error for CodexRequestError {}
+
+impl CodexRequestError {
+    fn can_retry_stream(&self) -> bool {
+        self.retryable_stream && !self.observable_delta
+    }
+}
 
 pub(super) fn validate_base_url(base_url: &str) -> Result<Url> {
     let parsed = Url::parse(base_url)
@@ -909,9 +917,32 @@ async fn post_codex_json_with_retry(
     prompt_cache_key: Option<&str>,
     on_delta: DeltaSink<'_>,
 ) -> std::result::Result<Value, CodexRequestError> {
+    post_codex_json_with_retry_delay(
+        client,
+        url,
+        body,
+        auth,
+        prompt_cache_key,
+        on_delta,
+        super::backoff_duration,
+    )
+    .await
+}
+
+async fn post_codex_json_with_retry_delay(
+    client: &Client,
+    url: &str,
+    body: &Value,
+    auth: &StoredCodexAuth,
+    prompt_cache_key: Option<&str>,
+    on_delta: DeltaSink<'_>,
+    retry_delay: impl Fn(usize) -> Duration,
+) -> std::result::Result<Value, CodexRequestError> {
     let mut last_error = CodexRequestError {
         status: None,
         message: "No attempts made".to_string(),
+        retryable_stream: false,
+        observable_delta: false,
     };
 
     for attempt in 0..10 {
@@ -934,9 +965,11 @@ async fn post_codex_json_with_retry(
                 last_error = CodexRequestError {
                     status: None,
                     message: format!("HTTP request failed for {url}: {e}"),
+                    retryable_stream: false,
+                    observable_delta: false,
                 };
                 if attempt < 9 {
-                    sleep(super::backoff_duration(attempt)).await;
+                    sleep(retry_delay(attempt)).await;
                 }
                 continue;
             }
@@ -962,11 +995,23 @@ async fn post_codex_json_with_retry(
             //
             // Codex often omits Content-Type on streamed responses. `Accept`
             // and `stream: true` make a missing header an SSE response here.
-            if content_type.is_none() || is_event_stream(content_type.as_deref()) {
-                return stream_codex_responses(response, url, status, on_delta).await;
+            let result = if content_type.is_none() || is_event_stream(content_type.as_deref()) {
+                stream_codex_responses(response, url, status, on_delta).await
+            } else {
+                let response_body = read_codex_body(response, url, status).await?;
+                parse_codex_success_body(url, status, content_type.as_deref(), &response_body)
+            };
+            match result {
+                Ok(value) => return Ok(value),
+                Err(error) if error.can_retry_stream() => {
+                    last_error = error;
+                    if attempt < 9 {
+                        sleep(retry_delay(attempt)).await;
+                    }
+                    continue;
+                }
+                Err(error) => return Err(error),
             }
-            let response_body = read_codex_body(response, url, status).await?;
-            return parse_codex_success_body(url, status, content_type.as_deref(), &response_body);
         }
 
         let response_body = read_codex_body(response, url, status).await?;
@@ -978,6 +1023,8 @@ async fn post_codex_json_with_retry(
                 status.as_u16(),
                 truncate(&response_body)
             ),
+            retryable_stream: false,
+            observable_delta: false,
         };
         if status == StatusCode::UNAUTHORIZED {
             return Err(error);
@@ -988,9 +1035,9 @@ async fn post_codex_json_with_retry(
                 let delay = if status.as_u16() == 429 {
                     retry_after
                         .map(Duration::from_secs)
-                        .unwrap_or_else(|| super::backoff_duration(attempt))
+                        .unwrap_or_else(|| retry_delay(attempt))
                 } else {
-                    super::backoff_duration(attempt)
+                    retry_delay(attempt)
                 };
                 sleep(delay).await;
             }
@@ -1010,6 +1057,8 @@ async fn read_codex_body(
     response.text().await.map_err(|error| CodexRequestError {
         status: Some(status),
         message: format!("Failed to read response body from {url}: {error}"),
+        retryable_stream: false,
+        observable_delta: false,
     })
 }
 
@@ -1031,7 +1080,9 @@ async fn stream_codex_responses(
         .await
         .map_err(|error| CodexRequestError {
             status: Some(status),
-            message: format!("{error:#}"),
+            message: error.to_string(),
+            retryable_stream: error.is_retryable(),
+            observable_delta: error.has_observable_delta(),
         })
 }
 
@@ -1046,12 +1097,14 @@ fn parse_codex_success_body(
         .unwrap_or(false)
         || response_body.lines().any(|line| line.starts_with("data:"))
     {
-        return parse_codex_sse_response(response_body).map_err(|message| CodexRequestError {
+        return parse_codex_sse_response(response_body).map_err(|error| CodexRequestError {
             status: Some(status),
             message: format!(
-                "Failed to parse SSE response from {url}: {message}\nBody: {}",
+                "Failed to parse SSE response from {url}: {error}\nBody: {}",
                 truncate(response_body)
             ),
+            retryable_stream: error.is_retryable(),
+            observable_delta: false,
         });
     }
 
@@ -1061,10 +1114,12 @@ fn parse_codex_success_body(
             "Failed to parse response from {url}: {error}\nBody: {}",
             truncate(response_body)
         ),
+        retryable_stream: false,
+        observable_delta: false,
     })
 }
 
-fn parse_codex_sse_response(response_body: &str) -> std::result::Result<Value, String> {
+fn parse_codex_sse_response(response_body: &str) -> std::result::Result<Value, StreamFoldError> {
     let mut fold = ResponsesStreamFold::new(None);
 
     for data in sse_data_payloads(response_body) {
@@ -1072,8 +1127,9 @@ fn parse_codex_sse_response(response_body: &str) -> std::result::Result<Value, S
             continue;
         }
 
-        let event: Value = serde_json::from_str(&data)
-            .map_err(|error| format!("invalid SSE JSON event: {error}"))?;
+        let event: Value = serde_json::from_str(&data).map_err(|error| {
+            StreamFoldError::permanent(format!("invalid SSE JSON event: {error}"))
+        })?;
         fold.push(&event)?;
     }
 
@@ -2085,6 +2141,225 @@ mod tests {
         assert_eq!(parsed["output"][0]["type"], "message");
         assert_eq!(parsed["output"][0]["content"][0]["text"], "hello");
         assert_eq!(parsed["usage"]["total_tokens"], 3);
+    }
+
+    #[test]
+    fn buffered_codex_sse_preserves_transient_retry_metadata() {
+        let body = concat!(
+            "data: {\"type\":\"response.failed\",\"response\":{\"error\":",
+            "{\"type\":\"overloaded_error\",\"message\":\"You can retry your request.\"}}}\n\n"
+        );
+        let error = parse_codex_success_body(
+            "https://chatgpt.com/backend-api/codex/responses",
+            StatusCode::OK,
+            Some("application/json"),
+            body,
+        )
+        .unwrap_err();
+
+        assert!(error.can_retry_stream());
+        assert!(error.to_string().contains("You can retry your request"));
+    }
+
+    async fn scripted_codex_sse_server(
+        bodies: Vec<&'static str>,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            for body in bodies {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                let mut request = [0; 16 * 1024];
+                let _ = stream.read(&mut request).await.unwrap();
+                let headers = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\
+                     Content-Length: {}\r\nConnection: close\r\n\r\n",
+                    body.len()
+                );
+                stream.write_all(headers.as_bytes()).await.unwrap();
+                stream.write_all(body.as_bytes()).await.unwrap();
+                stream.flush().await.unwrap();
+            }
+        });
+        (address, server)
+    }
+
+    fn completed_codex_sse() -> &'static str {
+        concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"thinking\"}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"complete\"}\n\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,",
+            "\"item\":{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",",
+            "\"text\":\"complete\"}]}}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":",
+            "{\"status\":\"completed\",\"output\":[]}}\n\n"
+        )
+    }
+
+    #[tokio::test]
+    async fn retries_transient_codex_sse_error_before_observable_output() {
+        use std::sync::mpsc;
+        use tokio::time::timeout;
+
+        let overloaded = concat!(
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",",
+            "\"message\":\"Our servers are currently overloaded. Please try again later.\"}}\n\n"
+        );
+        let (address, server) =
+            scripted_codex_sse_server(vec![overloaded, completed_codex_sse()]).await;
+        let (send, receive) = mpsc::channel();
+        let sink = move |delta| send.send(delta).expect("delta receiver should remain live");
+        let response = timeout(
+            Duration::from_secs(3),
+            post_codex_json_with_retry_delay(
+                &Client::new(),
+                &format!("http://{address}"),
+                &json!({"stream": true}),
+                &stored_codex_auth("access-token"),
+                None,
+                Some(&sink),
+                |_| Duration::ZERO,
+            ),
+        )
+        .await
+        .expect("transient stream retry timed out")
+        .unwrap();
+
+        timeout(Duration::from_secs(1), server)
+            .await
+            .expect("expected exactly two requests")
+            .unwrap();
+        assert_eq!(response["output"][0]["content"][0]["text"], "complete");
+        assert_eq!(
+            receive.try_iter().collect::<Vec<_>>(),
+            vec![
+                ModelStreamDelta::reasoning("thinking"),
+                ModelStreamDelta::text("complete"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_permanent_or_malformed_codex_sse_error() {
+        use tokio::time::timeout;
+
+        let permanent = concat!(
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"insufficient_quota\",",
+            "\"message\":\"quota exhausted\"}}\n\n"
+        );
+        for (body, expected_error) in [
+            (permanent, "quota exhausted"),
+            ("data: {not-json}\n\n", "invalid SSE event"),
+        ] {
+            let (address, server) = scripted_codex_sse_server(vec![body]).await;
+            let error = timeout(
+                Duration::from_secs(1),
+                post_codex_json_with_retry(
+                    &Client::new(),
+                    &format!("http://{address}"),
+                    &json!({"stream": true}),
+                    &stored_codex_auth("access-token"),
+                    None,
+                    None,
+                ),
+            )
+            .await
+            .expect("permanent stream error unexpectedly retried")
+            .unwrap_err();
+
+            timeout(Duration::from_secs(1), server)
+                .await
+                .expect("expected exactly one request")
+                .unwrap();
+            assert!(error.to_string().contains(expected_error), "{error}");
+        }
+    }
+
+    #[tokio::test]
+    async fn exhausts_transient_codex_sse_retries_with_final_provider_error() {
+        use tokio::time::timeout;
+
+        let overloaded = concat!(
+            "data: {\"type\":\"response.failed\",\"response\":{\"error\":",
+            "{\"type\":\"overloaded_error\",\"message\":\"You can retry your request.\"}}}\n\n"
+        );
+        let final_overloaded = concat!(
+            "data: {\"type\":\"response.failed\",\"response\":{\"error\":",
+            "{\"type\":\"overloaded_error\",\"message\":\"final provider failure\"}}}\n\n"
+        );
+        let mut bodies = vec![overloaded; 9];
+        bodies.push(final_overloaded);
+        let (address, server) = scripted_codex_sse_server(bodies).await;
+        let error = timeout(
+            Duration::from_secs(2),
+            post_codex_json_with_retry_delay(
+                &Client::new(),
+                &format!("http://{address}"),
+                &json!({"stream": true}),
+                &stored_codex_auth("access-token"),
+                None,
+                None,
+                |_| Duration::ZERO,
+            ),
+        )
+        .await
+        .expect("bounded transient stream retries timed out")
+        .unwrap_err();
+
+        timeout(Duration::from_secs(1), server)
+            .await
+            .expect("expected exactly ten requests")
+            .unwrap();
+        assert!(error.to_string().contains("final provider failure"));
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_codex_sse_error_after_observable_delta() {
+        use std::sync::mpsc;
+        use tokio::time::timeout;
+
+        let partial_text = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",",
+            "\"message\":\"Our servers are currently overloaded.\"}}\n\n"
+        );
+        let partial_reasoning = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"thinking\"}\n\n",
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",",
+            "\"message\":\"Our servers are currently overloaded.\"}}\n\n"
+        );
+        for (body, expected_delta) in [
+            (partial_text, ModelStreamDelta::text("partial")),
+            (partial_reasoning, ModelStreamDelta::reasoning("thinking")),
+        ] {
+            let (address, server) = scripted_codex_sse_server(vec![body]).await;
+            let (send, receive) = mpsc::channel();
+            let sink = move |delta| send.send(delta).expect("delta receiver should remain live");
+            let error = timeout(
+                Duration::from_secs(1),
+                post_codex_json_with_retry(
+                    &Client::new(),
+                    &format!("http://{address}"),
+                    &json!({"stream": true}),
+                    &stored_codex_auth("access-token"),
+                    None,
+                    Some(&sink),
+                ),
+            )
+            .await
+            .expect("post-delta stream error unexpectedly retried")
+            .unwrap_err();
+
+            timeout(Duration::from_secs(1), server)
+                .await
+                .expect("expected exactly one request")
+                .unwrap();
+            assert!(error.to_string().contains("currently overloaded"));
+            assert_eq!(receive.try_iter().collect::<Vec<_>>(), vec![expected_delta]);
+        }
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -872,7 +872,9 @@ impl ModelClient {
             .send_with_retry_headers(url, body, apply_headers)
             .await
             .map_err(|error| anyhow!(error.message))?;
-        read_sse_response(url, response, fold).await
+        read_sse_response(url, response, fold)
+            .await
+            .map_err(anyhow::Error::new)
     }
 
     /// Whether the configured extra_headers already set `name` (case-insensitive).

--- a/crates/nac-core/src/model/responses_stream.rs
+++ b/crates/nac-core/src/model/responses_stream.rs
@@ -1,6 +1,6 @@
 use serde_json::Value;
 
-use super::sse::StreamFold;
+use super::sse::{StreamFold, StreamFoldError};
 use super::stream::{DeltaSink, ModelStreamDelta};
 
 /// Folds a Responses-API event stream into the final `response` object, handing
@@ -12,6 +12,7 @@ pub(super) struct ResponsesStreamFold<'sink> {
     /// Items collected from `output_item.done`, used when the terminal event
     /// arrives with an empty `output` array.
     output_items: Vec<(usize, Value)>,
+    observable_delta: bool,
 }
 
 impl<'sink> ResponsesStreamFold<'sink> {
@@ -20,21 +21,26 @@ impl<'sink> ResponsesStreamFold<'sink> {
             on_delta,
             final_response: None,
             output_items: Vec::new(),
+            observable_delta: false,
         }
     }
 
-    fn emit(&self, event: &Value, build: impl Fn(&str) -> ModelStreamDelta) {
+    fn emit(&mut self, event: &Value, build: impl Fn(&str) -> ModelStreamDelta) {
         let Some(on_delta) = self.on_delta else {
             return;
         };
         if let Some(text) = event.get("delta").and_then(Value::as_str) {
-            on_delta(build(text));
+            let delta = build(text);
+            if !delta.is_empty() {
+                self.observable_delta = true;
+                on_delta(delta);
+            }
         }
     }
 }
 
 impl StreamFold for ResponsesStreamFold<'_> {
-    fn push(&mut self, event: &Value) -> Result<(), String> {
+    fn push(&mut self, event: &Value) -> Result<(), StreamFoldError> {
         match event.get("type").and_then(Value::as_str) {
             Some("response.output_text.delta") => {
                 self.emit(event, |text| ModelStreamDelta::text(text));
@@ -43,8 +49,10 @@ impl StreamFold for ResponsesStreamFold<'_> {
                 self.emit(event, |text| ModelStreamDelta::reasoning(text));
             }
             Some("error" | "response.failed") => {
-                return Err(responses_event_error_message(event)
-                    .unwrap_or_else(|| format!("model stream reported an error event: {event}")));
+                return Err(responses_event_error(
+                    event,
+                    "model stream reported an error event",
+                ));
             }
             Some("response.output_item.done") => {
                 if let Some(item) = event.get("item").cloned() {
@@ -61,8 +69,7 @@ impl StreamFold for ResponsesStreamFold<'_> {
             Some("response.completed" | "response.done" | "response.incomplete") => {
                 if let Some(response) = event.get("response").and_then(Value::as_object) {
                     if response.get("status").and_then(Value::as_str) == Some("failed") {
-                        return Err(responses_event_error_message(event)
-                            .unwrap_or_else(|| format!("model response failed: {event}")));
+                        return Err(responses_event_error(event, "model response failed"));
                     }
                     let mut response_value = Value::Object(response.clone());
                     if response_output_is_empty(&response_value) && !self.output_items.is_empty() {
@@ -82,13 +89,18 @@ impl StreamFold for ResponsesStreamFold<'_> {
         Ok(())
     }
 
+    fn has_observable_delta(&self) -> bool {
+        self.observable_delta
+    }
+
     fn is_complete(&self) -> bool {
         self.final_response.is_some()
     }
 
-    fn finish(self) -> Result<Value, String> {
-        self.final_response
-            .ok_or_else(|| "SSE stream did not include a final response event".to_string())
+    fn finish(self) -> Result<Value, StreamFoldError> {
+        self.final_response.ok_or_else(|| {
+            StreamFoldError::permanent("SSE stream did not include a final response event")
+        })
     }
 }
 
@@ -115,4 +127,98 @@ pub(super) fn responses_event_error_message(event: &Value) -> Option<String> {
         .or_else(|| event.get("message").and_then(Value::as_str))
         .filter(|message| !message.is_empty())
         .map(str::to_string)
+}
+
+fn responses_event_error(event: &Value, fallback: &str) -> StreamFoldError {
+    let message =
+        responses_event_error_message(event).unwrap_or_else(|| format!("{fallback}: {event}"));
+    if responses_event_is_retryable(event, &message) {
+        StreamFoldError::retryable(message)
+    } else {
+        StreamFoldError::permanent(message)
+    }
+}
+
+fn responses_event_is_retryable(event: &Value, message: &str) -> bool {
+    const RETRYABLE_CODES: &[&str] = &["server_error", "overloaded_error", "rate_limit_exceeded"];
+
+    let error = event
+        .get("response")
+        .and_then(|response| response.get("error"))
+        .or_else(|| event.get("error"));
+    let structured_retry = error
+        .into_iter()
+        .flat_map(|error| [error.get("code"), error.get("type")])
+        .chain([event.get("code")])
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(|value| value.to_ascii_lowercase())
+        .any(|value| RETRYABLE_CODES.contains(&value.as_str()));
+    if structured_retry {
+        return true;
+    }
+
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("our servers are currently overloaded")
+        || normalized.contains("you can retry your request")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::mpsc;
+
+    #[test]
+    fn classifies_only_explicit_transient_response_errors() {
+        let retryable = [
+            json!({"type": "error", "error": {"code": "server_error", "message": "failed"}}),
+            json!({"type": "response.failed", "response": {"error": {"type": "overloaded_error", "message": "failed"}}}),
+            json!({"type": "response.completed", "response": {"status": "failed", "error": {"code": "rate_limit_exceeded", "message": "failed"}}}),
+            json!({"type": "error", "message": "Our servers are currently overloaded. Please try again later."}),
+            json!({"type": "error", "message": "An error occurred. You can retry your request."}),
+        ];
+        for event in retryable {
+            let mut fold = ResponsesStreamFold::new(None);
+            let error = fold.push(&event).unwrap_err();
+            assert!(error.is_retryable(), "event should be retryable: {event}");
+        }
+
+        let permanent = [
+            json!({"type": "error", "error": {"code": "insufficient_quota", "message": "quota exhausted"}}),
+            json!({"type": "response.failed", "response": {"error": {"type": "invalid_request_error", "message": "fix the request and retry"}}}),
+            json!({"type": "error", "message": "Retry after correcting the API key."}),
+            json!({"type": "error", "error": {"code": "unknown", "message": "unknown failure"}}),
+        ];
+        for event in permanent {
+            let mut fold = ResponsesStreamFold::new(None);
+            let error = fold.push(&event).unwrap_err();
+            assert!(!error.is_retryable(), "event should be permanent: {event}");
+        }
+    }
+
+    #[test]
+    fn tracks_only_nonempty_deltas_delivered_to_a_live_sink() {
+        let (send, receive) = mpsc::channel();
+        let sink = move |delta| send.send(delta).expect("delta receiver should remain live");
+        let mut observed = ResponsesStreamFold::new(Some(&sink));
+        observed
+            .push(&json!({"type": "response.output_text.delta", "delta": ""}))
+            .unwrap();
+        assert!(!observed.has_observable_delta());
+        observed
+            .push(&json!({"type": "response.reasoning_text.delta", "delta": "thinking"}))
+            .unwrap();
+        assert!(observed.has_observable_delta());
+        assert_eq!(
+            receive.try_iter().collect::<Vec<_>>(),
+            vec![ModelStreamDelta::reasoning("thinking")]
+        );
+
+        let mut unobserved = ResponsesStreamFold::new(None);
+        unobserved
+            .push(&json!({"type": "response.output_text.delta", "delta": "hidden"}))
+            .unwrap();
+        assert!(!unobserved.has_observable_delta());
+    }
 }

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -9,20 +9,101 @@
 //! `data: [DONE]` is left to the caller: it is a wire-only sentinel that only
 //! the OpenAI-shaped backends send.
 
+use std::fmt;
 use std::pin::Pin;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
 use reqwest::Response;
 use serde_json::Value;
+
+#[derive(Debug)]
+pub(super) struct StreamFoldError {
+    message: String,
+    retryable: bool,
+}
+
+impl StreamFoldError {
+    pub(super) fn permanent(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: false,
+        }
+    }
+
+    pub(super) fn retryable(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: true,
+        }
+    }
+
+    pub(super) fn is_retryable(&self) -> bool {
+        self.retryable
+    }
+}
+
+impl fmt::Display for StreamFoldError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for StreamFoldError {}
+
+#[derive(Debug)]
+pub(super) struct SseError {
+    message: String,
+    retryable: bool,
+    observable_delta: bool,
+}
+
+impl SseError {
+    fn permanent(message: impl Into<String>, observable_delta: bool) -> Self {
+        Self {
+            message: message.into(),
+            retryable: false,
+            observable_delta,
+        }
+    }
+
+    fn fold(url: &str, error: StreamFoldError, observable_delta: bool) -> Self {
+        Self {
+            message: format!("model stream from {url} failed: {error}"),
+            retryable: error.retryable,
+            observable_delta,
+        }
+    }
+
+    pub(super) fn is_retryable(&self) -> bool {
+        self.retryable
+    }
+
+    pub(super) fn has_observable_delta(&self) -> bool {
+        self.observable_delta
+    }
+}
+
+impl fmt::Display for SseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SseError {}
 
 /// Rebuilds the response body a provider's buffered endpoint would have returned
 /// out of the events its streaming endpoint sends, so the existing parsers stay
 /// the single place that understands each provider's response shape.
 pub(super) trait StreamFold {
     /// Fold one event. `Err` is terminal and carries a user-facing reason.
-    fn push(&mut self, event: &Value) -> std::result::Result<(), String>;
+    fn push(&mut self, event: &Value) -> std::result::Result<(), StreamFoldError>;
+
+    /// Whether a non-empty model delta has reached a live observer.
+    fn has_observable_delta(&self) -> bool {
+        false
+    }
 
     /// Whether a protocol-level terminal event has been folded. Streaming
     /// callers can stop here instead of waiting for the provider to close an
@@ -31,7 +112,7 @@ pub(super) trait StreamFold {
         false
     }
 
-    fn finish(self) -> std::result::Result<Value, String>;
+    fn finish(self) -> std::result::Result<Value, StreamFoldError>;
 }
 
 /// Read an SSE body to completion, folding it into a response value.
@@ -39,28 +120,39 @@ pub(super) async fn read_sse_response<F: StreamFold>(
     url: &str,
     response: Response,
     mut fold: F,
-) -> Result<Value> {
+) -> std::result::Result<Value, SseError> {
     let mut reader = SseReader::new(response);
 
     while let Some(frame) = reader.next_frame().await {
-        let frame = frame.with_context(|| format!("model stream from {url} failed"))?;
+        let frame = frame.map_err(|error| {
+            SseError::permanent(
+                format!("model stream from {url} failed: {error:#}"),
+                fold.has_observable_delta(),
+            )
+        })?;
         if frame.is_done() {
             break;
         }
         if frame.data.trim().is_empty() {
             continue;
         }
-        let event: Value = serde_json::from_str(&frame.data)
-            .with_context(|| format!("invalid SSE event from {url}: {}", frame.data))?;
-        fold.push(&event)
-            .map_err(|message| anyhow!("model stream from {url} failed: {message}"))?;
+        let event: Value = serde_json::from_str(&frame.data).map_err(|error| {
+            SseError::permanent(
+                format!("invalid SSE event from {url}: {}\n{error}", frame.data),
+                fold.has_observable_delta(),
+            )
+        })?;
+        if let Err(error) = fold.push(&event) {
+            return Err(SseError::fold(url, error, fold.has_observable_delta()));
+        }
         if fold.is_complete() {
             break;
         }
     }
 
+    let observable_delta = fold.has_observable_delta();
     fold.finish()
-        .map_err(|message| anyhow!("model stream from {url} failed: {message}"))
+        .map_err(|error| SseError::fold(url, error, observable_delta))
 }
 
 /// One dispatched SSE event. Only the payload is kept: providers that also name

--- a/crates/nac-core/src/tools/thread/mod.rs
+++ b/crates/nac-core/src/tools/thread/mod.rs
@@ -241,13 +241,8 @@ pub async fn execute_parsed_dispatch(
                 timeout_reason: None,
                 usage: run.usage.clone(),
             });
-            let details = if !run.stderr.trim().is_empty() {
-                run.stderr.trim().to_string()
-            } else if !run.stdout.trim().is_empty() {
-                run.stdout.trim().to_string()
-            } else {
-                "no output".to_string()
-            };
+            let details =
+                worker_failure_details(run.model_error.as_deref(), &run.stderr, &run.stdout);
             ToolResult {
                 content: format!(
                     "Thread '{}' failed (exit {}):\n{}",
@@ -269,6 +264,26 @@ pub async fn execute_parsed_dispatch(
                 is_error: false,
             }
         }
+    }
+}
+
+fn worker_failure_details(model_error: Option<&str>, stderr: &str, stdout: &str) -> String {
+    let model_error = model_error
+        .map(str::trim)
+        .filter(|message| !message.is_empty());
+    let stderr = stderr.trim();
+    if let Some(model_error) = model_error {
+        if stderr.is_empty() {
+            return model_error.to_string();
+        }
+        return format!("{model_error}\n\nWorker diagnostics:\n{stderr}");
+    }
+    if !stderr.is_empty() {
+        stderr.to_string()
+    } else if !stdout.trim().is_empty() {
+        stdout.trim().to_string()
+    } else {
+        "no output".to_string()
     }
 }
 
@@ -603,6 +618,99 @@ mod tests {
             unavailable.content,
             "Error: no skills are available for thread dispatch"
         );
+    }
+
+    #[test]
+    fn worker_failure_prioritizes_model_error_and_preserves_diagnostics() {
+        assert_eq!(
+            worker_failure_details(
+                Some("provider overloaded"),
+                "pid file already exists\nMCP unavailable",
+                "partial stdout",
+            ),
+            "provider overloaded\n\nWorker diagnostics:\npid file already exists\nMCP unavailable"
+        );
+        assert_eq!(
+            worker_failure_details(Some("  provider overloaded  "), " \n", "partial stdout"),
+            "provider overloaded"
+        );
+    }
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_dispatch_reports_latest_model_error_before_ordered_diagnostics() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root =
+            std::env::temp_dir().join(format!("nac_dispatch_error_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let executable = root.join("worker.sh");
+        let model_started = serde_json::to_string(&AgentEvent::ModelCallStarted {
+            thread_name: Some("worker".to_string()),
+            iteration: 2,
+        })
+        .unwrap();
+        let first = serde_json::to_string(&AgentEvent::ModelError {
+            thread_name: Some("worker".to_string()),
+            message: "first provider error".to_string(),
+        })
+        .unwrap();
+        let second = serde_json::to_string(&AgentEvent::ModelError {
+            thread_name: Some("worker".to_string()),
+            message: "latest provider error\nrequest-id: safe".to_string(),
+        })
+        .unwrap();
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' '{prefix}{model_started}' >&2\n\
+             printf '%s\\n' '{prefix}{first}' >&2\n\
+             printf '%s\\n' 'pid file already exists' >&2\n\
+             printf '%s\\n' '{prefix}{second}' >&2\n\
+             printf '%s\\n' 'MCP unavailable' >&2\n\
+             printf '%s\\n' 'partial stdout'\nexit 1\n",
+            prefix = crate::events::STDERR_EVENT_PREFIX,
+        );
+        std::fs::write(&executable, script).unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut runtime = test_runtime();
+        runtime.workspace_cwd = root.clone();
+        runtime.config_cwd = root.clone();
+        runtime.worker_executable = Some(executable);
+        let params = ParsedDispatchParams {
+            thread_name: "worker".to_string(),
+            dispatch_id: "dispatch".to_string(),
+            action: "fail".to_string(),
+            source_threads: Vec::new(),
+            scheduled_skills: Vec::new(),
+            session_id: "test-session".to_string(),
+            timeout_secs: 30,
+        };
+        assert!(mark_thread_active(&runtime, "worker", "dispatch"));
+
+        let result = execute_parsed_dispatch(params, &runtime, &ModelClient::new_for_test()).await;
+
+        assert!(result.is_error);
+        assert_eq!(
+            result.content,
+            "Thread 'worker' failed (exit 1):\n\
+             latest provider error\nrequest-id: safe\n\n\
+             Worker diagnostics:\npid file already exists\nMCP unavailable"
+        );
+        assert!(!result.content.contains(crate::events::STDERR_EVENT_PREFIX));
+        assert!(!is_thread_active(&runtime, "worker"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn worker_failure_preserves_existing_output_fallbacks() {
+        assert_eq!(
+            worker_failure_details(None, " stderr details ", "stdout details"),
+            "stderr details"
+        );
+        assert_eq!(
+            worker_failure_details(None, " \n", " stdout details "),
+            "stdout details"
+        );
+        assert_eq!(worker_failure_details(None, "", ""), "no output");
     }
 
     #[test]

--- a/crates/nac-core/src/tools/thread/worker.rs
+++ b/crates/nac-core/src/tools/thread/worker.rs
@@ -8,7 +8,7 @@ use tokio::process::Command;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
-use crate::events::{decode_stderr_event, AgentEvent};
+use crate::events::{decode_stderr_event, sanitize_external_agent_event, AgentEvent};
 use crate::model::{ModelClient, TokenUsage};
 use crate::process::ProcessTreeGuard;
 use crate::tools::{ThreadCancellation, ToolRuntime};
@@ -21,6 +21,7 @@ pub(super) struct WorkerRun {
     pub(super) cancelled: bool,
     pub(super) timeout_reason: Option<String>,
     pub(super) usage: Option<TokenUsage>,
+    pub(super) model_error: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -258,6 +259,7 @@ pub(super) async fn run_worker(
         let mut lines = reader.lines();
         let mut output = String::new();
         let mut worker_usage = TokenUsage::default();
+        let mut model_error = None;
         while let Ok(Some(line)) = lines.next_line().await {
             if stderr_cancellation.is_cancelled() {
                 break;
@@ -269,6 +271,15 @@ pub(super) async fn run_worker(
                 } = &event
                 {
                     worker_usage += usage.clone();
+                }
+                if matches!(event, AgentEvent::ModelError { .. }) {
+                    if let Some(AgentEvent::ModelError { message, .. }) =
+                        sanitize_external_agent_event(event.clone())
+                    {
+                        if !message.trim().is_empty() {
+                            model_error = Some(message);
+                        }
+                    }
                 }
                 event_sink.emit(event);
             } else {
@@ -291,7 +302,7 @@ pub(super) async fn run_worker(
         } else {
             Some(worker_usage)
         };
-        (output, usage)
+        (output, usage, model_error)
     });
 
     let stdout = child.stdout.take().unwrap();
@@ -340,12 +351,12 @@ pub(super) async fn run_worker(
     }
 
     let readers = async {
-        let (stderr, worker_usage) = stderr_handle.await.unwrap_or_default();
+        let (stderr, worker_usage, model_error) = stderr_handle.await.unwrap_or_default();
         let stdout = stdout_handle.await.unwrap_or_default();
-        (stderr, worker_usage, stdout)
+        (stderr, worker_usage, model_error, stdout)
     };
     tokio::pin!(readers);
-    let (stderr, worker_usage, stdout) = if timed_out || cancelled {
+    let (stderr, worker_usage, model_error, stdout) = if timed_out || cancelled {
         readers.await
     } else {
         tokio::select! {
@@ -380,6 +391,7 @@ pub(super) async fn run_worker(
         cancelled,
         timeout_reason,
         usage: worker_usage,
+        model_error,
     })
 }
 
@@ -581,6 +593,69 @@ exit 0
         assert!(!root.join("late-write").exists());
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn worker_retains_latest_sanitized_model_error_separately_from_stderr() {
+        let root = std::env::temp_dir().join(format!("nac_worker_error_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let executable = root.join("worker.sh");
+        let model_started = serde_json::to_string(&AgentEvent::ModelCallStarted {
+            thread_name: Some("worker".to_string()),
+            iteration: 3,
+        })
+        .unwrap();
+        let first = serde_json::to_string(&AgentEvent::ModelError {
+            thread_name: Some("worker".to_string()),
+            message: "first model error".to_string(),
+        })
+        .unwrap();
+        let second = serde_json::to_string(&AgentEvent::ModelError {
+            thread_name: Some("worker".to_string()),
+            message: "x".repeat(700),
+        })
+        .unwrap();
+        let script = format!(
+            "#!/bin/sh\nprintf '%s\\n' '{prefix}{model_started}' >&2\n\
+             printf '%s\\n' '{prefix}{first}' >&2\n\
+             printf '%s\\n' 'pid file already exists' >&2\n\
+             printf '%s\\n' '{prefix}{second}' >&2\n\
+             printf '%s\\n' 'MCP unavailable' >&2\nexit 1\n",
+            prefix = crate::events::STDERR_EVENT_PREFIX,
+        );
+        std::fs::write(&executable, script).unwrap();
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+        let mut runtime = test_runtime();
+        runtime.workspace_cwd = root.clone();
+        runtime.config_cwd = root.clone();
+        runtime.worker_executable = Some(executable);
+        let no_sources = Vec::<String>::new();
+        let no_skills = Vec::<String>::new();
+        let run = run_worker(
+            &runtime,
+            &ModelClient::new_for_test(),
+            WorkerInvocation {
+                session_id: "session",
+                thread_name: "worker",
+                dispatch_id: "dispatch",
+                action: "worker",
+                source_threads: &no_sources,
+                scheduled_skills: &no_skills,
+                timeout_secs: 30,
+            },
+            ThreadCancellation::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(run.exit_code, 1);
+        assert_eq!(run.model_error.as_deref(), Some("x".repeat(600).as_str()));
+        assert_eq!(run.stderr, "pid file already exists\nMCP unavailable");
+        assert!(!run.stderr.contains(crate::events::STDERR_EVENT_PREFIX));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[test]
     fn worker_model_transport_is_complete_with_absent_effort_and_empty_headers() {
         let _guard = TEST_ENV_LOCK.lock().unwrap();


### PR DESCRIPTION
## Description

**What.** Retries explicitly transient ChatGPT Codex Responses API stream failures only when replay cannot duplicate visible output, and preserves the terminal model error as the primary thread failure detail.

**Why.** Managed threads could finish tool calls and then fail on an HTTP 200 SSE overload event; the existing HTTP retry loop never saw that event, while an earlier MCP startup warning could become the thread tile's apparent cause.

The Responses stream fold now returns typed retry metadata for a narrow allowlist of provider error codes and exact overload/retry messages. The existing ten-attempt backoff loop retries only before a nonempty text or reasoning delta reaches a live sink. Permanent, malformed, and post-delta failures remain one-shot.

Managed workers retain the latest sanitized `ModelError` independently from plain stderr. Failed thread results lead with that model error and append earlier undecoded stderr under `Worker diagnostics:`. Encoded lifecycle events still drive timeout tracing and stay out of diagnostics.

This does not change MCP transport, configuration, PID ownership, or Moraine startup behavior. Moraine's concurrent stdio-client PID collision is an independent upstream issue fixed by eric-tramel/moraine#666 but not yet present in v0.7.3.

## Bug Evidence

Affected workers successfully completed shell/read tool calls before their next model turn failed with a retryable `response.failed` or `error` event inside an HTTP 200 SSE response. Before this change, that event bypassed the status-based retry path and the resulting thread failure selected the first nonempty stderr warning, such as the Moraine `mcp.pid` refusal.

The new scripted SSE fixtures reproduce the transport boundary and verify retry-before-output, no retry after text or reasoning output, no retry for permanent or malformed events, and final-error preservation after exactly ten attempts. A fake-worker dispatch fixture verifies the user-visible failure ordering end to end.

## Usage

No configuration or operator action changes. Existing managed Codex threads recover automatically from eligible pre-output transient stream failures; exhausted or unsafe-to-replay failures remain visible with their worker diagnostics.

## Changelog

- Retry transient pre-output ChatGPT Codex SSE failures within the existing bounded retry policy.
- Report the latest structured model failure before incidental managed-worker stderr diagnostics.

## Validation

`cargo test -p nac-core model::responses_stream::tests -- --nocapture` passed 2 classifier and live-delta tracking tests. `cargo test -p nac-core codex_sse -- --nocapture` passed 6 buffered/streaming, retry, no-retry, replay-safety, and exhaustion tests. The focused worker retention, full dispatch failure, and fallback formatter tests passed.

`cargo check --workspace --locked` passed. `cargo test --workspace --locked -- --test-threads=1` passed 815 tests across 10 suites with 5 ignored. `git diff --check` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex request retry behavior and managed-thread failure messaging in core model/transport paths; bounded by explicit retry classification and no-retry-after-delta rules, with broad test coverage.
> 
> **Overview**
> **Codex streaming** now retries **transient** overload/server errors that arrive inside **HTTP 200** SSE bodies, using the existing ten-attempt backoff loop. `StreamFoldError` / `SseError` carry **retryable** vs **permanent** outcomes; the Responses stream fold classifies a narrow allowlist of provider codes/messages and tracks **non-empty** text/reasoning deltas sent to a live sink. Retries run only when **no observable delta** was emitted—permanent, malformed, and post-output failures stay one-shot.
> 
> **Managed thread failures** capture the latest sanitized **`ModelError`** from worker stderr separately from plain diagnostics; failed thread tool results lead with that message and append undecoded stderr under **Worker diagnostics:** when both exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e030a7aa48c0b6976adbd96b77772cf85e232f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->