### PR TITLE
fix(tools): support grep file roots

### DIFF
--- a/crates/nac-core/src/tools/discovery.rs
+++ b/crates/nac-core/src/tools/discovery.rs
@@ -1065,6 +1065,18 @@ struct GrepPlan {
     context: usize,
 }
 
+enum GrepRoot {
+    Directory,
+    File(u64),
+    Diagnostic(Record),
+}
+
+impl GrepRoot {
+    fn contains_descendants(&self) -> bool {
+        matches!(self, Self::Directory)
+    }
+}
+
 pub(crate) async fn execute(tool: &'static str, args: Value, runtime: &ToolRuntime) -> ToolResult {
     if !args.is_object() {
         return error_result(
@@ -1184,14 +1196,16 @@ async fn run_grep(
     }
     roots.sort();
     roots.dedup();
-    let mut minimal_roots = Vec::<String>::new();
+    let mut grep_roots = Vec::<(String, GrepRoot)>::new();
     for root in roots {
-        if minimal_roots.iter().any(|parent| {
-            root == *parent || parent.is_empty() || root.starts_with(&format!("{parent}/"))
+        if grep_roots.iter().any(|(parent, kind)| {
+            kind.contains_descendants()
+                && (root == *parent || parent.is_empty() || root.starts_with(&format!("{parent}/")))
         }) {
             continue;
         }
-        minimal_roots.push(root);
+        let kind = classify_grep_root(fs, &root).await?;
+        grep_roots.push((root, kind));
     }
 
     let globs_value = object.get("globs").cloned().unwrap_or_else(|| json!([]));
@@ -1218,10 +1232,11 @@ async fn run_grep(
     let mut seen = HashSet::new();
     let mut walk_budget = WalkBudget { entries: 0 };
     let mut ignore_state = IgnoreState::new();
-    for root in minimal_roots {
-        let records = walk_root(
+    for (root, kind) in grep_roots {
+        let records = collect_grep_root(
             fs,
             &root,
+            kind,
             common.hidden,
             common.gitignore,
             &mut walk_budget,
@@ -1305,6 +1320,106 @@ async fn run_grep(
     paginate("grep", args, records, common.limit)
 }
 
+async fn classify_grep_root(fs: &mut WorkspaceFs, root: &str) -> SearchResult<GrepRoot> {
+    if root.is_empty() {
+        return Ok(GrepRoot::Directory);
+    }
+
+    if let Some((parent_path, _)) = root.rsplit_once('/') {
+        let mut parent = String::new();
+        for component in parent_path.split('/') {
+            parent = join_path(&parent, component);
+            match fs.path_kind(&parent).await? {
+                EntryKind::Directory => {}
+                EntryKind::Symlink => {
+                    return Ok(GrepRoot::Diagnostic(fs.symlink_diagnostic(&parent).await));
+                }
+                EntryKind::File | EntryKind::Other => {
+                    return Err(SearchError::at(
+                        "not_directory",
+                        "search root ancestor is not a directory",
+                        parent,
+                    ));
+                }
+            }
+        }
+    }
+
+    let Some((kind, size)) = fs.optional_path_metadata(root).await? else {
+        return Err(SearchError::at(
+            "unreadable_path",
+            "search root does not exist",
+            root,
+        ));
+    };
+    match kind {
+        EntryKind::Directory => Ok(GrepRoot::Directory),
+        EntryKind::File => Ok(GrepRoot::File(size)),
+        EntryKind::Symlink => Ok(GrepRoot::Diagnostic(fs.symlink_diagnostic(root).await)),
+        EntryKind::Other => Err(SearchError::at(
+            "not_directory",
+            "search root is not a directory or regular file",
+            root,
+        )),
+    }
+}
+
+async fn collect_grep_root(
+    fs: &mut WorkspaceFs,
+    root: &str,
+    kind: GrepRoot,
+    hidden: bool,
+    gitignore: bool,
+    walk_budget: &mut WalkBudget,
+    ignore_state: &mut IgnoreState,
+    cancellation: &Arc<AtomicBool>,
+) -> SearchResult<Vec<Record>> {
+    match kind {
+        GrepRoot::Directory => {
+            walk_directory_root(
+                fs,
+                root,
+                hidden,
+                gitignore,
+                walk_budget,
+                ignore_state,
+                cancellation,
+            )
+            .await
+        }
+        GrepRoot::Diagnostic(record) => Ok(vec![record]),
+        GrepRoot::File(size) => {
+            if !hidden && is_hidden(root) {
+                return Ok(Vec::new());
+            }
+
+            let mut inherited = Vec::new();
+            let mut records = Vec::new();
+            if gitignore {
+                for ancestor in ancestors_before(root) {
+                    if !ancestor.is_empty() && ignored(fs.root(), &ancestor, true, &inherited) {
+                        return Ok(records);
+                    }
+                    let (layer, diagnostics) = load_ignore(fs, &ancestor, ignore_state).await?;
+                    records.extend(diagnostics);
+                    if let Some(layer) = layer {
+                        inherited.push(layer);
+                    }
+                }
+                if ignored(fs.root(), root, false, &inherited) {
+                    return Ok(records);
+                }
+            }
+            records.push(Record::Entry(json!({
+                "path": root,
+                "kind": "file",
+                "size": size,
+            })));
+            Ok(records)
+        }
+    }
+}
+
 async fn walk_root(
     fs: &mut WorkspaceFs,
     root: &str,
@@ -1314,8 +1429,6 @@ async fn walk_root(
     ignore_state: &mut IgnoreState,
     cancellation: &Arc<AtomicBool>,
 ) -> SearchResult<Vec<Record>> {
-    let mut inherited = Vec::new();
-    let mut records = Vec::new();
     if !root.is_empty() {
         let mut prefix = String::new();
         for component in root.split('/') {
@@ -1323,8 +1436,7 @@ async fn walk_root(
             match fs.path_kind(&prefix).await? {
                 EntryKind::Directory => {}
                 EntryKind::Symlink => {
-                    records.push(fs.symlink_diagnostic(&prefix).await);
-                    return Ok(records);
+                    return Ok(vec![fs.symlink_diagnostic(&prefix).await]);
                 }
                 EntryKind::File | EntryKind::Other => {
                     return Err(SearchError::at(
@@ -1336,6 +1448,29 @@ async fn walk_root(
             }
         }
     }
+    walk_directory_root(
+        fs,
+        root,
+        hidden,
+        gitignore,
+        walk_budget,
+        ignore_state,
+        cancellation,
+    )
+    .await
+}
+
+async fn walk_directory_root(
+    fs: &mut WorkspaceFs,
+    root: &str,
+    hidden: bool,
+    gitignore: bool,
+    walk_budget: &mut WalkBudget,
+    ignore_state: &mut IgnoreState,
+    cancellation: &Arc<AtomicBool>,
+) -> SearchResult<Vec<Record>> {
+    let mut inherited = Vec::new();
+    let mut records = Vec::new();
     if gitignore {
         for ancestor in ancestors_before(root) {
             let (layer, diagnostics) = load_ignore(fs, &ancestor, ignore_state).await?;

--- a/crates/nac-core/src/tools/discovery/tests.rs
+++ b/crates/nac-core/src/tools/discovery/tests.rs
@@ -153,6 +153,82 @@ async fn grep_paginates_every_match_once() {
 }
 
 #[tokio::test]
+async fn grep_accepts_file_roots() {
+    let (runtime, root) = fixture_runtime();
+    let output = parsed(
+        execute(
+            "grep",
+            json!({
+                "pattern": "ExecutionBackend",
+                "regex": false,
+                "roots": ["src/a.rs"]
+            }),
+            &runtime,
+        )
+        .await,
+    );
+    assert_eq!(output["matches"].as_array().expect("matches").len(), 1);
+    assert_eq!(output["matches"][0]["path"], "src/a.rs");
+    assert_eq!(output["matches"][0]["line"], 1);
+
+    fs::create_dir(root.join("blocked")).expect("create ignored file-root fixture");
+    fs::write(root.join("blocked/item.rs"), "ExecutionBackend\n")
+        .expect("write ignored file-root fixture");
+    fs::write(root.join(".gitignore"), "ignored.rs\nblocked/\n").expect("ignore file-root parent");
+    fs::write(root.join("blocked/.gitignore"), "[unterminated\n")
+        .expect("write invalid nested ignore fixture");
+    let ignored = parsed(
+        execute(
+            "grep",
+            json!({
+                "pattern": "ExecutionBackend",
+                "regex": false,
+                "roots": ["blocked/item.rs"]
+            }),
+            &runtime,
+        )
+        .await,
+    );
+    assert!(ignored["matches"].as_array().expect("matches").is_empty());
+    assert!(ignored["errors"].as_array().expect("errors").is_empty());
+
+    fs::write(root.join(".hidden/.gitignore"), "[unterminated\n")
+        .expect("write hidden invalid ignore fixture");
+    let hidden = parsed(
+        execute(
+            "grep",
+            json!({
+                "pattern": "ExecutionBackend",
+                "regex": false,
+                "roots": [".hidden/secret.rs"]
+            }),
+            &runtime,
+        )
+        .await,
+    );
+    assert!(hidden["matches"].as_array().expect("matches").is_empty());
+    assert!(hidden["errors"].as_array().expect("errors").is_empty());
+
+    let invalid_descendant = execute(
+        "grep",
+        json!({
+            "pattern": "ExecutionBackend",
+            "regex": false,
+            "roots": ["src/a.rs", "src/a.rs/child"]
+        }),
+        &runtime,
+    )
+    .await;
+    assert!(invalid_descendant.is_error);
+    assert_eq!(
+        serde_json::from_str::<Value>(&invalid_descendant.content).expect("error JSON")["error"]
+            ["code"],
+        "not_directory"
+    );
+    fs::remove_dir_all(root).expect("remove fixture");
+}
+
+#[tokio::test]
 async fn invalid_patterns_and_outside_roots_are_explicit_errors() {
     let (runtime, root) = fixture_runtime();
     let invalid = execute("glob", json!({"pattern": "["}), &runtime).await;

--- a/crates/nac-core/src/tools/grep.rs
+++ b/crates/nac-core/src/tools/grep.rs
@@ -14,7 +14,7 @@ pub fn definition() -> ToolDefinition {
                 "type": "object",
                 "properties": {
                     "pattern": { "type": "string", "minLength": 1, "maxLength": 65536, "description": "Literal text or regular expression to find" },
-                    "roots": { "type": "array", "items": { "type": "string", "maxLength": 1024 }, "minItems": 1, "maxItems": 32, "description": "Workspace-relative directories to search", "default": ["."] },
+                    "roots": { "type": "array", "items": { "type": "string", "maxLength": 1024 }, "minItems": 1, "maxItems": 32, "description": "Workspace-relative files or directories to search", "default": ["."] },
                     "regex": { "type": "boolean", "description": "Interpret pattern as a regular expression", "default": true },
                     "case": { "type": "string", "enum": ["smart", "sensitive", "insensitive"], "description": "Case matching mode; smart is insensitive only when pattern has no uppercase characters", "default": "smart" },
                     "globs": { "type": "array", "items": { "type": "string", "maxLength": 1024 }, "maxItems": 128, "description": "Optional workspace-relative path glob filters" },


### PR DESCRIPTION
## Description

**What.** Allows the native `grep` tool to search regular files supplied in `roots`, while preserving directory-root behavior.

**Why.** `grep` previously routed every root through the directory walker, so an exact file path failed with `not_directory`.

The discovery path now classifies each normalized root once. Directories retain recursive traversal, regular files enter the existing bounded content-search pipeline, and only directories subsume descendant roots during deduplication. File roots preserve hidden-path, gitignore, generated-directory, symlink, confinement, and resource-limit behavior. The public tool schema now advertises files or directories.

## Usage

Search one exact workspace file:

```json
{
  "pattern": "ExecutionBackend",
  "regex": false,
  "roots": ["src/a.rs"]
}
```

## Bug Evidence

Before this change, the regression test failed with:

```text
unexpected tool error: {"error":{"code":"not_directory","message":"search root is not a directory","path":"src/a.rs"}}
```

The root cause was `run_grep` sending file roots to the directory-only `walk_root` path. `classify_grep_root` now distinguishes directories, regular files, symlinks, and unsupported paths before collection, and the focused regression passes.

## Changelog

- Supports exact regular-file paths in native `grep` `roots`.
- Preserves filtering and confinement semantics for direct file roots.

## Validation

`cargo test -p nac-core grep_accepts_file_roots` passes, covering a visible file, hidden and ignored file parents with invalid nested ignore files, and a file root that must not subsume an invalid descendant. `cargo test -p nac-core tools::discovery::tests -- --test-threads=1` passes 34 tests with 3 ignored. At default test parallelism, the unrelated `aborting_native_search_stops_promptly` timing-sensitive test timed out; that test passes in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches grep root classification, gitignore/hidden filtering, and path confinement for discovery, so incorrect handling could skip files or weaken search boundaries. Scope is focused and covered by regression tests.
> 
> **Overview**
> **Allows `grep` `roots` to target exact regular files**, not just directories. Previously every root went through the directory walker and failed with `not_directory`.
> 
> Roots are now classified once as directory, file, or diagnostic. Directories still recurse; files enter the existing content-search path while keeping gitignore, hidden-path, symlink, and confinement behavior. Only directory roots subsume descendants during deduplication.
> 
> The public schema now documents files or directories, with a regression covering visible, ignored, and hidden file roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c7b100cf44155d2454c175d3b9bd6af17b6f95e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->