### PR TITLE
Harden model token limits and retries

### DIFF
--- a/crates/nac-core/src/model/anthropic_stream.rs
+++ b/crates/nac-core/src/model/anthropic_stream.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-use super::sse::{StreamFold, StreamFoldError};
+use super::sse::{provider_stream_error, StreamFold, StreamFoldError};
 use super::stream::{DeltaSink, ModelStreamDelta};
 
 /// Rebuilds an Anthropic Messages response out of its event stream.
@@ -19,6 +19,7 @@ pub(super) struct AnthropicStreamFold<'sink> {
     input_usage: Option<Value>,
     output_tokens: Option<u64>,
     saw_message: bool,
+    observable_delta: bool,
 }
 
 struct PartialBlock {
@@ -36,11 +37,13 @@ impl<'sink> AnthropicStreamFold<'sink> {
             input_usage: None,
             output_tokens: None,
             saw_message: false,
+            observable_delta: false,
         }
     }
 
-    fn emit(&self, delta: ModelStreamDelta) {
-        if let Some(on_delta) = self.on_delta {
+    fn emit(&mut self, delta: ModelStreamDelta) {
+        if let Some(on_delta) = self.on_delta.filter(|_| !delta.is_empty()) {
+            self.observable_delta = true;
             on_delta(delta);
         }
     }
@@ -66,7 +69,11 @@ impl StreamFold for AnthropicStreamFold<'_> {
                     .and_then(|error| error.get("message"))
                     .and_then(Value::as_str)
                     .unwrap_or("Anthropic stream reported an error");
-                return Err(StreamFoldError::permanent(message));
+                let code = event
+                    .get("error")
+                    .and_then(|error| error.get("type"))
+                    .and_then(Value::as_str);
+                return Err(provider_stream_error(code, message));
             }
             Some("message_start") => {
                 self.saw_message = true;
@@ -143,9 +150,13 @@ impl StreamFold for AnthropicStreamFold<'_> {
         }
         Ok(())
     }
+    fn has_observable_delta(&self) -> bool {
+        self.observable_delta
+    }
+
     fn finish(self) -> Result<Value, StreamFoldError> {
         if !self.saw_message {
-            return Err(StreamFoldError::permanent(
+            return Err(StreamFoldError::retryable(
                 "stream ended without a message_start event",
             ));
         }

--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -320,7 +320,7 @@ fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
     let max_tokens = model
         .max_output_length
         .filter(|&m| m > 0)
-        .unwrap_or(super::FALLBACK_MAX_TOKENS);
+        .unwrap_or_else(|| arcee_max_tokens_fallback(&model.id, context_window));
     let max_tokens = max_tokens.min(context_window);
 
     let pricing = model.pricing.as_ref();
@@ -366,6 +366,16 @@ fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
             context_management: false,
             clear_thinking: false,
         },
+    }
+}
+
+fn arcee_max_tokens_fallback(model_id: &str, context_window: u64) -> u64 {
+    match model_id {
+        "trinity-large-thinking" => 80_000,
+        id if passthrough_effort_map(id).is_some() => {
+            262_144.min((context_window / 2).max(1))
+        }
+        _ => super::FALLBACK_MAX_TOKENS,
     }
 }
 
@@ -482,7 +492,11 @@ pub(super) fn merge_arcee_overlay(
     };
 
     let mut models = BTreeMap::new();
-    for entry in entries {
+    for mut entry in entries {
+        if entry.model.max_tokens == super::FALLBACK_MAX_TOKENS {
+            entry.model.max_tokens =
+                arcee_max_tokens_fallback(&entry.id, entry.model.context_window);
+        }
         models.insert(entry.id.clone(), entry.model);
     }
 

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -559,6 +559,20 @@ fn generated_baseline_merges_real_models_dev_data_over_the_seeds() {
 }
 
 #[test]
+fn arcee_passthrough_without_output_limit_gets_a_large_safe_default() {
+    let entries = arcee_overlay::map_arcee_api_response(
+        r#"{"data":[{"id":"deepseek-ai/deepseek-v4-pro","context_length":512000},{"id":"trinity-large-thinking","context_length":128000}]}"#,
+    )
+    .unwrap();
+    let entry = serde_json::to_value(&entries[0]).unwrap();
+    assert_eq!(entry["max_tokens"], 256_000);
+    assert_eq!(
+        serde_json::to_value(&entries[1]).unwrap()["max_tokens"],
+        80_000
+    );
+}
+
+#[test]
 fn manifest_sha256_pins_the_embedded_catalog() {
     let manifest = data::parse_manifest().expect("embedded manifest parses");
     assert!(!manifest.sha256.is_empty());

--- a/crates/nac-core/src/model/chat_stream.rs
+++ b/crates/nac-core/src/model/chat_stream.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde_json::{json, Value};
 
-use super::sse::{StreamFold, StreamFoldError};
+use super::sse::{provider_stream_error, StreamFold, StreamFoldError};
 use super::stream::{DeltaSink, ModelStreamDelta};
 
 /// Rebuilds a chat-completions response out of its stream chunks, so the
@@ -20,6 +20,7 @@ pub(super) struct ChatStreamFold<'sink> {
     /// in the call list: identity comes once and the arguments accumulate.
     tool_calls: BTreeMap<u64, PartialToolCall>,
     saw_choice: bool,
+    observable_delta: bool,
 }
 
 #[derive(Default)]
@@ -41,11 +42,13 @@ impl<'sink> ChatStreamFold<'sink> {
             usage: None,
             tool_calls: BTreeMap::new(),
             saw_choice: false,
+            observable_delta: false,
         }
     }
 
-    fn emit(&self, delta: ModelStreamDelta) {
-        if let Some(on_delta) = self.on_delta {
+    fn emit(&mut self, delta: ModelStreamDelta) {
+        if let Some(on_delta) = self.on_delta.filter(|_| !delta.is_empty()) {
+            self.observable_delta = true;
             on_delta(delta);
         }
     }
@@ -77,12 +80,16 @@ impl<'sink> ChatStreamFold<'sink> {
 
 impl StreamFold for ChatStreamFold<'_> {
     fn push(&mut self, event: &Value) -> Result<(), StreamFoldError> {
-        if let Some(message) = event
-            .get("error")
-            .and_then(|error| error.get("message"))
-            .and_then(Value::as_str)
-        {
-            return Err(StreamFoldError::permanent(message));
+        if let Some(error) = event.get("error") {
+            let message = error
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("model stream reported an error");
+            let code = error
+                .get("code")
+                .or_else(|| error.get("type"))
+                .and_then(Value::as_str);
+            return Err(provider_stream_error(code, message));
         }
 
         if let Some(usage) = event.get("usage").filter(|usage| !usage.is_null()) {
@@ -123,9 +130,13 @@ impl StreamFold for ChatStreamFold<'_> {
 
         Ok(())
     }
+    fn has_observable_delta(&self) -> bool {
+        self.observable_delta
+    }
+
     fn finish(self) -> Result<Value, StreamFoldError> {
         if !self.saw_choice {
-            return Err(StreamFoldError::permanent(
+            return Err(StreamFoldError::retryable(
                 "stream ended without any completion chunk",
             ));
         }

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -976,11 +976,7 @@ async fn post_codex_json_with_retry_delay(
         };
 
         let status = response.status();
-        let retry_after = response
-            .headers()
-            .get("retry-after")
-            .and_then(|value| value.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok());
+        let retry_after = super::retry_after_delay(response.headers());
         let content_type = response
             .headers()
             .get(header::CONTENT_TYPE)
@@ -1029,16 +1025,10 @@ async fn post_codex_json_with_retry_delay(
         if status == StatusCode::UNAUTHORIZED {
             return Err(error);
         }
-        if status.as_u16() == 429 || status.is_server_error() {
+        if super::retryable_http_status(status) {
             last_error = error;
             if attempt < 9 {
-                let delay = if status.as_u16() == 429 {
-                    retry_after
-                        .map(Duration::from_secs)
-                        .unwrap_or_else(|| retry_delay(attempt))
-                } else {
-                    retry_delay(attempt)
-                };
+                let delay = retry_after.unwrap_or_else(|| retry_delay(attempt));
                 sleep(delay).await;
             }
             continue;

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -398,7 +398,7 @@ impl ModelClient {
         // Trinity's vLLM front end needs its own assistant-message shape; the
         // quirk rides the provider axis, like the URL join right below.
         let arcee = matches!(self.backend, BackendKind::ArceeAuth | BackendKind::ArceeApi);
-        let request = completions_chat_request(
+        let mut request = completions_chat_request(
             &self.model,
             self.reasoning_effort,
             &messages,
@@ -411,6 +411,10 @@ impl ModelClient {
                 CompletionsMessageShape::Standard
             },
         );
+        request["max_tokens"] = json!(self.resolved_model.max_tokens.min(262_144));
+        if self.backend == BackendKind::TogetherChat {
+            request["context_length_exceeded_behavior"] = json!("truncate");
+        }
         let url = match self.backend {
             BackendKind::ArceeAuth | BackendKind::ArceeApi => {
                 arcee::chat_completions_url(&self.base_url)
@@ -473,7 +477,7 @@ impl ModelClient {
             url,
             &request,
             |request| request.header("Authorization", format!("Bearer {api_key}")),
-            ChatStreamFold::new(on_delta, reasoning_field),
+            || ChatStreamFold::new(on_delta, reasoning_field),
         )
         .await
     }
@@ -515,7 +519,7 @@ impl ModelClient {
             url,
             &request,
             apply_headers,
-            ChatStreamFold::new(on_delta, reasoning_field),
+            || ChatStreamFold::new(on_delta, reasoning_field),
         )
         .await
     }
@@ -544,7 +548,7 @@ impl ModelClient {
                     &url,
                     &request,
                     |request| request.header("Authorization", format!("Bearer {}", api_key)),
-                    ResponsesStreamFold::new(on_delta),
+                    || ResponsesStreamFold::new(on_delta),
                 )
                 .await?
             }
@@ -592,7 +596,7 @@ impl ModelClient {
                     &url,
                     &request,
                     |request| anthropic_headers(request, api_key, cache_ttl, context_management),
-                    AnthropicStreamFold::new(on_delta),
+                    || AnthropicStreamFold::new(on_delta),
                 )
                 .await?
             }
@@ -656,23 +660,14 @@ impl ModelClient {
         on_delta: DeltaSink<'_>,
     ) -> std::result::Result<Value, ModelHttpError> {
         if let Some(on_delta) = on_delta {
-            // Same forfeit-retry rule as the other SSE adapters: once chunks
-            // have been forwarded, a mid-stream failure cannot be retried.
-            let response = self
-                .send_with_retry_headers(url, body, |request| {
-                    request.header("Authorization", format!("Bearer {token}"))
-                })
-                .await?;
-            return read_sse_response(
-                url,
-                response,
-                ChatStreamFold::new(Some(on_delta), reasoning_field),
-            )
-            .await
-            .map_err(|error| ModelHttpError {
-                status: None,
-                message: error.to_string(),
-            });
+            return self
+                .try_post_sse_with_retry_headers(
+                    url,
+                    body,
+                    |request| request.header("Authorization", format!("Bearer {token}")),
+                    || ChatStreamFold::new(Some(on_delta), reasoning_field),
+                )
+                .await;
         }
         self.try_post_json_with_retry_headers(url, body, |request| {
             request.header("Authorization", format!("Bearer {token}"))
@@ -779,11 +774,7 @@ impl ModelClient {
             };
 
             let status = response.status();
-            let retry_after = response
-                .headers()
-                .get("retry-after")
-                .and_then(|value| value.to_str().ok())
-                .and_then(|s| s.parse::<u64>().ok());
+            let retry_after = super::retry_after_delay(response.headers());
             let redirect_location = response
                 .headers()
                 .get(reqwest::header::LOCATION)
@@ -823,16 +814,10 @@ impl ModelClient {
                 ),
             };
 
-            if status.as_u16() == 429 || status.is_server_error() {
+            if super::retryable_http_status(status) {
                 last_error = error;
                 if attempt < 9 {
-                    let delay = if status.as_u16() == 429 {
-                        retry_after
-                            .map(Duration::from_secs)
-                            .unwrap_or_else(|| super::backoff_duration(attempt))
-                    } else {
-                        super::backoff_duration(attempt)
-                    };
+                    let delay = retry_after.unwrap_or_else(|| super::backoff_duration(attempt));
                     sleep(delay).await;
                 }
                 continue;
@@ -846,24 +831,60 @@ impl ModelClient {
 
     /// Send a streaming request, folding the event stream back into the response
     /// value the buffered parsers expect.
-    async fn post_sse_with_retry_headers<F, Fold>(
+    async fn post_sse_with_retry_headers<F, MakeFold, Fold>(
         &self,
         url: &str,
         body: &Value,
         apply_headers: F,
-        fold: Fold,
+        make_fold: MakeFold,
     ) -> Result<Value>
     where
         F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
+        MakeFold: Fn() -> Fold,
         Fold: StreamFold,
     {
-        let response = self
-            .send_with_retry_headers(url, body, apply_headers)
+        self.try_post_sse_with_retry_headers(url, body, apply_headers, make_fold)
             .await
-            .map_err(|error| anyhow!(error.message))?;
-        read_sse_response(url, response, fold)
-            .await
-            .map_err(anyhow::Error::new)
+            .map_err(|error| anyhow!(error.message))
+    }
+
+    async fn try_post_sse_with_retry_headers<F, MakeFold, Fold>(
+        &self,
+        url: &str,
+        body: &Value,
+        apply_headers: F,
+        make_fold: MakeFold,
+    ) -> std::result::Result<Value, ModelHttpError>
+    where
+        F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
+        MakeFold: Fn() -> Fold,
+        Fold: StreamFold,
+    {
+        let mut last_error = None;
+        for attempt in 0..10 {
+            let response = self
+                .send_with_retry_headers(url, body, apply_headers)
+                .await?;
+            match read_sse_response(url, response, make_fold()).await {
+                Ok(value) => return Ok(value),
+                Err(error) if error.is_retryable() && !error.has_observable_delta() => {
+                    last_error = Some(ModelHttpError {
+                        status: None,
+                        message: error.to_string(),
+                    });
+                    if attempt < 9 {
+                        sleep(super::backoff_duration(attempt)).await;
+                    }
+                }
+                Err(error) => {
+                    return Err(ModelHttpError {
+                        status: None,
+                        message: error.to_string(),
+                    });
+                }
+            }
+        }
+        Err(last_error.expect("SSE retry loop makes at least one attempt"))
     }
 
     /// Whether the configured extra_headers already set `name` (case-insensitive).

--- a/crates/nac-core/src/model/client/tests/http_contract.rs
+++ b/crates/nac-core/src/model/client/tests/http_contract.rs
@@ -100,7 +100,7 @@ async fn arcee_inference_sends_expected_contract_and_parses_chat_response() {
         })
         .to_string(),
     )]);
-    let client = ModelClient {
+    let mut client = ModelClient {
         client: arcee::no_redirect_client().unwrap(),
         base_url: format!("{}/tenant/base", server.base_url),
         api_key: "stored-login-credential".to_string(),
@@ -117,6 +117,7 @@ async fn arcee_inference_sends_expected_contract_and_parses_chat_response() {
         prompt_cache_key: None,
         resolved_model: catalog::resolve(BackendKind::ArceeApi, "arcee-test-model"),
     };
+    client.resolved_model.max_tokens = 500_000;
     let messages = vec![
         Message::System {
             content: "Follow instructions".to_string(),
@@ -187,6 +188,7 @@ async fn arcee_inference_sends_expected_contract_and_parses_chat_response() {
     );
     let body: Value = serde_json::from_slice(&request.body).expect("request JSON");
     assert_eq!(body["model"], "arcee-test-model");
+    assert_eq!(body["max_tokens"], 262_144);
     assert_eq!(body["temperature"], 0.0);
     assert_eq!(
         body["messages"],
@@ -423,6 +425,90 @@ fn truncate_utf8_preserves_exact_boundary_and_short_values() {
     assert_eq!(exact.len(), 500);
     assert_eq!(truncate_utf8(&exact, 500), exact);
     assert_eq!(truncate_utf8("short", 500), "short");
+}
+
+#[tokio::test]
+async fn retries_request_timeout_and_conflict_responses() {
+    for status in ["408 Request Timeout", "409 Conflict"] {
+        let server = ScriptedServer::start(vec![
+            ScriptedResponse::json(status, "{}"),
+            ScriptedResponse::json("200 OK", r#"{"ok":true}"#),
+        ]);
+        let client = test_model_client(
+            BackendKind::OpenAiResponses,
+            server.base_url.clone(),
+            std::collections::BTreeMap::new(),
+        );
+        let value = client
+            .post_json_with_retry(&format!("{}/retry", server.base_url), &json!({}))
+            .await
+            .unwrap();
+        assert_eq!(value["ok"], true, "{status}");
+        assert_eq!(server.finish().len(), 2, "{status}");
+    }
+}
+
+#[tokio::test]
+async fn retries_transient_shared_sse_before_observable_output() {
+    let server = ScriptedServer::start(vec![
+        ScriptedResponse::json(
+            "200 OK",
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",\"message\":\"try later\"}}\n\n",
+        ),
+        ScriptedResponse::json(
+            "200 OK",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[]}}\n\n",
+        ),
+    ]);
+    let client = test_model_client(
+        BackendKind::OpenAiResponses,
+        server.base_url.clone(),
+        std::collections::BTreeMap::new(),
+    );
+    let value = client
+        .post_sse_with_retry_headers(
+            &format!("{}/stream", server.base_url),
+            &json!({}),
+            |request| request,
+            || ResponsesStreamFold::new(None),
+        )
+        .await
+        .unwrap();
+    assert_eq!(value["status"], "completed");
+    assert_eq!(server.finish().len(), 2);
+}
+
+#[tokio::test]
+async fn does_not_retry_shared_sse_after_observable_output() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let server = ScriptedServer::start(vec![ScriptedResponse::json(
+        "200 OK",
+        concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"partial\"}\n\n",
+            "data: {\"type\":\"error\",\"error\":{\"code\":\"server_error\",\"message\":\"try later\"}}\n\n"
+        ),
+    )]);
+    let client = test_model_client(
+        BackendKind::OpenAiResponses,
+        server.base_url.clone(),
+        std::collections::BTreeMap::new(),
+    );
+    let seen = AtomicUsize::new(0);
+    let sink = |_| {
+        seen.fetch_add(1, Ordering::Relaxed);
+    };
+    client
+        .post_sse_with_retry_headers(
+            &format!("{}/stream", server.base_url),
+            &json!({}),
+            |request| request,
+            || ResponsesStreamFold::new(Some(&sink)),
+        )
+        .await
+        .expect_err("observable output must forfeit replay");
+    assert_eq!(seen.load(Ordering::Relaxed), 1);
+    assert_eq!(server.finish().len(), 1);
 }
 
 #[tokio::test]

--- a/crates/nac-core/src/model/client/tests/s5_wire.rs
+++ b/crates/nac-core/src/model/client/tests/s5_wire.rs
@@ -335,6 +335,8 @@ async fn together_reasoning_round_trips_under_the_reasoning_field() {
     let requests = server.finish();
     assert_eq!(requests.len(), 2);
     let body = serde_json::from_slice::<Value>(&requests[1].body).expect("request body is JSON");
+    assert_eq!(body["max_tokens"], client.resolved_model.max_tokens);
+    assert_eq!(body["context_length_exceeded_behavior"], "truncate");
     assert_eq!(
         body["messages"][1],
         json!({

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -16,6 +16,18 @@ fn backoff_duration(attempt: usize) -> Duration {
     Duration::from_millis((delay_ms as f64 * jitter) as u64)
 }
 
+fn retryable_http_status(status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 408 | 409 | 429) || status.is_server_error()
+}
+
+fn retry_after_delay(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|seconds| Duration::from_secs(seconds.min(60)))
+}
+
 mod anthropic;
 mod anthropic_stream;
 mod api_key_store;

--- a/crates/nac-core/src/model/responses_stream.rs
+++ b/crates/nac-core/src/model/responses_stream.rs
@@ -99,7 +99,7 @@ impl StreamFold for ResponsesStreamFold<'_> {
 
     fn finish(self) -> Result<Value, StreamFoldError> {
         self.final_response.ok_or_else(|| {
-            StreamFoldError::permanent("SSE stream did not include a final response event")
+            StreamFoldError::retryable("SSE stream did not include a final response event")
         })
     }
 }

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -44,6 +44,25 @@ impl StreamFoldError {
     }
 }
 
+pub(super) fn provider_stream_error(code: Option<&str>, message: &str) -> StreamFoldError {
+    let retryable = code.is_some_and(|code| {
+        matches!(
+            code.to_ascii_lowercase().as_str(),
+            "api_error"
+                | "internal_error"
+                | "overloaded_error"
+                | "rate_limit_error"
+                | "rate_limit_exceeded"
+                | "server_error"
+        )
+    });
+    if retryable {
+        StreamFoldError::retryable(message)
+    } else {
+        StreamFoldError::permanent(message)
+    }
+}
+
 impl fmt::Display for StreamFoldError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(&self.message)
@@ -72,6 +91,14 @@ impl SseError {
         Self {
             message: format!("model stream from {url} failed: {error}"),
             retryable: error.retryable,
+            observable_delta,
+        }
+    }
+
+    fn retryable(message: impl Into<String>, observable_delta: bool) -> Self {
+        Self {
+            message: message.into(),
+            retryable: true,
             observable_delta,
         }
     }
@@ -125,7 +152,7 @@ pub(super) async fn read_sse_response<F: StreamFold>(
 
     while let Some(frame) = reader.next_frame().await {
         let frame = frame.map_err(|error| {
-            SseError::permanent(
+            SseError::retryable(
                 format!("model stream from {url} failed: {error:#}"),
                 fold.has_observable_delta(),
             )
@@ -372,6 +399,14 @@ mod tests {
     #[test]
     fn returns_a_trailing_frame_the_server_left_unterminated() {
         assert_eq!(frames(&["data: [DONE]\n"]), vec!["[DONE]".to_string()]);
+    }
+
+    #[test]
+    fn classifies_only_known_transient_provider_stream_errors() {
+        assert!(provider_stream_error(Some("overloaded_error"), "busy").is_retryable());
+        assert!(provider_stream_error(Some("server_error"), "failed").is_retryable());
+        assert!(!provider_stream_error(Some("insufficient_quota"), "quota").is_retryable());
+        assert!(!provider_stream_error(None, "failed").is_retryable());
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/model/tests/mod.rs
+++ b/crates/nac-core/src/model/tests/mod.rs
@@ -48,3 +48,20 @@ fn backoff_duration_stays_within_jitter_bounds() {
         }
     }
 }
+
+#[test]
+fn retry_policy_covers_transient_statuses_and_bounds_retry_after() {
+    for status in [408, 409, 429, 500, 599] {
+        assert!(retryable_http_status(
+            reqwest::StatusCode::from_u16(status).unwrap()
+        ));
+    }
+    for status in [400, 401, 403, 404, 422] {
+        assert!(!retryable_http_status(
+            reqwest::StatusCode::from_u16(status).unwrap()
+        ));
+    }
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::RETRY_AFTER, "600".parse().unwrap());
+    assert_eq!(retry_after_delay(&headers), Some(Duration::from_secs(60)));
+}


### PR DESCRIPTION
## Summary

Hardens model requests against premature output truncation and expands retry handling for transient provider failures.

## Root cause

Some chat-completions backends were allowed to choose their own output-token defaults. In particular, Arcee models with a missing `max_output_length` were mapped to the conservative 16,384-token fallback, causing long-running threads to terminate much earlier than their context window implied.

Retry handling also covered only network failures, HTTP 429, and 5xx responses. HTTP 408/409 and retryable streaming failures could terminate an otherwise recoverable run.

## Changes

- Send `max_tokens = min(262,144, catalog model limit)` for chat-completions backends.
- Add Together’s context-length truncation guard so a large output allowance does not reject prompts approaching the context limit.
- Give known Arcee passthrough models a large context-aware fallback when `max_output_length` is absent.
- Repair previously cached Arcee overlays containing the old 16,384-token fallback.
- Retry network failures and HTTP 408, 409, 429, and 5xx responses.
- Honor `Retry-After` with a 60-second upper bound.
- Retry transient SSE/provider errors only before output has become visible, preventing duplicate streamed content.
- Apply the same HTTP retry classification to the ChatGPT Codex path.

## Impact

Long-running workers can use substantially more of their model’s available output and context capacity. Temporary provider and streaming failures are more likely to recover without replaying visible output or duplicating content.

Anthropic and OpenAI Responses max-token behavior is unchanged.

## Validation

- All 711 `nac-core` tests pass.
- `cargo check --workspace` passes.
- `git diff --check` passes.
- Fresh DeepSeek V4 Pro orchestration smoke test completed successfully.
- A 15-minute stress test completed four research workers:
  - 131K–152K input tokens per worker
  - 8.6K–12.7K output tokens per worker
  - 53,225-character final synthesis
- No context-window, timeout, transport, or retry-exhaustion failures occurred.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model request shaping and shared retry/stream replay logic across providers. Incorrect retry gating could duplicate streamed output or change failure recovery behavior.
> 
> **Overview**
> Raises chat-completions **output token ceilings** and expands retry coverage so long-running model turns are less likely to truncate early or fail on transient provider errors.
> 
> Chat-completions requests now send `max_tokens = min(catalog limit, 262_144)`. Together also gets `context_length_exceeded_behavior: "truncate"`. Arcee passthrough models without an API output limit get a large context-aware fallback (and cached overlays still carrying the old 16,384 default are repaired on load).
> 
> Retries now cover HTTP **408/409** in addition to 429/5xx, honor `Retry-After` with a **60s cap**, and retry transient SSE/provider stream errors **only before any observable delta** has been forwarded—so recoverable failures can be replayed without duplicating visible output. Incomplete streams are treated as retryable rather than permanent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580aa724fa131ea514f50841341566560b9e0d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->