### PR TITLE
fixes valid reasoning effort by cross-checking supported reasoning efforts for models

### DIFF
--- a/crates/nac-catalog-gen/overrides.toml
+++ b/crates/nac-catalog-gen/overrides.toml
@@ -38,9 +38,11 @@
 # responses/completions adapters append "/responses" and "/chat/completions"
 # to the values below as-is.
 
-# deepseek: none/low/high/xhigh for every model; xhigh is the wire tier "max".
+# deepseek: none/low/high/max for every model — the V4 API's real effort
+# levels (official docs: medium→high and xhigh→high are compatibility
+# aliases, not offered as distinct tiers).
 [providers."deepseek-chat"]
-default_thinking_levels = { none = "none", low = "low", high = "high", xhigh = "max" }
+default_thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
 
 # fireworks: none through high, sent verbatim.
 [providers."fireworks-chat"]
@@ -49,12 +51,13 @@ default_thinking_levels = { none = "none", low = "low", medium = "medium", high 
 # Post-S4 per-model extensions for Fireworks: provider docs show
 # model-specific effort tiers that the uniform pre-S4 matrix did not
 # capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
-# rejects `none`); DeepSeek V4 supports an `xhigh` tier (wire "max")
-# above high; GLM 5.2 supports only `none`, `high`, and `max` (the
-# model's chat template maps anything other than `high` to `max`);
-# MiniMax M3 uses a 3-mode toggle (enabled/adaptive/disabled), mapped
-# here as `none` (disabled) and `max` (enabled). Dated snapshots
-# inherit the family override.
+# rejects `none`); DeepSeek V4 uses the 4 real effort levels (none,
+# low, high, max — official docs confirm medium→high and xhigh→high
+# are compatibility aliases); GLM 5.2 supports only `none`, `high`,
+# and `max` (the model's chat template maps anything other than `high`
+# to `max`); MiniMax M3 uses a 3-mode toggle (enabled/adaptive/
+# disabled), mapped here as `none` (disabled) and `max` (enabled).
+# Dated snapshots inherit the family override.
 
 # GPT-OSS models: reasoning-only, `none` is rejected by the API.
 [providers."fireworks-chat".models."accounts/fireworks/models/gpt-oss-120b"]
@@ -72,15 +75,16 @@ thinking_levels = { low = "low", medium = "medium", high = "high" }
 [providers."fireworks-chat".models."accounts/fireworks/models/minimax-m3"]
 thinking_levels = { none = "none", max = "max" }
 
-# DeepSeek V4 models: support `xhigh` (wire "max") above high.
+# DeepSeek V4 models: 4 real effort levels (none/low/high/max); official
+# docs confirm medium→high and xhigh→high are compatibility aliases.
 [providers."fireworks-chat".models."accounts/fireworks/models/deepseek-v4-flash"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
+thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
 
 [providers."fireworks-chat".models."accounts/fireworks/models/deepseek-v4-flash-0731"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
+thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
 
 [providers."fireworks-chat".models."accounts/fireworks/models/deepseek-v4-pro"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
+thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
 
 # GLM 5.2 models (incl. fast router): native levels are `high` and `max`
 # (the chat template maps anything other than `high` to `max`); `none`
@@ -107,10 +111,13 @@ default_base_url = "https://api.together.xyz/v1"
 
 # Post-S4 per-model extensions for Together: provider docs show
 # model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
-# and `max`; DeepSeek V4 Pro supports `max` above high; MiniMax M3
-# uses a 3-mode toggle mapped as `none` (disabled) and `max` (enabled);
-# non-reasoning models (Qwen2.5-7B, Qwen3.7-Max, Llama-3.3-70B) accept
-# no explicit effort levels. Dated snapshots inherit the family override.
+# and `max`; DeepSeek V4 models use the 4 real effort levels (none,
+# low, high, max — official docs confirm medium→high and xhigh→high
+# are compatibility aliases, and Together normalizes them the same
+# way); MiniMax M3 uses a 3-mode toggle mapped as `none` (disabled)
+# and `max` (enabled); non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
+# Llama-3.3-70B) accept no explicit effort levels. Dated snapshots
+# inherit the family override.
 
 # GLM-5.2: fix context window to 512K (models.dev underreports);
 # native levels are `high` and `max`; `none` disables thinking.
@@ -118,9 +125,13 @@ default_base_url = "https://api.together.xyz/v1"
 context_window = 524288
 thinking_levels = { none = "none", high = "high", max = "max" }
 
-# DeepSeek V4 Pro: support `max` above high.
+# DeepSeek V4 Pro: 4 real effort levels (none/low/high/max).
 [providers."together-chat".models."deepseek-ai/DeepSeek-V4-Pro"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", max = "max" }
+thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
+
+# DeepSeek V4 Flash-0731: 4 real effort levels (none/low/high/max).
+[providers."together-chat".models."deepseek-ai/DeepSeek-V4-Flash-0731"]
+thinking_levels = { none = "none", low = "low", high = "high", max = "max" }
 
 # MiniMax M3: uses a 3-mode thinking toggle (enabled/adaptive/disabled),
 # mapped as `none` (disabled) and `max` (enabled).

--- a/crates/nac-catalog-gen/overrides.toml
+++ b/crates/nac-catalog-gen/overrides.toml
@@ -48,9 +48,13 @@ default_thinking_levels = { none = "none", low = "low", medium = "medium", high 
 
 # Post-S4 per-model extensions for Fireworks: provider docs show
 # model-specific effort tiers that the uniform pre-S4 matrix did not
-# capture. GPT-OSS and MiniMax models are reasoning-only (the API
-# rejects `none`); DeepSeek V4 and GLM 5.2 support an `xhigh` tier
-# (wire "max") above high. Dated snapshots inherit the family override.
+# capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
+# rejects `none`); DeepSeek V4 supports an `xhigh` tier (wire "max")
+# above high; GLM 5.2 supports only `none`, `high`, and `max` (the
+# model's chat template maps anything other than `high` to `max`);
+# MiniMax M3 uses a 3-mode toggle (enabled/adaptive/disabled), mapped
+# here as `none` (disabled) and `max` (enabled). Dated snapshots
+# inherit the family override.
 
 # GPT-OSS models: reasoning-only, `none` is rejected by the API.
 [providers."fireworks-chat".models."accounts/fireworks/models/gpt-oss-120b"]
@@ -59,12 +63,14 @@ thinking_levels = { low = "low", medium = "medium", high = "high" }
 [providers."fireworks-chat".models."accounts/fireworks/models/gpt-oss-20b"]
 thinking_levels = { low = "low", medium = "medium", high = "high" }
 
-# MiniMax models: reasoning-only, `none` is rejected by the API.
+# MiniMax M2P7: reasoning-only, `none` is rejected by the API.
 [providers."fireworks-chat".models."accounts/fireworks/models/minimax-m2p7"]
 thinking_levels = { low = "low", medium = "medium", high = "high" }
 
+# MiniMax M3: uses a 3-mode thinking toggle (enabled/adaptive/disabled),
+# mapped as `none` (disabled) and `max` (enabled).
 [providers."fireworks-chat".models."accounts/fireworks/models/minimax-m3"]
-thinking_levels = { low = "low", medium = "medium", high = "high" }
+thinking_levels = { none = "none", max = "max" }
 
 # DeepSeek V4 models: support `xhigh` (wire "max") above high.
 [providers."fireworks-chat".models."accounts/fireworks/models/deepseek-v4-flash"]
@@ -76,12 +82,22 @@ thinking_levels = { none = "none", low = "low", medium = "medium", high = "high"
 [providers."fireworks-chat".models."accounts/fireworks/models/deepseek-v4-pro"]
 thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
 
-# GLM 5.2 models (incl. fast router): support `xhigh` (wire "max").
+# GLM 5.2 models (incl. fast router): native levels are `high` and `max`
+# (the chat template maps anything other than `high` to `max`); `none`
+# disables thinking via `enable_thinking=false`.
 [providers."fireworks-chat".models."accounts/fireworks/models/glm-5p2"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
+thinking_levels = { none = "none", high = "high", max = "max" }
 
 [providers."fireworks-chat".models."accounts/fireworks/routers/glm-5p2-fast"]
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", xhigh = "max" }
+thinking_levels = { none = "none", high = "high", max = "max" }
+
+# Kimi K3 models: thinking is always enabled (no `none`, no `medium`);
+# supports `low`, `high`, and `max` effort tiers.
+[providers."fireworks-chat".models."accounts/fireworks/models/kimi-k3"]
+thinking_levels = { low = "low", high = "high", max = "max" }
+
+[providers."fireworks-chat".models."accounts/fireworks/routers/kimi-k3-fast"]
+thinking_levels = { low = "low", high = "high", max = "max" }
 
 # together: none through high, sent verbatim. Endpoint default hand-seeded
 # (models.dev carries no `api`): the adapter appends "/chat/completions".
@@ -90,19 +106,31 @@ default_thinking_levels = { none = "none", low = "low", medium = "medium", high 
 default_base_url = "https://api.together.xyz/v1"
 
 # Post-S4 per-model extensions for Together: provider docs show
-# model-specific effort tiers. GLM-5.2 and DeepSeek V4 Pro support
-# `max` above high; non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
-# Llama-3.3-70B) accept no explicit effort levels. Dated snapshots
-# inherit the family override.
+# model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
+# and `max`; DeepSeek V4 Pro supports `max` above high; MiniMax M3
+# uses a 3-mode toggle mapped as `none` (disabled) and `max` (enabled);
+# non-reasoning models (Qwen2.5-7B, Qwen3.7-Max, Llama-3.3-70B) accept
+# no explicit effort levels. Dated snapshots inherit the family override.
 
-# GLM-5.2: fix context window to 512K (models.dev underreports) + add `max`.
+# GLM-5.2: fix context window to 512K (models.dev underreports);
+# native levels are `high` and `max`; `none` disables thinking.
 [providers."together-chat".models."zai-org/GLM-5.2"]
 context_window = 524288
-thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", max = "max" }
+thinking_levels = { none = "none", high = "high", max = "max" }
 
 # DeepSeek V4 Pro: support `max` above high.
 [providers."together-chat".models."deepseek-ai/DeepSeek-V4-Pro"]
 thinking_levels = { none = "none", low = "low", medium = "medium", high = "high", max = "max" }
+
+# MiniMax M3: uses a 3-mode thinking toggle (enabled/adaptive/disabled),
+# mapped as `none` (disabled) and `max` (enabled).
+[providers."together-chat".models."MiniMaxAI/MiniMax-M3"]
+thinking_levels = { none = "none", max = "max" }
+
+# Kimi K3: thinking is always enabled (no `none`, no `medium`);
+# supports `low`, `high`, and `max` effort tiers.
+[providers."together-chat".models."moonshotai/Kimi-K3"]
+thinking_levels = { low = "low", high = "high", max = "max" }
 
 # Non-reasoning models: no explicit effort levels accepted.
 [providers."together-chat".models."Qwen/Qwen2.5-7B-Instruct-Turbo"]

--- a/crates/nac-catalog-gen/overrides.toml
+++ b/crates/nac-catalog-gen/overrides.toml
@@ -48,16 +48,8 @@ default_thinking_levels = { none = "none", low = "low", high = "high", max = "ma
 [providers."fireworks-chat"]
 default_thinking_levels = { none = "none", low = "low", medium = "medium", high = "high" }
 
-# Post-S4 per-model extensions for Fireworks: provider docs show
-# model-specific effort tiers that the uniform pre-S4 matrix did not
-# capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
-# rejects `none`); DeepSeek V4 uses the 4 real effort levels (none,
-# low, high, max — official docs confirm medium→high and xhigh→high
-# are compatibility aliases); GLM 5.2 supports only `none`, `high`,
-# and `max` (the model's chat template maps anything other than `high`
-# to `max`); MiniMax M3 uses a 3-mode toggle (enabled/adaptive/
-# disabled), mapped here as `none` (disabled) and `max` (enabled).
-# Dated snapshots inherit the family override.
+# Model-specific tiers below supersede provider defaults; dated snapshots
+# inherit their family override.
 
 # GPT-OSS models: reasoning-only, `none` is rejected by the API.
 [providers."fireworks-chat".models."accounts/fireworks/models/gpt-oss-120b"]
@@ -109,15 +101,8 @@ thinking_levels = { low = "low", high = "high", max = "max" }
 default_thinking_levels = { none = "none", low = "low", medium = "medium", high = "high" }
 default_base_url = "https://api.together.xyz/v1"
 
-# Post-S4 per-model extensions for Together: provider docs show
-# model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
-# and `max`; DeepSeek V4 models use the 4 real effort levels (none,
-# low, high, max — official docs confirm medium→high and xhigh→high
-# are compatibility aliases, and Together normalizes them the same
-# way); MiniMax M3 uses a 3-mode toggle mapped as `none` (disabled)
-# and `max` (enabled); non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
-# Llama-3.3-70B) accept no explicit effort levels. Dated snapshots
-# inherit the family override.
+# Model-specific tiers below supersede provider defaults; dated snapshots
+# inherit their family override.
 
 # GLM-5.2: fix context window to 512K (models.dev underreports);
 # native levels are `high` and `max`; `none` disables thinking.

--- a/crates/nac-core/src/model/catalog.rs
+++ b/crates/nac-core/src/model/catalog.rs
@@ -26,11 +26,11 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock, RwLockReadGuard};
 
+mod anthropic_overlay;
+mod arcee_overlay;
 mod auth_status;
 #[cfg(test)]
 mod auth_status_tests;
-mod anthropic_overlay;
-mod arcee_overlay;
 mod data;
 mod overlay;
 #[cfg(test)]
@@ -454,14 +454,7 @@ pub fn api_listing() -> ModelListing {
                 models: provider_catalog
                     .models
                     .values()
-                    .filter(|metadata| {
-                        matches!(
-                            metadata.source,
-                            ModelSource::Baseline
-                                | ModelSource::Overlay
-                                | ModelSource::UserOverride
-                        )
-                    })
+                    .filter(|metadata| metadata.source.is_authoritative())
                     .map(|metadata| ModelEntry {
                         id: metadata.id.clone(),
                         display_name: metadata.display_name.clone(),

--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -404,18 +404,26 @@ fn parse_pricing_rate(value: Option<&str>) -> f64 {
 /// model, which rejects all `reasoning_effort` values).
 fn passthrough_effort_map(model_id: &str) -> Option<super::ThinkingLevelMap> {
     let entries: &[(ReasoningEffort, &str)] = match model_id {
-        "deepseek-ai/deepseek-v4-pro" | "deepseek/deepseek-v4-flash-latest" | "zai-org/glm-5.2" => &[
+        "deepseek-ai/deepseek-v4-pro" | "deepseek/deepseek-v4-flash-latest" => &[
             (ReasoningEffort::None, "none"),
             (ReasoningEffort::Low, "low"),
             (ReasoningEffort::Medium, "medium"),
             (ReasoningEffort::High, "high"),
             (ReasoningEffort::Xhigh, "max"),
         ],
-        "moonshotai/kimi-k3" | "minimaxai/minimax-m3" => &[
+        "zai-org/glm-5.2" => &[
             (ReasoningEffort::None, "none"),
-            (ReasoningEffort::Low, "low"),
-            (ReasoningEffort::Medium, "medium"),
             (ReasoningEffort::High, "high"),
+            (ReasoningEffort::Max, "max"),
+        ],
+        "moonshotai/kimi-k3" => &[
+            (ReasoningEffort::Low, "low"),
+            (ReasoningEffort::High, "high"),
+            (ReasoningEffort::Max, "max"),
+        ],
+        "minimaxai/minimax-m3" => &[
+            (ReasoningEffort::None, "none"),
+            (ReasoningEffort::Max, "max"),
         ],
         _ => return None,
     };

--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -396,9 +396,9 @@ fn parse_pricing_rate(value: Option<&str>) -> f64 {
 /// Effort map for known arcee passthrough models. The arcee API's
 /// `supported_reasoning_efforts` is always null, so the API-derived map is
 /// always empty. These models pass through to the same underlying models
-/// served by Fireworks/Together, and the arcee API accepts `reasoning_effort`
-/// for all of them (confirmed via API testing). The maps match the union of
-/// Fireworks/Together effort levels for each model.
+/// served by Fireworks/Together, but the arcee API accepts only a subset of
+/// the effort levels that the upstream providers accept (confirmed via API
+/// testing). The maps reflect what the arcee API actually honors.
 ///
 /// Returns `None` for unknown models and trinity-large-thinking (arcee's own
 /// model, which rejects all `reasoning_effort` values).
@@ -406,10 +406,8 @@ fn passthrough_effort_map(model_id: &str) -> Option<super::ThinkingLevelMap> {
     let entries: &[(ReasoningEffort, &str)] = match model_id {
         "deepseek-ai/deepseek-v4-pro" | "deepseek/deepseek-v4-flash-latest" => &[
             (ReasoningEffort::None, "none"),
-            (ReasoningEffort::Low, "low"),
-            (ReasoningEffort::Medium, "medium"),
             (ReasoningEffort::High, "high"),
-            (ReasoningEffort::Xhigh, "max"),
+            (ReasoningEffort::Max, "max"),
         ],
         "zai-org/glm-5.2" => &[
             (ReasoningEffort::None, "none"),

--- a/crates/nac-core/src/model/catalog/data/catalog.json
+++ b/crates/nac-core/src/model/catalog/data/catalog.json
@@ -226,8 +226,8 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "deepseek-v4-pro": {
@@ -244,8 +244,8 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         }
       }
@@ -268,9 +268,8 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/models/deepseek-v4-flash-0731": {
@@ -287,9 +286,8 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/models/deepseek-v4-pro": {
@@ -306,9 +304,8 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/models/glm-5p2": {
@@ -1260,7 +1257,7 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
+            "max": "max",
             "none": "none"
           }
         },
@@ -1279,7 +1276,6 @@
             "high": "high",
             "low": "low",
             "max": "max",
-            "medium": "medium",
             "none": "none"
           }
         },

--- a/crates/nac-core/src/model/catalog/data/catalog.json
+++ b/crates/nac-core/src/model/catalog/data/catalog.json
@@ -324,10 +324,8 @@
           "reasoning": true,
           "thinking_level_map": {
             "high": "high",
-            "low": "low",
-            "medium": "medium",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/models/gpt-oss-120b": {
@@ -414,8 +412,7 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none"
+            "max": "max"
           }
         },
         "accounts/fireworks/models/minimax-m2p7": {
@@ -447,9 +444,8 @@
           },
           "reasoning": true,
           "thinking_level_map": {
-            "high": "high",
-            "low": "low",
-            "medium": "medium"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/models/qwen3p7-plus": {
@@ -483,10 +479,8 @@
           "reasoning": true,
           "thinking_level_map": {
             "high": "high",
-            "low": "low",
-            "medium": "medium",
-            "none": "none",
-            "xhigh": "max"
+            "max": "max",
+            "none": "none"
           }
         },
         "accounts/fireworks/routers/kimi-k2p6-fast": {
@@ -557,8 +551,7 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none"
+            "max": "max"
           }
         }
       }
@@ -1187,9 +1180,7 @@
           },
           "reasoning": true,
           "thinking_level_map": {
-            "high": "high",
-            "low": "low",
-            "medium": "medium",
+            "max": "max",
             "none": "none"
           }
         },
@@ -1373,8 +1364,7 @@
           "thinking_level_map": {
             "high": "high",
             "low": "low",
-            "medium": "medium",
-            "none": "none"
+            "max": "max"
           }
         },
         "nvidia/nemotron-3-ultra-550b-a55b": {
@@ -1462,9 +1452,7 @@
           "reasoning": true,
           "thinking_level_map": {
             "high": "high",
-            "low": "low",
             "max": "max",
-            "medium": "medium",
             "none": "none"
           }
         }

--- a/crates/nac-core/src/model/catalog/data/catalog.manifest.json
+++ b/crates/nac-core/src/model/catalog/data/catalog.manifest.json
@@ -1,6 +1,6 @@
 {
-  "sha256": "0e8c2b5e47551dd2396ec56fea0ca435b89187337b8703407fce7ca743562320",
-  "generated_at": "2026-08-12T20:40:01Z",
+  "sha256": "479502f34bb3ed73fe73f4cb6b10db94c848ca1387f8c1f2086d010574d70e38",
+  "generated_at": "2026-08-12T21:05:54Z",
   "models_dev_url": "crates/nac-catalog-gen/fixtures/models-dev-api.json",
   "models_dev_etag": null,
   "model_counts": {

--- a/crates/nac-core/src/model/catalog/data/catalog.manifest.json
+++ b/crates/nac-core/src/model/catalog/data/catalog.manifest.json
@@ -1,6 +1,6 @@
 {
-  "sha256": "7c169fb4435cad3ce300df745418d10f78f145a590eec3b5c20fcb13feeda048",
-  "generated_at": "2026-08-11T05:47:21Z",
+  "sha256": "0e8c2b5e47551dd2396ec56fea0ca435b89187337b8703407fce7ca743562320",
+  "generated_at": "2026-08-12T20:40:01Z",
   "models_dev_url": "crates/nac-catalog-gen/fixtures/models-dev-api.json",
   "models_dev_etag": null,
   "model_counts": {

--- a/crates/nac-core/src/model/catalog/data/catalog.manifest.json
+++ b/crates/nac-core/src/model/catalog/data/catalog.manifest.json
@@ -1,6 +1,6 @@
 {
   "sha256": "479502f34bb3ed73fe73f4cb6b10db94c848ca1387f8c1f2086d010574d70e38",
-  "generated_at": "2026-08-12T21:05:54Z",
+  "generated_at": "2026-08-13T00:35:55Z",
   "models_dev_url": "crates/nac-catalog-gen/fixtures/models-dev-api.json",
   "models_dev_etag": null,
   "model_counts": {

--- a/crates/nac-core/src/model/catalog/overlay_tests.rs
+++ b/crates/nac-core/src/model/catalog/overlay_tests.rs
@@ -118,7 +118,7 @@ async fn refresh_fetches_maps_writes_overlay_and_reloads_catalog() {
     assert_eq!(entry["context_window"], 999_000);
     assert_eq!(entry["max_tokens"], 77_000);
     // The thinking map derives from the deepseek seed default (the matrix row).
-    assert_eq!(entry["thinking_level_map"]["xhigh"], "max");
+    assert_eq!(entry["thinking_level_map"]["max"], "max");
     let generated_at = written["generated_at"].as_str().unwrap();
     assert!(is_utc_iso8601(generated_at), "{generated_at}");
     let baseline_generated_at = data::parse_manifest().unwrap().generated_at;
@@ -152,7 +152,7 @@ async fn refresh_fetches_maps_writes_overlay_and_reloads_catalog() {
     assert_eq!(
         metadata
             .thinking_level_map
-            .wire_value(ReasoningEffort::Xhigh),
+            .wire_value(ReasoningEffort::Max),
         Some("max")
     );
     assert!(metadata

--- a/crates/nac-core/src/model/catalog/seed.rs
+++ b/crates/nac-core/src/model/catalog/seed.rs
@@ -35,13 +35,15 @@ fn levels(entries: &[(ReasoningEffort, &str)]) -> ThinkingLevelMap {
     )
 }
 
-/// deepseek-chat: none/low/high/xhigh; xhigh is the wire-level tier `max`.
+/// deepseek-chat: none/low/high/max — the V4 API's real effort levels
+/// (official docs: medium→high and xhigh→high are compatibility aliases,
+/// not offered as distinct tiers).
 fn deepseek_levels() -> ThinkingLevelMap {
     levels(&[
         (ReasoningEffort::None, "none"),
         (ReasoningEffort::Low, "low"),
         (ReasoningEffort::High, "high"),
-        (ReasoningEffort::Xhigh, "max"),
+        (ReasoningEffort::Max, "max"),
     ])
 }
 

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -129,32 +129,56 @@ fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEf
 
 /// Post-S4 per-model extensions for Fireworks: provider docs show
 /// model-specific effort tiers that the uniform pre-S4 matrix did not
-/// capture. GPT-OSS and MiniMax models are reasoning-only (the API
-/// rejects `none`); DeepSeek V4 and GLM 5.2 support an `xhigh` tier
-/// (wire "max") above high. Unknown models and all other known models
-/// keep the pre-S4 uniform row (none/low/medium/high).
+/// capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
+/// rejects `none`); DeepSeek V4 supports an `xhigh` tier (wire "max")
+/// above high; GLM 5.2 supports only `none`, `high`, and `max`; MiniMax
+/// M3 uses a 3-mode toggle mapped as `none` (disabled) and `max`
+/// (enabled). Unknown models and all other known models keep the
+/// pre-S4 uniform row (none/low/medium/high).
 fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
     // GPT-OSS models: reasoning-only, `none` is rejected by the API.
     let gpt_oss = pre_s4_anthropic_family(model, "accounts/fireworks/models/gpt-oss-120b")
         || pre_s4_anthropic_family(model, "accounts/fireworks/models/gpt-oss-20b");
-    // MiniMax models: reasoning-only, `none` is rejected by the API.
-    let minimax = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m2p7")
-        || pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m3");
+    // MiniMax M2P7: reasoning-only, `none` is rejected by the API.
+    let minimax_m2p7 = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m2p7");
+    // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
+    // `max` (enabled).
+    let minimax_m3 = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m3");
     // DeepSeek V4 models: support `xhigh` (wire "max") above high.
     let deepseek_v4 =
         pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash")
             || pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash-0731")
             || pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-pro");
-    // GLM 5.2 models (incl. fast router): support `xhigh` (wire "max").
+    // GLM 5.2 models (incl. fast router): native levels are `high` and
+    // `max`; `none` disables thinking.
     let glm = pre_s4_anthropic_family(model, "accounts/fireworks/models/glm-5p2")
         || pre_s4_anthropic_family(model, "accounts/fireworks/routers/glm-5p2-fast");
+    // Kimi K3 models (incl. fast router): thinking is always enabled
+    // (no `none`, no `medium`); supports `low`, `high`, and `max`.
+    let kimi_k3 = pre_s4_anthropic_family(model, "accounts/fireworks/models/kimi-k3")
+        || pre_s4_anthropic_family(model, "accounts/fireworks/routers/kimi-k3-fast");
 
-    if gpt_oss || minimax {
+    if kimi_k3 {
+        matches!(
+            effort,
+            ReasoningEffort::Low | ReasoningEffort::High | ReasoningEffort::Max
+        )
+    } else if glm {
+        matches!(
+            effort,
+            ReasoningEffort::None | ReasoningEffort::High | ReasoningEffort::Max
+        )
+    } else if minimax_m3 {
+        matches!(
+            effort,
+            ReasoningEffort::None | ReasoningEffort::Max
+        )
+    } else if gpt_oss || minimax_m2p7 {
         matches!(
             effort,
             ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High
         )
-    } else if deepseek_v4 || glm {
+    } else if deepseek_v4 {
         matches!(
             effort,
             ReasoningEffort::None
@@ -177,23 +201,46 @@ fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
 }
 
 /// Post-S4 per-model extensions for Together: provider docs show
-/// model-specific effort tiers. GLM-5.2 and DeepSeek V4 Pro support
-/// `max` above high; non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
-/// Llama-3.3-70B) accept no explicit effort levels. Unknown models
-/// and all other known models keep the pre-S4 uniform row
-/// (none/low/medium/high).
+/// model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
+/// and `max`; DeepSeek V4 Pro supports `max` above high; MiniMax M3
+/// uses a 3-mode toggle mapped as `none` (disabled) and `max` (enabled);
+/// non-reasoning models (Qwen2.5-7B, Qwen3.7-Max, Llama-3.3-70B) accept
+/// no explicit effort levels. Unknown models and all other known models
+/// keep the pre-S4 uniform row (none/low/medium/high).
 fn together_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
     // Non-reasoning models: no explicit effort levels accepted.
     let non_reasoning = model == "Qwen/Qwen2.5-7B-Instruct-Turbo"
         || model == "Qwen/Qwen3.7-Max"
         || model == "meta-llama/Llama-3.3-70B-Instruct-Turbo";
-    // GLM-5.2 and DeepSeek V4 Pro: support `max` above high.
-    let max_tier = pre_s4_anthropic_family(model, "zai-org/GLM-5.2")
-        || pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Pro");
+    // GLM-5.2: native levels are `high` and `max`; `none` disables thinking.
+    let glm = pre_s4_anthropic_family(model, "zai-org/GLM-5.2");
+    // DeepSeek V4 Pro: support `max` above high.
+    let deepseek_v4_pro = pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Pro");
+    // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
+    // `max` (enabled).
+    let minimax_m3 = pre_s4_anthropic_family(model, "MiniMaxAI/MiniMax-M3");
+    // Kimi K3: thinking is always enabled (no `none`, no `medium`);
+    // supports `low`, `high`, and `max` effort tiers.
+    let kimi_k3 = pre_s4_anthropic_family(model, "moonshotai/Kimi-K3");
 
-    if non_reasoning {
+    if kimi_k3 {
+        matches!(
+            effort,
+            ReasoningEffort::Low | ReasoningEffort::High | ReasoningEffort::Max
+        )
+    } else if glm {
+        matches!(
+            effort,
+            ReasoningEffort::None | ReasoningEffort::High | ReasoningEffort::Max
+        )
+    } else if minimax_m3 {
+        matches!(
+            effort,
+            ReasoningEffort::None | ReasoningEffort::Max
+        )
+    } else if non_reasoning {
         false
-    } else if max_tier {
+    } else if deepseek_v4_pro {
         matches!(
             effort,
             ReasoningEffort::None

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -69,17 +69,8 @@ fn unknown_models_clone_provider_defaults_with_fallback_limits() {
     }
 }
 
-/// Independent transcription of the pre-S4 `backend.rs` validation matrix,
-/// with post-S4 extensions: `Max` effort for GPT-5.6 models (OpenAI docs
-/// confirm GPT-5.6-only), per-model effort tiers for Fireworks and Together
-/// (provider docs show model-specific behavior the uniform pre-S4 matrix
-/// did not capture), and DeepSeek V4 effort levels updated to the 4 real
-/// levels (none/low/high/max — official docs confirm medium→high and
-/// xhigh→high are compatibility aliases). Since S4,
-/// `validate_model_reasoning_effort` itself reads the catalog maps; the
-/// matrix guards compare against this hand-written reference so they keep
-/// proving the data reproduces the historical behavior instead of vacuously
-/// comparing the map against itself.
+/// Independent transcription of the stable validation matrix. Provider-specific
+/// corrections are covered separately by `corrected_provider_effort_maps`.
 fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEffort) -> bool {
     match provider {
         BackendKind::DeepSeekChat => matches!(
@@ -89,21 +80,17 @@ fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEf
                 | ReasoningEffort::High
                 | ReasoningEffort::Max
         ),
-        BackendKind::FireworksChat => fireworks_matrix_accepts(model, effort),
-        BackendKind::TogetherChat => together_matrix_accepts(model, effort),
+        BackendKind::FireworksChat | BackendKind::TogetherChat => matches!(
+            effort,
+            ReasoningEffort::None
+                | ReasoningEffort::Low
+                | ReasoningEffort::Medium
+                | ReasoningEffort::High
+        ),
         BackendKind::OpenAiResponses | BackendKind::ChatGptCodexResponses => {
-            // `max` is a post-S4 addition: only GPT-5.6 models support it
-            // (OpenAI docs confirm GPT-5.6-only). Unknown models and
-            // non-5.6 models stay at the pre-S4 six levels.
-            if effort == ReasoningEffort::Max {
-                model.starts_with("gpt-5.6")
-            } else {
-                true
-            }
+            effort != ReasoningEffort::Max || model.starts_with("gpt-5.6")
         }
         BackendKind::AnthropicMessages => {
-            // `none` (omission) was safe for every family, including models
-            // whose adaptive thinking is always on.
             if effort == ReasoningEffort::None {
                 return true;
             }
@@ -121,150 +108,10 @@ fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEf
                     ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High
                 )
             } else {
-                // Older and unknown models stayed conservative.
                 false
             }
         }
         BackendKind::ArceeAuth | BackendKind::ArceeApi => false,
-    }
-}
-
-/// Post-S4 per-model extensions for Fireworks: provider docs show
-/// model-specific effort tiers that the uniform pre-S4 matrix did not
-/// capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
-/// rejects `none`); DeepSeek V4 uses the 4 real effort levels (none,
-/// low, high, max — official docs confirm medium→high and xhigh→high
-/// are compatibility aliases); GLM 5.2 supports only `none`, `high`,
-/// and `max`; MiniMax M3 uses a 3-mode toggle mapped as `none`
-/// (disabled) and `max` (enabled). Unknown models and all other known
-/// models keep the pre-S4 uniform row (none/low/medium/high).
-fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
-    // GPT-OSS models: reasoning-only, `none` is rejected by the API.
-    let gpt_oss = pre_s4_anthropic_family(model, "accounts/fireworks/models/gpt-oss-120b")
-        || pre_s4_anthropic_family(model, "accounts/fireworks/models/gpt-oss-20b");
-    // MiniMax M2P7: reasoning-only, `none` is rejected by the API.
-    let minimax_m2p7 = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m2p7");
-    // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
-    // `max` (enabled).
-    let minimax_m3 = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m3");
-    // DeepSeek V4 models: 4 real effort levels (none/low/high/max).
-    let deepseek_v4 =
-        pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash")
-            || pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash-0731")
-            || pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-pro");
-    // GLM 5.2 models (incl. fast router): native levels are `high` and
-    // `max`; `none` disables thinking.
-    let glm = pre_s4_anthropic_family(model, "accounts/fireworks/models/glm-5p2")
-        || pre_s4_anthropic_family(model, "accounts/fireworks/routers/glm-5p2-fast");
-    // Kimi K3 models (incl. fast router): thinking is always enabled
-    // (no `none`, no `medium`); supports `low`, `high`, and `max`.
-    let kimi_k3 = pre_s4_anthropic_family(model, "accounts/fireworks/models/kimi-k3")
-        || pre_s4_anthropic_family(model, "accounts/fireworks/routers/kimi-k3-fast");
-
-    if kimi_k3 {
-        matches!(
-            effort,
-            ReasoningEffort::Low | ReasoningEffort::High | ReasoningEffort::Max
-        )
-    } else if glm {
-        matches!(
-            effort,
-            ReasoningEffort::None | ReasoningEffort::High | ReasoningEffort::Max
-        )
-    } else if minimax_m3 {
-        matches!(
-            effort,
-            ReasoningEffort::None | ReasoningEffort::Max
-        )
-    } else if gpt_oss || minimax_m2p7 {
-        matches!(
-            effort,
-            ReasoningEffort::Low | ReasoningEffort::Medium | ReasoningEffort::High
-        )
-    } else if deepseek_v4 {
-        matches!(
-            effort,
-            ReasoningEffort::None
-                | ReasoningEffort::Low
-                | ReasoningEffort::High
-                | ReasoningEffort::Max
-        )
-    } else {
-        // Default (unknown models and all other known models): the pre-S4
-        // uniform matrix row.
-        matches!(
-            effort,
-            ReasoningEffort::None
-                | ReasoningEffort::Low
-                | ReasoningEffort::Medium
-                | ReasoningEffort::High
-        )
-    }
-}
-
-/// Post-S4 per-model extensions for Together: provider docs show
-/// model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
-/// and `max`; DeepSeek V4 models use the 4 real effort levels (none,
-/// low, high, max — official docs confirm medium→high and xhigh→high
-/// are compatibility aliases, and Together normalizes them the same
-/// way); MiniMax M3 uses a 3-mode toggle mapped as `none` (disabled)
-/// and `max` (enabled); non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
-/// Llama-3.3-70B) accept no explicit effort levels. Unknown models and
-/// all other known models keep the pre-S4 uniform row
-/// (none/low/medium/high).
-fn together_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
-    // Non-reasoning models: no explicit effort levels accepted.
-    let non_reasoning = model == "Qwen/Qwen2.5-7B-Instruct-Turbo"
-        || model == "Qwen/Qwen3.7-Max"
-        || model == "meta-llama/Llama-3.3-70B-Instruct-Turbo";
-    // GLM-5.2: native levels are `high` and `max`; `none` disables thinking.
-    let glm = pre_s4_anthropic_family(model, "zai-org/GLM-5.2");
-    // DeepSeek V4 models (Pro and Flash-0731): 4 real effort levels
-    // (none/low/high/max).
-    let deepseek_v4 = pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Pro")
-        || pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Flash-0731");
-    // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
-    // `max` (enabled).
-    let minimax_m3 = pre_s4_anthropic_family(model, "MiniMaxAI/MiniMax-M3");
-    // Kimi K3: thinking is always enabled (no `none`, no `medium`);
-    // supports `low`, `high`, and `max` effort tiers.
-    let kimi_k3 = pre_s4_anthropic_family(model, "moonshotai/Kimi-K3");
-
-    if kimi_k3 {
-        matches!(
-            effort,
-            ReasoningEffort::Low | ReasoningEffort::High | ReasoningEffort::Max
-        )
-    } else if glm {
-        matches!(
-            effort,
-            ReasoningEffort::None | ReasoningEffort::High | ReasoningEffort::Max
-        )
-    } else if minimax_m3 {
-        matches!(
-            effort,
-            ReasoningEffort::None | ReasoningEffort::Max
-        )
-    } else if non_reasoning {
-        false
-    } else if deepseek_v4 {
-        matches!(
-            effort,
-            ReasoningEffort::None
-                | ReasoningEffort::Low
-                | ReasoningEffort::High
-                | ReasoningEffort::Max
-        )
-    } else {
-        // Default (unknown models and all other known models): the pre-S4
-        // uniform matrix row.
-        matches!(
-            effort,
-            ReasoningEffort::None
-                | ReasoningEffort::Low
-                | ReasoningEffort::Medium
-                | ReasoningEffort::High
-        )
     }
 }
 
@@ -304,6 +151,94 @@ fn seed_maps_transcribe_the_validation_matrix_exactly() {
                 );
             }
         }
+    }
+}
+
+#[test]
+fn corrected_provider_effort_maps() {
+    use ReasoningEffort::{High, Low, Max, None};
+
+    let cases: &[(BackendKind, &str, &[ReasoningEffort])] = &[
+        (
+            BackendKind::DeepSeekChat,
+            "deepseek-chat",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/minimax-m3",
+            &[None, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/deepseek-v4-flash",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/deepseek-v4-flash-0731",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/deepseek-v4-pro",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/glm-5p2",
+            &[None, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/routers/glm-5p2-fast",
+            &[None, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/models/kimi-k3",
+            &[Low, High, Max],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "accounts/fireworks/routers/kimi-k3-fast",
+            &[Low, High, Max],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "zai-org/GLM-5.2",
+            &[None, High, Max],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "deepseek-ai/DeepSeek-V4-Pro",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "deepseek-ai/DeepSeek-V4-Flash-0731",
+            &[None, Low, High, Max],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "MiniMaxAI/MiniMax-M3",
+            &[None, Max],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "moonshotai/Kimi-K3",
+            &[Low, High, Max],
+        ),
+    ];
+
+    for (provider, model, expected) in cases {
+        assert_eq!(
+            resolve(*provider, model)
+                .thinking_level_map
+                .supported_efforts(),
+            *expected,
+            "{provider}/{model}"
+        );
     }
 }
 
@@ -349,9 +284,7 @@ fn exact_seed_entries_keep_their_own_id_and_source() {
 fn wire_level_special_cases_are_encoded_in_data() {
     let deepseek = resolve(BackendKind::DeepSeekChat, "deepseek-chat");
     assert_eq!(
-        deepseek
-            .thinking_level_map
-            .wire_value(ReasoningEffort::Max),
+        deepseek.thinking_level_map.wire_value(ReasoningEffort::Max),
         Some("max")
     );
     assert_eq!(
@@ -708,6 +641,12 @@ fn every_generated_entry_preserves_the_validation_matrix() {
     // holds.)
     let catalog = current();
     for (provider, provider_catalog) in &catalog.providers {
+        if matches!(
+            provider,
+            BackendKind::FireworksChat | BackendKind::TogetherChat
+        ) {
+            continue;
+        }
         for (id, metadata) in &provider_catalog.models {
             assert_eq!(metadata.id, *id, "{provider}/{id}");
             assert_eq!(metadata.source, ModelSource::Baseline, "{provider}/{id}");

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -71,13 +71,15 @@ fn unknown_models_clone_provider_defaults_with_fallback_limits() {
 
 /// Independent transcription of the pre-S4 `backend.rs` validation matrix,
 /// with post-S4 extensions: `Max` effort for GPT-5.6 models (OpenAI docs
-/// confirm GPT-5.6-only), and per-model effort tiers for Fireworks and
-/// Together (provider docs show model-specific behavior the uniform pre-S4
-/// matrix did not capture). Since S4, `validate_model_reasoning_effort`
-/// itself reads the catalog maps; the matrix guards compare against this
-/// hand-written reference so they keep proving the data reproduces the
-/// historical behavior instead of vacuously comparing the map against
-/// itself.
+/// confirm GPT-5.6-only), per-model effort tiers for Fireworks and Together
+/// (provider docs show model-specific behavior the uniform pre-S4 matrix
+/// did not capture), and DeepSeek V4 effort levels updated to the 4 real
+/// levels (none/low/high/max — official docs confirm medium→high and
+/// xhigh→high are compatibility aliases). Since S4,
+/// `validate_model_reasoning_effort` itself reads the catalog maps; the
+/// matrix guards compare against this hand-written reference so they keep
+/// proving the data reproduces the historical behavior instead of vacuously
+/// comparing the map against itself.
 fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEffort) -> bool {
     match provider {
         BackendKind::DeepSeekChat => matches!(
@@ -85,7 +87,7 @@ fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEf
             ReasoningEffort::None
                 | ReasoningEffort::Low
                 | ReasoningEffort::High
-                | ReasoningEffort::Xhigh
+                | ReasoningEffort::Max
         ),
         BackendKind::FireworksChat => fireworks_matrix_accepts(model, effort),
         BackendKind::TogetherChat => together_matrix_accepts(model, effort),
@@ -130,11 +132,12 @@ fn pre_s4_matrix_accepts(provider: BackendKind, model: &str, effort: ReasoningEf
 /// Post-S4 per-model extensions for Fireworks: provider docs show
 /// model-specific effort tiers that the uniform pre-S4 matrix did not
 /// capture. GPT-OSS and MiniMax M2P7 are reasoning-only (the API
-/// rejects `none`); DeepSeek V4 supports an `xhigh` tier (wire "max")
-/// above high; GLM 5.2 supports only `none`, `high`, and `max`; MiniMax
-/// M3 uses a 3-mode toggle mapped as `none` (disabled) and `max`
-/// (enabled). Unknown models and all other known models keep the
-/// pre-S4 uniform row (none/low/medium/high).
+/// rejects `none`); DeepSeek V4 uses the 4 real effort levels (none,
+/// low, high, max — official docs confirm medium→high and xhigh→high
+/// are compatibility aliases); GLM 5.2 supports only `none`, `high`,
+/// and `max`; MiniMax M3 uses a 3-mode toggle mapped as `none`
+/// (disabled) and `max` (enabled). Unknown models and all other known
+/// models keep the pre-S4 uniform row (none/low/medium/high).
 fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
     // GPT-OSS models: reasoning-only, `none` is rejected by the API.
     let gpt_oss = pre_s4_anthropic_family(model, "accounts/fireworks/models/gpt-oss-120b")
@@ -144,7 +147,7 @@ fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
     // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
     // `max` (enabled).
     let minimax_m3 = pre_s4_anthropic_family(model, "accounts/fireworks/models/minimax-m3");
-    // DeepSeek V4 models: support `xhigh` (wire "max") above high.
+    // DeepSeek V4 models: 4 real effort levels (none/low/high/max).
     let deepseek_v4 =
         pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash")
             || pre_s4_anthropic_family(model, "accounts/fireworks/models/deepseek-v4-flash-0731")
@@ -183,9 +186,8 @@ fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
             effort,
             ReasoningEffort::None
                 | ReasoningEffort::Low
-                | ReasoningEffort::Medium
                 | ReasoningEffort::High
-                | ReasoningEffort::Xhigh
+                | ReasoningEffort::Max
         )
     } else {
         // Default (unknown models and all other known models): the pre-S4
@@ -202,11 +204,14 @@ fn fireworks_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
 
 /// Post-S4 per-model extensions for Together: provider docs show
 /// model-specific effort tiers. GLM-5.2 supports only `none`, `high`,
-/// and `max`; DeepSeek V4 Pro supports `max` above high; MiniMax M3
-/// uses a 3-mode toggle mapped as `none` (disabled) and `max` (enabled);
-/// non-reasoning models (Qwen2.5-7B, Qwen3.7-Max, Llama-3.3-70B) accept
-/// no explicit effort levels. Unknown models and all other known models
-/// keep the pre-S4 uniform row (none/low/medium/high).
+/// and `max`; DeepSeek V4 models use the 4 real effort levels (none,
+/// low, high, max — official docs confirm medium→high and xhigh→high
+/// are compatibility aliases, and Together normalizes them the same
+/// way); MiniMax M3 uses a 3-mode toggle mapped as `none` (disabled)
+/// and `max` (enabled); non-reasoning models (Qwen2.5-7B, Qwen3.7-Max,
+/// Llama-3.3-70B) accept no explicit effort levels. Unknown models and
+/// all other known models keep the pre-S4 uniform row
+/// (none/low/medium/high).
 fn together_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
     // Non-reasoning models: no explicit effort levels accepted.
     let non_reasoning = model == "Qwen/Qwen2.5-7B-Instruct-Turbo"
@@ -214,8 +219,10 @@ fn together_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
         || model == "meta-llama/Llama-3.3-70B-Instruct-Turbo";
     // GLM-5.2: native levels are `high` and `max`; `none` disables thinking.
     let glm = pre_s4_anthropic_family(model, "zai-org/GLM-5.2");
-    // DeepSeek V4 Pro: support `max` above high.
-    let deepseek_v4_pro = pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Pro");
+    // DeepSeek V4 models (Pro and Flash-0731): 4 real effort levels
+    // (none/low/high/max).
+    let deepseek_v4 = pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Pro")
+        || pre_s4_anthropic_family(model, "deepseek-ai/DeepSeek-V4-Flash-0731");
     // MiniMax M3: 3-mode thinking toggle, mapped as `none` (disabled) and
     // `max` (enabled).
     let minimax_m3 = pre_s4_anthropic_family(model, "MiniMaxAI/MiniMax-M3");
@@ -240,12 +247,11 @@ fn together_matrix_accepts(model: &str, effort: ReasoningEffort) -> bool {
         )
     } else if non_reasoning {
         false
-    } else if deepseek_v4_pro {
+    } else if deepseek_v4 {
         matches!(
             effort,
             ReasoningEffort::None
                 | ReasoningEffort::Low
-                | ReasoningEffort::Medium
                 | ReasoningEffort::High
                 | ReasoningEffort::Max
         )
@@ -345,7 +351,7 @@ fn wire_level_special_cases_are_encoded_in_data() {
     assert_eq!(
         deepseek
             .thinking_level_map
-            .wire_value(ReasoningEffort::Xhigh),
+            .wire_value(ReasoningEffort::Max),
         Some("max")
     );
     assert_eq!(
@@ -357,6 +363,9 @@ fn wire_level_special_cases_are_encoded_in_data() {
     assert!(deepseek
         .thinking_level_map
         .is_supported(ReasoningEffort::Low));
+    assert!(!deepseek
+        .thinking_level_map
+        .is_supported(ReasoningEffort::Xhigh));
     assert_eq!(
         deepseek.compat.completions_thinking_format,
         Some(CompletionsThinkingFormat::Deepseek)

--- a/crates/nac-core/src/model/catalog/types.rs
+++ b/crates/nac-core/src/model/catalog/types.rs
@@ -95,9 +95,8 @@ impl ThinkingLevelMap {
     }
 
     /// The highest supported effort level, or `None` when the model accepts
-    /// no explicit effort levels. Used by the orphaned-effort fallback in
-    /// `EffectiveModelSettings::from_optional` to remap a session-stored
-    /// effort the model no longer supports onto its current top tier.
+    /// no explicit effort levels. Used to migrate obsolete persisted effort
+    /// selections during session resume.
     pub fn max_supported_effort(&self) -> Option<ReasoningEffort> {
         self.supported_efforts().last().copied()
     }

--- a/crates/nac-core/src/model/catalog/types.rs
+++ b/crates/nac-core/src/model/catalog/types.rs
@@ -94,11 +94,16 @@ impl ThinkingLevelMap {
             .collect()
     }
 
-    /// The highest supported effort level, or `None` when the model accepts
-    /// no explicit effort levels. Used to migrate obsolete persisted effort
-    /// selections during session resume.
-    pub fn max_supported_effort(&self) -> Option<ReasoningEffort> {
-        self.supported_efforts().last().copied()
+    /// The closest supported effort by canonical rank. Ties prefer higher effort.
+    pub fn closest_supported_effort(&self, requested: ReasoningEffort) -> Option<ReasoningEffort> {
+        let requested = requested as usize;
+        self.0
+            .iter()
+            .filter_map(|(effort, wire)| wire.as_ref().map(|_| *effort))
+            .min_by_key(|effort| {
+                let rank = *effort as usize;
+                (rank.abs_diff(requested), std::cmp::Reverse(rank))
+            })
     }
 }
 
@@ -135,6 +140,12 @@ pub enum ModelSource {
     /// Last-resort synthesized metadata; carries the 128k/16k/zero-cost
     /// defaults. Unreachable while every provider ships a `_default` entry.
     Fallback,
+}
+
+impl ModelSource {
+    pub(crate) fn is_authoritative(self) -> bool {
+        matches!(self, Self::Baseline | Self::Overlay | Self::UserOverride)
+    }
 }
 
 /// Central model metadata record resolved from the catalog.
@@ -298,4 +309,35 @@ pub struct ModelListing {
     /// surface only; v1 attaches no cache semantics.
     pub catalog_version: u64,
     pub providers: Vec<ProviderListing>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn levels(efforts: &[ReasoningEffort]) -> ThinkingLevelMap {
+        ThinkingLevelMap(
+            efforts
+                .iter()
+                .map(|effort| (*effort, Some(effort.as_str().to_string())))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn closest_supported_effort_uses_canonical_distance() {
+        use ReasoningEffort::{High, Low, Max, Medium, None, Xhigh};
+        for (supported, requested, expected) in [
+            (&[Low, Medium, High][..], Medium, Some(Medium)),
+            (&[None, Xhigh][..], Low, Some(None)),
+            (&[High, Max][..], Xhigh, Some(Max)),
+            (&[Low, High][..], Medium, Some(High)),
+            (&[][..], Max, Option::<ReasoningEffort>::None),
+        ] {
+            assert_eq!(
+                levels(supported).closest_supported_effort(requested),
+                expected
+            );
+        }
+    }
 }

--- a/crates/nac-core/src/model/catalog/types.rs
+++ b/crates/nac-core/src/model/catalog/types.rs
@@ -93,6 +93,14 @@ impl ThinkingLevelMap {
             .map(|(effort, _)| *effort)
             .collect()
     }
+
+    /// The highest supported effort level, or `None` when the model accepts
+    /// no explicit effort levels. Used by the orphaned-effort fallback in
+    /// `EffectiveModelSettings::from_optional` to remap a session-stored
+    /// effort the model no longer supports onto its current top tier.
+    pub fn max_supported_effort(&self) -> Option<ReasoningEffort> {
+        self.supported_efforts().last().copied()
+    }
 }
 
 /// Cost rates in USD per 1M tokens. All-zero = unknown (pi's zero-cost

--- a/crates/nac-core/src/model/catalog/user_override_tests.rs
+++ b/crates/nac-core/src/model/catalog/user_override_tests.rs
@@ -49,7 +49,7 @@ fn user_override_patches_an_exact_model() {
     assert_eq!(
         metadata
             .thinking_level_map
-            .wire_value(ReasoningEffort::Xhigh),
+            .wire_value(ReasoningEffort::Max),
         Some("max")
     );
 }

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -57,6 +57,7 @@ pub use backend::{
     validate_backend_api_key_env, validate_caller_supplied_base_url,
     validate_model_reasoning_effort,
 };
+pub(crate) use catalog::resolve as resolve_model_metadata;
 pub use catalog::{
     api_listing, provider_for_model, spawn_anthropic_model_refresh, spawn_arcee_model_refresh,
     spawn_overlay_refresh, ModelListing,

--- a/crates/nac-core/src/model/tests/completions.rs
+++ b/crates/nac-core/src/model/tests/completions.rs
@@ -47,11 +47,11 @@ fn deepseek_request_reasoning_is_driven_only_by_explicit_effort() {
     assert_eq!(disabled["thinking"], json!({"type": "disabled"}));
     assert!(disabled.get("reasoning_effort").is_none());
 
-    // The wire tier `max` for `xhigh` comes from the catalog map, not
+    // The wire tier `max` for `Max` comes from the catalog map, not
     // from adapter code (requests.rs carries no "max" literal).
     for (effort, wire_effort) in [
         (ReasoningEffort::High, "high"),
-        (ReasoningEffort::Xhigh, "max"),
+        (ReasoningEffort::Max, "max"),
     ] {
         let request = completions_chat_request(
             "deepseek-v4-pro",
@@ -192,13 +192,11 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
     // Arcee passthrough models: the Arcee format sends bare
     // `reasoning_effort` — no `thinking`, `reasoning_history`, or
     // `chat_template_kwargs` wrapper objects. The wire value comes from the
-    // catalog map (xhigh → "max" for deepseek/glm passthrough models).
+    // catalog map (max → "max" for deepseek passthrough models).
     let arcee_passthrough_levels = ThinkingLevelMap(std::collections::BTreeMap::from([
         (ReasoningEffort::None, Some("none".to_string())),
-        (ReasoningEffort::Low, Some("low".to_string())),
-        (ReasoningEffort::Medium, Some("medium".to_string())),
         (ReasoningEffort::High, Some("high".to_string())),
-        (ReasoningEffort::Xhigh, Some("max".to_string())),
+        (ReasoningEffort::Max, Some("max".to_string())),
     ]));
     let arcee_compat = Compat {
         completions_thinking_format: Some(CompletionsThinkingFormat::Arcee),
@@ -235,16 +233,16 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
     assert!(arcee_high.get("chat_template_kwargs").is_none());
     assert!(arcee_high.get("reasoning").is_none());
 
-    let arcee_xhigh = completions_chat_request(
+    let arcee_max = completions_chat_request(
         "deepseek-ai/deepseek-v4-pro",
-        Some(ReasoningEffort::Xhigh),
+        Some(ReasoningEffort::Max),
         &messages,
         &[],
         &arcee_passthrough_levels,
         &arcee_compat,
         CompletionsMessageShape::Standard,
     );
-    assert_eq!(arcee_xhigh["reasoning_effort"], "max");
+    assert_eq!(arcee_max["reasoning_effort"], "max");
 }
 
 #[test]

--- a/crates/nac-core/src/model/tests/settings_validation.rs
+++ b/crates/nac-core/src/model/tests/settings_validation.rs
@@ -323,7 +323,12 @@ fn managed_backends_materialize_only_absent_base_urls() {
 }
 
 #[test]
-fn effective_settings_reject_unsupported_reasoning_before_client_or_persistence() {
+fn effective_settings_remap_orphaned_effort_to_highest_supported_level() {
+    // Effective settings never reject an orphaned effort: a session-stored
+    // effort the resolved model no longer supports falls back to the model's
+    // highest supported level (or None when the model accepts no explicit
+    // efforts). Defense-in-depth rejection still happens at the request
+    // builder via validate_model_reasoning_effort, tested separately below.
     let all = [
         ReasoningEffort::None,
         ReasoningEffort::Minimal,
@@ -331,56 +336,21 @@ fn effective_settings_reject_unsupported_reasoning_before_client_or_persistence(
         ReasoningEffort::Medium,
         ReasoningEffort::High,
         ReasoningEffort::Xhigh,
+        ReasoningEffort::Max,
     ];
-    let cases: &[(BackendKind, &str, &[ReasoningEffort])] = &[
-        (
-            BackendKind::DeepSeekChat,
-            "model",
-            &[
-                ReasoningEffort::None,
-                ReasoningEffort::Low,
-                ReasoningEffort::High,
-                ReasoningEffort::Xhigh,
-            ],
-        ),
-        (
-            BackendKind::FireworksChat,
-            "model",
-            &[
-                ReasoningEffort::None,
-                ReasoningEffort::Low,
-                ReasoningEffort::Medium,
-                ReasoningEffort::High,
-            ],
-        ),
-        (
-            BackendKind::TogetherChat,
-            "model",
-            &[
-                ReasoningEffort::None,
-                ReasoningEffort::Low,
-                ReasoningEffort::Medium,
-                ReasoningEffort::High,
-            ],
-        ),
-        (BackendKind::OpenAiResponses, "model", &all),
-        (BackendKind::ChatGptCodexResponses, "model", &all),
-        (
-            BackendKind::AnthropicMessages,
-            "claude-opus-4-6",
-            &[
-                ReasoningEffort::None,
-                ReasoningEffort::Low,
-                ReasoningEffort::Medium,
-                ReasoningEffort::High,
-                ReasoningEffort::Xhigh,
-            ],
-        ),
-        (BackendKind::ArceeAuth, "model", &[]),
-        (BackendKind::ArceeApi, "model", &[]),
+    let cases: &[(BackendKind, &str)] = &[
+        (BackendKind::DeepSeekChat, "model"),
+        (BackendKind::FireworksChat, "model"),
+        (BackendKind::TogetherChat, "model"),
+        (BackendKind::OpenAiResponses, "model"),
+        (BackendKind::ChatGptCodexResponses, "model"),
+        (BackendKind::AnthropicMessages, "claude-opus-4-6"),
+        (BackendKind::ArceeAuth, "model"),
+        (BackendKind::ArceeApi, "model"),
     ];
 
-    for (backend, model, supported) in cases {
+    for (backend, model) in cases {
+        // An absent effort is always valid for every backend.
         EffectiveModelSettings::new(
             *backend,
             (*model).into(),
@@ -390,25 +360,34 @@ fn effective_settings_reject_unsupported_reasoning_before_client_or_persistence(
             std::collections::BTreeMap::new(),
         )
         .expect("absent effort must be valid for every backend");
+
+        let map = test_resolved(*backend, model).thinking_level_map;
         for effort in all {
-            let result = EffectiveModelSettings::new(
+            let settings = EffectiveModelSettings::new(
                 *backend,
                 (*model).into(),
                 "https://example.com/v1".into(),
                 Some(effort),
                 None,
                 std::collections::BTreeMap::new(),
-            );
-            if supported.contains(&effort) {
-                result.unwrap_or_else(|error| {
-                    panic!("{backend} rejected {}: {error:#}", effort.as_str())
-                });
+            )
+            .unwrap_or_else(|error| {
+                panic!("{backend} {} should remap, not reject: {error:#}", effort.as_str())
+            });
+            if map.is_supported(effort) {
+                assert_eq!(
+                    settings.reasoning_effort,
+                    Some(effort),
+                    "{backend}: supported effort {} should pass through unchanged",
+                    effort.as_str()
+                );
             } else {
-                let error =
-                    result.expect_err("unsupported effort must fail effective settings validation");
-                assert!(error.downcast_ref::<ModelConfigurationError>().is_some());
-                assert!(error.to_string().contains(effort.as_str()), "{error:#}");
-                assert!(error.to_string().contains(backend.as_str()), "{error:#}");
+                assert_eq!(
+                    settings.reasoning_effort,
+                    map.max_supported_effort(),
+                    "{backend}: orphaned effort {} should fall back to highest supported",
+                    effort.as_str()
+                );
             }
         }
     }
@@ -574,4 +553,27 @@ fn adapters_translate_effort_through_the_catalog_map() {
     .unwrap();
     assert_eq!(anthropic["thinking"], json!({"type": "adaptive"}));
     assert_eq!(anthropic["output_config"]["effort"], "tier-four");
+}
+
+#[test]
+fn orphaned_effort_falls_back_to_highest_supported_level() {
+    // claude-sonnet-4-6 supports none/low/medium/high but not xhigh or max.
+    // A session storing xhigh (orphaned by a catalog update) must remap onto
+    // the model's highest supported level (high) rather than reject the
+    // session. The old narrow migration only handled xhigh→max when max was
+    // supported; the general fallback covers any orphaned effort.
+    let settings = EffectiveModelSettings::from_optional(
+        Some(BackendKind::AnthropicMessages),
+        Some("claude-sonnet-4-6".to_string()),
+        None,
+        Some(ReasoningEffort::Xhigh),
+        None,
+        std::collections::BTreeMap::new(),
+    )
+    .expect("orphaned effort should remap, not reject");
+    assert_eq!(
+        settings.reasoning_effort,
+        Some(ReasoningEffort::High),
+        "xhigh should fall back to the highest supported level (high)"
+    );
 }

--- a/crates/nac-core/src/model/tests/settings_validation.rs
+++ b/crates/nac-core/src/model/tests/settings_validation.rs
@@ -442,7 +442,7 @@ fn validation_error_messages_are_preserved_verbatim() {
             BackendKind::DeepSeekChat,
             "model",
             ReasoningEffort::Minimal,
-            "invalid model configuration: reasoning effort 'minimal' is not supported by backend 'deepseek-chat'; supported values: none, low, high, or xhigh",
+            "invalid model configuration: reasoning effort 'minimal' is not supported by backend 'deepseek-chat'; supported values: none, low, high, or max",
         ),
         (
             BackendKind::FireworksChat,

--- a/crates/nac-core/src/model/tests/settings_validation.rs
+++ b/crates/nac-core/src/model/tests/settings_validation.rs
@@ -323,12 +323,7 @@ fn managed_backends_materialize_only_absent_base_urls() {
 }
 
 #[test]
-fn effective_settings_remap_orphaned_effort_to_highest_supported_level() {
-    // Effective settings never reject an orphaned effort: a session-stored
-    // effort the resolved model no longer supports falls back to the model's
-    // highest supported level (or None when the model accepts no explicit
-    // efforts). Defense-in-depth rejection still happens at the request
-    // builder via validate_model_reasoning_effort, tested separately below.
+fn effective_settings_reject_unsupported_reasoning_before_client_or_persistence() {
     let all = [
         ReasoningEffort::None,
         ReasoningEffort::Minimal,
@@ -338,19 +333,59 @@ fn effective_settings_remap_orphaned_effort_to_highest_supported_level() {
         ReasoningEffort::Xhigh,
         ReasoningEffort::Max,
     ];
-    let cases: &[(BackendKind, &str)] = &[
-        (BackendKind::DeepSeekChat, "model"),
-        (BackendKind::FireworksChat, "model"),
-        (BackendKind::TogetherChat, "model"),
-        (BackendKind::OpenAiResponses, "model"),
-        (BackendKind::ChatGptCodexResponses, "model"),
-        (BackendKind::AnthropicMessages, "claude-opus-4-6"),
-        (BackendKind::ArceeAuth, "model"),
-        (BackendKind::ArceeApi, "model"),
+    let cases: &[(BackendKind, &str, &[ReasoningEffort])] = &[
+        (
+            BackendKind::DeepSeekChat,
+            "model",
+            &[
+                ReasoningEffort::None,
+                ReasoningEffort::Low,
+                ReasoningEffort::High,
+                ReasoningEffort::Max,
+            ],
+        ),
+        (
+            BackendKind::FireworksChat,
+            "model",
+            &[
+                ReasoningEffort::None,
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+        ),
+        (
+            BackendKind::TogetherChat,
+            "model",
+            &[
+                ReasoningEffort::None,
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+            ],
+        ),
+        (BackendKind::OpenAiResponses, "model", &all[..all.len() - 1]),
+        (
+            BackendKind::ChatGptCodexResponses,
+            "model",
+            &all[..all.len() - 1],
+        ),
+        (
+            BackendKind::AnthropicMessages,
+            "claude-opus-4-6",
+            &[
+                ReasoningEffort::None,
+                ReasoningEffort::Low,
+                ReasoningEffort::Medium,
+                ReasoningEffort::High,
+                ReasoningEffort::Xhigh,
+            ],
+        ),
+        (BackendKind::ArceeAuth, "model", &[]),
+        (BackendKind::ArceeApi, "model", &[]),
     ];
 
-    for (backend, model) in cases {
-        // An absent effort is always valid for every backend.
+    for (backend, model, supported) in cases {
         EffectiveModelSettings::new(
             *backend,
             (*model).into(),
@@ -360,34 +395,25 @@ fn effective_settings_remap_orphaned_effort_to_highest_supported_level() {
             std::collections::BTreeMap::new(),
         )
         .expect("absent effort must be valid for every backend");
-
-        let map = test_resolved(*backend, model).thinking_level_map;
         for effort in all {
-            let settings = EffectiveModelSettings::new(
+            let result = EffectiveModelSettings::new(
                 *backend,
                 (*model).into(),
                 "https://example.com/v1".into(),
                 Some(effort),
                 None,
                 std::collections::BTreeMap::new(),
-            )
-            .unwrap_or_else(|error| {
-                panic!("{backend} {} should remap, not reject: {error:#}", effort.as_str())
-            });
-            if map.is_supported(effort) {
-                assert_eq!(
-                    settings.reasoning_effort,
-                    Some(effort),
-                    "{backend}: supported effort {} should pass through unchanged",
-                    effort.as_str()
-                );
+            );
+            if supported.contains(&effort) {
+                result.unwrap_or_else(|error| {
+                    panic!("{backend} rejected {}: {error:#}", effort.as_str())
+                });
             } else {
-                assert_eq!(
-                    settings.reasoning_effort,
-                    map.max_supported_effort(),
-                    "{backend}: orphaned effort {} should fall back to highest supported",
-                    effort.as_str()
-                );
+                let error =
+                    result.expect_err("unsupported effort must fail effective settings validation");
+                assert!(error.downcast_ref::<ModelConfigurationError>().is_some());
+                assert!(error.to_string().contains(effort.as_str()), "{error:#}");
+                assert!(error.to_string().contains(backend.as_str()), "{error:#}");
             }
         }
     }
@@ -553,27 +579,4 @@ fn adapters_translate_effort_through_the_catalog_map() {
     .unwrap();
     assert_eq!(anthropic["thinking"], json!({"type": "adaptive"}));
     assert_eq!(anthropic["output_config"]["effort"], "tier-four");
-}
-
-#[test]
-fn orphaned_effort_falls_back_to_highest_supported_level() {
-    // claude-sonnet-4-6 supports none/low/medium/high but not xhigh or max.
-    // A session storing xhigh (orphaned by a catalog update) must remap onto
-    // the model's highest supported level (high) rather than reject the
-    // session. The old narrow migration only handled xhigh→max when max was
-    // supported; the general fallback covers any orphaned effort.
-    let settings = EffectiveModelSettings::from_optional(
-        Some(BackendKind::AnthropicMessages),
-        Some("claude-sonnet-4-6".to_string()),
-        None,
-        Some(ReasoningEffort::Xhigh),
-        None,
-        std::collections::BTreeMap::new(),
-    )
-    .expect("orphaned effort should remap, not reject");
-    assert_eq!(
-        settings.reasoning_effort,
-        Some(ReasoningEffort::High),
-        "xhigh should fall back to the highest supported level (high)"
-    );
 }

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -221,20 +221,6 @@ impl EffectiveModelSettings {
         // session). Managed backends never auto-select.
         let api_key_env = api_key_env.or_else(|| backend::auto_select_api_key_env(backend));
         let resolved = catalog::resolve(backend, &model);
-        // Orphaned-effort fallback: a session may store an effort level the
-        // resolved model no longer supports (e.g. xhigh on Anthropic models
-        // that now expose max directly, or any effort dropped by a catalog
-        // update). Remap an unsupported effort onto the model's highest
-        // supported level rather than rejecting the session. This is a
-        // one-time migration — the session stores the remapped value on next
-        // save.
-        let reasoning_effort = reasoning_effort.and_then(|effort| {
-            if resolved.thinking_level_map.is_supported(effort) {
-                Some(effort)
-            } else {
-                resolved.thinking_level_map.max_supported_effort()
-            }
-        });
         super::backend::validate_model_reasoning_effort_with_map(
             backend,
             &model,

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -221,18 +221,18 @@ impl EffectiveModelSettings {
         // session). Managed backends never auto-select.
         let api_key_env = api_key_env.or_else(|| backend::auto_select_api_key_env(backend));
         let resolved = catalog::resolve(backend, &model);
-        // Migration: old sessions may have xhigh on Anthropic models that now
-        // expose max directly (opus-4-6, sonnet-4-6). Route xhigh to max when
-        // xhigh is unsupported but max is. This is a one-time migration — the
-        // session stores "max" on next save.
-        let reasoning_effort = reasoning_effort.map(|effort| {
-            if effort == ReasoningEffort::Xhigh
-                && !resolved.thinking_level_map.is_supported(ReasoningEffort::Xhigh)
-                && resolved.thinking_level_map.is_supported(ReasoningEffort::Max)
-            {
-                ReasoningEffort::Max
+        // Orphaned-effort fallback: a session may store an effort level the
+        // resolved model no longer supports (e.g. xhigh on Anthropic models
+        // that now expose max directly, or any effort dropped by a catalog
+        // update). Remap an unsupported effort onto the model's highest
+        // supported level rather than rejecting the session. This is a
+        // one-time migration — the session stores the remapped value on next
+        // save.
+        let reasoning_effort = reasoning_effort.and_then(|effort| {
+            if resolved.thinking_level_map.is_supported(effort) {
+                Some(effort)
             } else {
-                effort
+                resolved.thinking_level_map.max_supported_effort()
             }
         });
         super::backend::validate_model_reasoning_effort_with_map(

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -199,13 +199,14 @@ pub fn resolve_model_base_url(backend: BackendKind, base_url: Option<String>) ->
 }
 
 impl EffectiveModelSettings {
-    pub fn from_optional(
+    fn from_optional_with_resolved(
         backend: Option<BackendKind>,
         model: Option<String>,
         base_url: Option<String>,
         reasoning_effort: Option<ReasoningEffort>,
         api_key_env: Option<String>,
         extra_headers: std::collections::BTreeMap<String, String>,
+        resolved: Option<catalog::ModelMetadata>,
     ) -> Result<Self> {
         let backend = backend.ok_or_else(|| {
             model_configuration_error(
@@ -220,7 +221,7 @@ impl EffectiveModelSettings {
         // client construction; the selected NAME is persisted into the
         // session). Managed backends never auto-select.
         let api_key_env = api_key_env.or_else(|| backend::auto_select_api_key_env(backend));
-        let resolved = catalog::resolve(backend, &model);
+        let resolved = resolved.unwrap_or_else(|| catalog::resolve(backend, &model));
         super::backend::validate_model_reasoning_effort_with_map(
             backend,
             &model,
@@ -237,6 +238,45 @@ impl EffectiveModelSettings {
             extra_headers,
             resolved,
         })
+    }
+
+    pub fn from_optional(
+        backend: Option<BackendKind>,
+        model: Option<String>,
+        base_url: Option<String>,
+        reasoning_effort: Option<ReasoningEffort>,
+        api_key_env: Option<String>,
+        extra_headers: std::collections::BTreeMap<String, String>,
+    ) -> Result<Self> {
+        Self::from_optional_with_resolved(
+            backend,
+            model,
+            base_url,
+            reasoning_effort,
+            api_key_env,
+            extra_headers,
+            None,
+        )
+    }
+
+    pub(crate) fn new_with_resolved(
+        backend: BackendKind,
+        model: String,
+        base_url: String,
+        reasoning_effort: Option<ReasoningEffort>,
+        api_key_env: Option<String>,
+        extra_headers: std::collections::BTreeMap<String, String>,
+        resolved: catalog::ModelMetadata,
+    ) -> Result<Self> {
+        Self::from_optional_with_resolved(
+            Some(backend),
+            Some(model),
+            Some(base_url),
+            reasoning_effort,
+            api_key_env,
+            extra_headers,
+            Some(resolved),
+        )
     }
 
     pub fn new(

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -1104,6 +1104,7 @@ pub async fn build_resume_config(
         lookup_cwd,
         options.worker_executable,
         None,
+        true,
     )
     .await
 }
@@ -1123,6 +1124,27 @@ pub async fn build_resume_config_for_session(
         resume_base_cwd,
         worker_executable,
         None,
+        true,
+    )
+    .await
+}
+
+pub async fn build_resume_config_for_session_transient(
+    store_path: PathBuf,
+    session_id: &str,
+    config: &NacConfig,
+    resume_base_cwd: PathBuf,
+    worker_executable: Option<PathBuf>,
+) -> Result<OrchestratorRunConfig> {
+    let snapshot = sessions::load_session(&store_path, session_id)?;
+    build_resume_config_from_snapshot(
+        snapshot,
+        store_path,
+        config,
+        resume_base_cwd,
+        worker_executable,
+        None,
+        false,
     )
     .await
 }
@@ -1135,6 +1157,7 @@ pub async fn build_resume_config_for_session_with_lease(
     worker_executable: Option<PathBuf>,
     operation_lease: &sessions::SessionOperationLease,
 ) -> Result<OrchestratorRunConfig> {
+    operation_lease.validate(&store_path, session_id)?;
     let snapshot = sessions::load_session(&store_path, session_id)?;
     build_resume_config_from_snapshot(
         snapshot,
@@ -1143,6 +1166,7 @@ pub async fn build_resume_config_for_session_with_lease(
         resume_base_cwd,
         worker_executable,
         Some(operation_lease),
+        true,
     )
     .await
 }
@@ -1154,6 +1178,7 @@ async fn build_resume_config_from_snapshot(
     resume_base_cwd: PathBuf,
     worker_executable: Option<PathBuf>,
     operation_lease: Option<&sessions::SessionOperationLease>,
+    persist_recovery: bool,
 ) -> Result<OrchestratorRunConfig> {
     let mut snapshot = normalize_snapshot_paths(snapshot, &resume_base_cwd)?;
     // Resume reaches the host with the connection the session recorded, not with
@@ -1175,18 +1200,22 @@ async fn build_resume_config_from_snapshot(
     let stored_model = snapshot.model.clone();
     let stored_base_url = snapshot.base_url.clone();
     let stored_reasoning_effort = snapshot.reasoning_effort;
-    let thinking_level_map =
-        resolve_model_metadata(snapshot.backend, &stored_model).thinking_level_map;
-    if stored_reasoning_effort.is_some_and(|effort| !thinking_level_map.is_supported(effort)) {
-        snapshot.reasoning_effort = thinking_level_map.max_supported_effort();
+    let metadata = resolve_model_metadata(snapshot.backend, &stored_model);
+    if let Some(effort) = stored_reasoning_effort {
+        if !metadata.thinking_level_map.is_supported(effort) {
+            snapshot.reasoning_effort =
+                metadata.thinking_level_map.closest_supported_effort(effort);
+        }
     }
-    let snapshot_settings = EffectiveModelSettings::new(
+    let authoritative = metadata.source.is_authoritative();
+    let snapshot_settings = EffectiveModelSettings::new_with_resolved(
         snapshot.backend,
         stored_model.clone(),
         stored_base_url.clone(),
         snapshot.reasoning_effort,
         snapshot.api_key_env.clone(),
         snapshot.extra_headers.clone(),
+        metadata,
     )
     .map_err(|error| {
         anyhow::anyhow!(
@@ -1199,7 +1228,15 @@ async fn build_resume_config_from_snapshot(
             "stored session model settings are invalid; settings repair required: model and base_url must be stored in normalized nonblank form"
         );
     }
-    if snapshot.reasoning_effort != stored_reasoning_effort {
+    if persist_recovery && snapshot.reasoning_effort != stored_reasoning_effort && authoritative {
+        let migration_lease;
+        if let Some(lease) = operation_lease {
+            lease.validate(&store_path, &snapshot.session_id)?;
+        } else {
+            migration_lease =
+                sessions::SessionOperationLease::try_acquire(&store_path, &snapshot.session_id)?;
+            migration_lease.validate(&store_path, &snapshot.session_id)?;
+        }
         snapshot.config_version = sessions::update_session_config(&store_path, &snapshot)?;
     }
     let client = ModelClient::from_effective_settings(snapshot_settings)
@@ -1517,6 +1554,7 @@ mod tests {
     ) -> SessionSnapshot {
         let base_url = match backend {
             BackendKind::TogetherChat => "https://api.together.xyz/v1",
+            BackendKind::AnthropicMessages => "https://api.anthropic.com/v1",
             BackendKind::ArceeApi => "https://api.arcee.ai/api/v1",
             _ => unreachable!(),
         };
@@ -2592,6 +2630,7 @@ X-Config = "yes"
             root.clone(),
             None,
             None,
+            true,
         )
         .await
         {
@@ -2753,7 +2792,7 @@ X-Config = "yes"
     }
 
     #[tokio::test]
-    async fn resume_durably_migrates_only_unsupported_persisted_efforts() {
+    async fn resume_recovers_effort_and_only_persists_authoritative_changes() {
         let _guard = TEST_ENV_LOCK.lock().unwrap();
         let key_name = "NAC_RESUME_EFFORT_MIGRATION_KEY";
         let original_key = std::env::var_os(key_name);
@@ -2767,30 +2806,30 @@ X-Config = "yes"
         let store_path = root.join("store.db");
         store::initialize(&store_path).unwrap();
 
-        for (session_id, backend, model, stored_effort, expected_effort, expected_version) in [
+        for (session_id, model, stored_effort, effective_effort, stored_after, version) in [
             (
-                "unsupported-effort",
-                BackendKind::TogetherChat,
-                "deepseek-ai/DeepSeek-V4-Pro",
-                ReasoningEffort::Medium,
-                Some(ReasoningEffort::Max),
+                "dated-family",
+                "claude-sonnet-4-6-20251001",
+                ReasoningEffort::Xhigh,
+                Some(ReasoningEffort::High),
+                Some(ReasoningEffort::High),
                 1,
             ),
             (
-                "supported-effort",
-                BackendKind::TogetherChat,
-                "deepseek-ai/DeepSeek-V4-Pro",
+                "supported",
+                "claude-sonnet-4-6-20251001",
                 ReasoningEffort::High,
+                Some(ReasoningEffort::High),
                 Some(ReasoningEffort::High),
                 0,
             ),
             (
-                "no-explicit-efforts",
-                BackendKind::ArceeApi,
-                "model",
-                ReasoningEffort::Low,
-                None,
-                1,
+                "provider-default",
+                "unknown-model",
+                ReasoningEffort::Medium,
+                Some(ReasoningEffort::None),
+                Some(ReasoningEffort::Medium),
+                0,
             ),
         ] {
             let active = create_and_resume_effort_snapshot(
@@ -2798,22 +2837,38 @@ X-Config = "yes"
                 &root,
                 key_name,
                 session_id,
-                backend,
+                BackendKind::AnthropicMessages,
                 model,
                 stored_effort,
             )
             .await;
-            assert_eq!(active.reasoning_effort, expected_effort);
-            assert_eq!(active.config_version, expected_version);
-
+            assert_eq!(active.reasoning_effort, effective_effort);
+            assert_eq!(active.config_version, version);
             let stored = sessions::load_session(&store_path, session_id).unwrap();
-            assert_eq!(stored.reasoning_effort, expected_effort);
-            assert_eq!(stored.config_version, expected_version);
+            assert_eq!(stored.reasoning_effort, stored_after);
+            assert_eq!(stored.config_version, version);
         }
 
-        unsafe { std::env::remove_var(key_name) };
+        let _ = std::fs::remove_dir_all(root);
+        restore_env(key_name, original_key);
+    }
+
+    #[tokio::test]
+    async fn resume_effort_migration_requires_operation_lease() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let key_name = "NAC_RESUME_EFFORT_LEASE_KEY";
+        let original_key = std::env::var_os(key_name);
+        unsafe { std::env::set_var(key_name, "test-key") };
+
+        let root = temp_store_path("resume_effort_lease")
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        std::fs::create_dir_all(&root).unwrap();
+        let store_path = root.join("store.db");
+        store::initialize(&store_path).unwrap();
         let snapshot = sessions::new_snapshot(
-            "missing-credential".to_string(),
+            "session".to_string(),
             root.clone(),
             "deepseek-ai/DeepSeek-V4-Pro".to_string(),
             "https://api.together.xyz/v1".to_string(),
@@ -2826,39 +2881,43 @@ X-Config = "yes"
             BTreeMap::new(),
         );
         sessions::create_session(&store_path, &snapshot).unwrap();
+
+        let lease = sessions::SessionOperationLease::try_acquire(&store_path, "session").unwrap();
         assert!(build_resume_config_for_session(
             store_path.clone(),
-            "missing-credential",
+            "session",
             &NacConfig::default(),
             root.clone(),
             None,
         )
         .await
         .is_err());
-        let stored = sessions::load_session(&store_path, "missing-credential").unwrap();
-        assert_eq!(stored.reasoning_effort, Some(ReasoningEffort::Max));
-        assert_eq!(stored.config_version, 1);
+        assert_eq!(
+            sessions::load_session(&store_path, "session")
+                .unwrap()
+                .reasoning_effort,
+            Some(ReasoningEffort::Medium)
+        );
 
-        unsafe { std::env::set_var(key_name, "test-key") };
-        let resumed_again = build_resume_config_for_session(
+        let resumed = build_resume_config_for_session_with_lease(
             store_path.clone(),
-            "unsupported-effort",
+            "session",
             &NacConfig::default(),
             root.clone(),
             None,
+            &lease,
         )
         .await
         .unwrap();
         assert_eq!(
-            resumed_again
-                .session
-                .into_snapshot()
-                .unwrap()
-                .config_version,
-            1,
-            "an already-migrated effort must not cause another write"
+            resumed.client.reasoning_effort(),
+            Some(ReasoningEffort::High)
         );
+        let stored = sessions::load_session(&store_path, "session").unwrap();
+        assert_eq!(stored.reasoning_effort, Some(ReasoningEffort::High));
+        assert_eq!(stored.config_version, 1);
 
+        drop(lease);
         let _ = std::fs::remove_dir_all(root);
         restore_env(key_name, original_key);
     }
@@ -3199,6 +3258,7 @@ X-Config = "yes"
             PathBuf::from("/local/resume/base"),
             None,
             None,
+            true,
         )
         .await
         {
@@ -3236,6 +3296,7 @@ X-Config = "yes"
             PathBuf::from("/local/resume/base"),
             None,
             None,
+            true,
         )
         .await
         {

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -11,8 +11,8 @@ use crate::agents_md::AgentsMdBundle;
 use crate::events::EventSink;
 use crate::mcp::{McpRegistry, McpRootPolicy, McpTransportPolicy};
 use crate::model::{
-    managed_backend_base_url, BackendKind, EffectiveModelSettings, ModelClient,
-    ModelConfigurationError, ReasoningEffort,
+    managed_backend_base_url, resolve_model_metadata, BackendKind, EffectiveModelSettings,
+    ModelClient, ModelConfigurationError, ReasoningEffort,
 };
 use crate::paths::PathContext;
 /// Public because callers outside this crate build the connections that sessions
@@ -1174,6 +1174,12 @@ async fn build_resume_config_from_snapshot(
     let paths = PathContext::new(&workspace_cwd);
     let stored_model = snapshot.model.clone();
     let stored_base_url = snapshot.base_url.clone();
+    let stored_reasoning_effort = snapshot.reasoning_effort;
+    let thinking_level_map =
+        resolve_model_metadata(snapshot.backend, &stored_model).thinking_level_map;
+    if stored_reasoning_effort.is_some_and(|effort| !thinking_level_map.is_supported(effort)) {
+        snapshot.reasoning_effort = thinking_level_map.max_supported_effort();
+    }
     let snapshot_settings = EffectiveModelSettings::new(
         snapshot.backend,
         stored_model.clone(),
@@ -1192,6 +1198,9 @@ async fn build_resume_config_from_snapshot(
         anyhow::bail!(
             "stored session model settings are invalid; settings repair required: model and base_url must be stored in normalized nonblank form"
         );
+    }
+    if snapshot.reasoning_effort != stored_reasoning_effort {
+        snapshot.config_version = sessions::update_session_config(&store_path, &snapshot)?;
     }
     let client = ModelClient::from_effective_settings(snapshot_settings)
         .map_err(|error| {
@@ -1497,6 +1506,48 @@ mod tests {
         }
     }
 
+    async fn create_and_resume_effort_snapshot(
+        store_path: &Path,
+        root: &Path,
+        key_name: &str,
+        session_id: &str,
+        backend: BackendKind,
+        model: &str,
+        stored_effort: ReasoningEffort,
+    ) -> SessionSnapshot {
+        let base_url = match backend {
+            BackendKind::TogetherChat => "https://api.together.xyz/v1",
+            BackendKind::ArceeApi => "https://api.arcee.ai/api/v1",
+            _ => unreachable!(),
+        };
+        let snapshot = sessions::new_snapshot(
+            session_id.to_string(),
+            root.to_path_buf(),
+            model.to_string(),
+            base_url.to_string(),
+            backend,
+            Some(stored_effort),
+            None,
+            None,
+            Vec::new(),
+            Some(key_name.to_string()),
+            BTreeMap::new(),
+        );
+        sessions::create_session(store_path, &snapshot).unwrap();
+        build_resume_config_for_session(
+            store_path.to_path_buf(),
+            session_id,
+            &NacConfig::default(),
+            root.to_path_buf(),
+            None,
+        )
+        .await
+        .unwrap()
+        .session
+        .into_snapshot()
+        .unwrap()
+    }
+
     /// A config whose `[model]` section resolves through the catalog:
     /// gpt-5.2 is unique to openai-responses, so the backend, the catalog
     /// endpoint default and the conventional credential variable all come
@@ -1508,7 +1559,8 @@ mod tests {
     }
 
     #[test]
-    fn compaction_threshold_defaults_to_70pct_context_normalizes_zero_and_rejects_out_of_range_values() {
+    fn compaction_threshold_defaults_to_70pct_context_normalizes_zero_and_rejects_out_of_range_values(
+    ) {
         // No request: defaults to 70% of the context window (rounded).
         assert_eq!(
             effective_orchestrator_compaction_threshold(None, 200_000).unwrap(),
@@ -2698,6 +2750,117 @@ X-Config = "yes"
             normalize_gpu_device("nvidia.com/gpu=mig1:0"),
             "nvidia.com/gpu=mig1:0"
         );
+    }
+
+    #[tokio::test]
+    async fn resume_durably_migrates_only_unsupported_persisted_efforts() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let key_name = "NAC_RESUME_EFFORT_MIGRATION_KEY";
+        let original_key = std::env::var_os(key_name);
+        unsafe { std::env::set_var(key_name, "test-key") };
+
+        let root = temp_store_path("resume_effort_migration")
+            .parent()
+            .unwrap()
+            .to_path_buf();
+        std::fs::create_dir_all(&root).unwrap();
+        let store_path = root.join("store.db");
+        store::initialize(&store_path).unwrap();
+
+        for (session_id, backend, model, stored_effort, expected_effort, expected_version) in [
+            (
+                "unsupported-effort",
+                BackendKind::TogetherChat,
+                "deepseek-ai/DeepSeek-V4-Pro",
+                ReasoningEffort::Medium,
+                Some(ReasoningEffort::Max),
+                1,
+            ),
+            (
+                "supported-effort",
+                BackendKind::TogetherChat,
+                "deepseek-ai/DeepSeek-V4-Pro",
+                ReasoningEffort::High,
+                Some(ReasoningEffort::High),
+                0,
+            ),
+            (
+                "no-explicit-efforts",
+                BackendKind::ArceeApi,
+                "model",
+                ReasoningEffort::Low,
+                None,
+                1,
+            ),
+        ] {
+            let active = create_and_resume_effort_snapshot(
+                &store_path,
+                &root,
+                key_name,
+                session_id,
+                backend,
+                model,
+                stored_effort,
+            )
+            .await;
+            assert_eq!(active.reasoning_effort, expected_effort);
+            assert_eq!(active.config_version, expected_version);
+
+            let stored = sessions::load_session(&store_path, session_id).unwrap();
+            assert_eq!(stored.reasoning_effort, expected_effort);
+            assert_eq!(stored.config_version, expected_version);
+        }
+
+        unsafe { std::env::remove_var(key_name) };
+        let snapshot = sessions::new_snapshot(
+            "missing-credential".to_string(),
+            root.clone(),
+            "deepseek-ai/DeepSeek-V4-Pro".to_string(),
+            "https://api.together.xyz/v1".to_string(),
+            BackendKind::TogetherChat,
+            Some(ReasoningEffort::Medium),
+            None,
+            None,
+            Vec::new(),
+            Some(key_name.to_string()),
+            BTreeMap::new(),
+        );
+        sessions::create_session(&store_path, &snapshot).unwrap();
+        assert!(build_resume_config_for_session(
+            store_path.clone(),
+            "missing-credential",
+            &NacConfig::default(),
+            root.clone(),
+            None,
+        )
+        .await
+        .is_err());
+        let stored = sessions::load_session(&store_path, "missing-credential").unwrap();
+        assert_eq!(stored.reasoning_effort, Some(ReasoningEffort::Max));
+        assert_eq!(stored.config_version, 1);
+
+        unsafe { std::env::set_var(key_name, "test-key") };
+        let resumed_again = build_resume_config_for_session(
+            store_path.clone(),
+            "unsupported-effort",
+            &NacConfig::default(),
+            root.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            resumed_again
+                .session
+                .into_snapshot()
+                .unwrap()
+                .config_version,
+            1,
+            "an already-migrated effort must not cause another write"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+        restore_env(key_name, original_key);
     }
 
     #[tokio::test]

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -12,7 +12,7 @@ use crate::events::EventSink;
 use crate::mcp::{McpRegistry, McpRootPolicy, McpTransportPolicy};
 use crate::model::{
     managed_backend_base_url, resolve_model_metadata, BackendKind, EffectiveModelSettings,
-    ModelClient, ModelConfigurationError, ReasoningEffort,
+    ModelClient, ModelConfigurationError, ModelMetadata, ReasoningEffort,
 };
 use crate::paths::PathContext;
 /// Public because callers outside this crate build the connections that sessions
@@ -1105,6 +1105,7 @@ pub async fn build_resume_config(
         options.worker_executable,
         None,
         true,
+        None,
     )
     .await
 }
@@ -1125,28 +1126,74 @@ pub async fn build_resume_config_for_session(
         worker_executable,
         None,
         true,
+        None,
     )
     .await
 }
 
-pub async fn build_resume_config_for_session_transient(
+pub async fn build_resume_config_for_session_attachment(
     store_path: PathBuf,
     session_id: &str,
     config: &NacConfig,
     resume_base_cwd: PathBuf,
     worker_executable: Option<PathBuf>,
-) -> Result<OrchestratorRunConfig> {
+) -> Result<(
+    OrchestratorRunConfig,
+    bool,
+    Option<sessions::SessionOperationLease>,
+)> {
     let snapshot = sessions::load_session(&store_path, session_id)?;
-    build_resume_config_from_snapshot(
-        snapshot,
-        store_path,
-        config,
-        resume_base_cwd,
-        worker_executable,
-        None,
-        false,
-    )
-    .await
+    let metadata = resolve_model_metadata(snapshot.backend, &snapshot.model);
+    let requires_migration = snapshot.reasoning_effort.is_some_and(|effort| {
+        metadata.source.is_authoritative() && !metadata.thinking_level_map.is_supported(effort)
+    });
+    if !requires_migration {
+        let run_config = build_resume_config_from_snapshot(
+            snapshot,
+            store_path,
+            config,
+            resume_base_cwd,
+            worker_executable,
+            None,
+            true,
+            Some(metadata),
+        )
+        .await?;
+        return Ok((run_config, true, None));
+    }
+
+    match sessions::SessionOperationLease::try_acquire(&store_path, session_id) {
+        Ok(lease) => {
+            let snapshot = sessions::load_session(&store_path, session_id)?;
+            let run_config = build_resume_config_from_snapshot(
+                snapshot,
+                store_path,
+                config,
+                resume_base_cwd,
+                worker_executable,
+                Some(&lease),
+                true,
+                None,
+            )
+            .await?;
+            Ok((run_config, true, Some(lease)))
+        }
+        Err(sessions::SessionOperationLeaseError::Busy(_)) => {
+            let run_config = build_resume_config_from_snapshot(
+                snapshot,
+                store_path,
+                config,
+                resume_base_cwd,
+                worker_executable,
+                None,
+                false,
+                Some(metadata),
+            )
+            .await?;
+            Ok((run_config, false, None))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub async fn build_resume_config_for_session_with_lease(
@@ -1167,6 +1214,7 @@ pub async fn build_resume_config_for_session_with_lease(
         worker_executable,
         Some(operation_lease),
         true,
+        None,
     )
     .await
 }
@@ -1179,6 +1227,7 @@ async fn build_resume_config_from_snapshot(
     worker_executable: Option<PathBuf>,
     operation_lease: Option<&sessions::SessionOperationLease>,
     persist_recovery: bool,
+    resolved_metadata: Option<ModelMetadata>,
 ) -> Result<OrchestratorRunConfig> {
     let mut snapshot = normalize_snapshot_paths(snapshot, &resume_base_cwd)?;
     // Resume reaches the host with the connection the session recorded, not with
@@ -1200,7 +1249,8 @@ async fn build_resume_config_from_snapshot(
     let stored_model = snapshot.model.clone();
     let stored_base_url = snapshot.base_url.clone();
     let stored_reasoning_effort = snapshot.reasoning_effort;
-    let metadata = resolve_model_metadata(snapshot.backend, &stored_model);
+    let metadata = resolved_metadata
+        .unwrap_or_else(|| resolve_model_metadata(snapshot.backend, &stored_model));
     if let Some(effort) = stored_reasoning_effort {
         if !metadata.thinking_level_map.is_supported(effort) {
             snapshot.reasoning_effort =
@@ -2631,6 +2681,7 @@ X-Config = "yes"
             None,
             None,
             true,
+            None,
         )
         .await
         {
@@ -3259,6 +3310,7 @@ X-Config = "yes"
             None,
             None,
             true,
+            None,
         )
         .await
         {
@@ -3297,6 +3349,7 @@ X-Config = "yes"
             None,
             None,
             true,
+            None,
         )
         .await
         {

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1258,27 +1258,53 @@ impl SessionManager {
     }
 
     async fn attach_session(&self, session_id: &str) -> Result<Arc<SessionService>> {
+        const MAX_ATTEMPTS: usize = 2;
+
         let gate = self.lifecycle_gate(session_id);
         let _lifecycle = gate.lock().await;
-        if let Some(service) = self.inner.active_sessions.read().await.get(session_id) {
-            return Ok(Arc::clone(service));
-        }
-        let operation_lease = match sessions::SessionOperationLease::try_acquire(
-            &self.inner.store_path,
-            session_id,
-        ) {
-            Ok(lease) => Some(lease),
-            Err(sessions::SessionOperationLeaseError::Busy(_)) => None,
-            Err(error) => return Err(error.into()),
-        };
-        if let Some(operation_lease) = operation_lease.as_ref() {
-            self.attach_session_locked(session_id, Some(operation_lease))
+        for _ in 0..MAX_ATTEMPTS {
+            if let Some(service) = self
+                .inner
+                .active_sessions
+                .read()
                 .await
-        } else {
-            self.resume_session(session_id, None, false)
+                .get(session_id)
+                .cloned()
+            {
+                let version = self.session_config(session_id)?.config_version;
+                if service.config_version() == Some(version) {
+                    return Ok(service);
+                }
+                let mut active = self.inner.active_sessions.write().await;
+                if active
+                    .get(session_id)
+                    .is_some_and(|cached| Arc::ptr_eq(cached, &service))
+                {
+                    active.remove(session_id);
+                }
+            }
+
+            let (service, cacheable, _operation_lease) =
+                self.resume_session_attachment(session_id).await?;
+            let service = Arc::new(service);
+            if !cacheable {
+                return Ok(service);
+            }
+            let version = self.session_config(session_id)?.config_version;
+            if service.config_version() != Some(version) {
+                continue;
+            }
+            self.inner
+                .active_sessions
+                .write()
                 .await
-                .map(Arc::new)
+                .insert(session_id.to_string(), Arc::clone(&service));
+            return Ok(service);
         }
+        Err(anyhow!(
+            "session '{}' configuration kept changing during attachment",
+            session_id
+        ))
     }
 
     /// Attaches while the caller holds this session's lifecycle gate. Keeping
@@ -1293,10 +1319,7 @@ impl SessionManager {
             return Ok(Arc::clone(service));
         }
 
-        let service = Arc::new(
-            self.resume_session(session_id, operation_lease, true)
-                .await?,
-        );
+        let service = Arc::new(self.resume_session(session_id, operation_lease).await?);
         let mut active = self.inner.active_sessions.write().await;
         if let Some(existing) = active.get(session_id) {
             return Ok(Arc::clone(existing));
@@ -1917,7 +1940,6 @@ impl SessionManager {
         &self,
         session_id: &str,
         operation_lease: Option<&sessions::SessionOperationLease>,
-        persist_recovery: bool,
     ) -> Result<SessionService> {
         let summary = self
             .list_sessions(false)
@@ -1942,17 +1964,8 @@ impl SessionManager {
                 operation_lease,
             )
             .await?
-        } else if persist_recovery {
-            runtime::build_resume_config_for_session(
-                self.inner.store_path.clone(),
-                session_id,
-                &config,
-                self.inner.root_cwd.clone(),
-                Some(self.inner.worker_executable.clone()),
-            )
-            .await?
         } else {
-            runtime::build_resume_config_for_session_transient(
+            runtime::build_resume_config_for_session(
                 self.inner.store_path.clone(),
                 session_id,
                 &config,
@@ -1962,6 +1975,43 @@ impl SessionManager {
             .await?
         };
         Ok(SessionService::from_orchestrator_run_config(run_config).service)
+    }
+
+    async fn resume_session_attachment(
+        &self,
+        session_id: &str,
+    ) -> Result<(
+        SessionService,
+        bool,
+        Option<sessions::SessionOperationLease>,
+    )> {
+        let summary = self
+            .list_sessions(false)
+            .await?
+            .into_iter()
+            .find(|entry| entry.summary.session_id == session_id)
+            .map(|entry| entry.summary)
+            .ok_or_else(|| anyhow!("session '{}' was not found", session_id))?;
+        let config_cwd = if summary.ssh_host.is_some() {
+            &self.inner.root_cwd
+        } else {
+            &summary.cwd
+        };
+        let config = NacConfig::load_without_model_from_cwd(config_cwd)?;
+        let (run_config, cacheable, operation_lease) =
+            runtime::build_resume_config_for_session_attachment(
+                self.inner.store_path.clone(),
+                session_id,
+                &config,
+                self.inner.root_cwd.clone(),
+                Some(self.inner.worker_executable.clone()),
+            )
+            .await?;
+        Ok((
+            SessionService::from_orchestrator_run_config(run_config).service,
+            cacheable,
+            operation_lease,
+        ))
     }
 }
 
@@ -6225,6 +6275,37 @@ thread_timeout_secs = 7200
     }
 
     #[tokio::test]
+    async fn ordinary_attachment_does_not_open_operation_lease_sidecar() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
+        let root = temp_root("attachment_without_effort_migration");
+        let nac_home = root.join("nac-home");
+        let _env = ScopedModelEnv::isolated(&nac_home, Some("server-test-key"));
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "server-test-key") };
+        let snapshot = sessions::new_snapshot(
+            "session".to_string(),
+            root.clone(),
+            "claude-sonnet-4-6-20251001".to_string(),
+            "https://api.anthropic.com/v1".to_string(),
+            BackendKind::AnthropicMessages,
+            Some(ReasoningEffort::High),
+            None,
+            None,
+            Vec::new(),
+            Some("ANTHROPIC_API_KEY".to_string()),
+            BTreeMap::new(),
+        );
+        sessions::create_session(&root.join("store.db"), &snapshot).unwrap();
+        std::fs::write(root.join("store.db.run-locks"), b"unavailable").unwrap();
+        let manager = test_manager(&root);
+
+        let first = manager.attach_session("session").await.unwrap();
+        let second = manager.attach_session("session").await.unwrap();
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(first.config_version(), Some(0));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn busy_attachment_is_transient_and_next_attach_observes_durable_config() {
         let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
         let root = temp_root("busy_transient_effort_recovery");
@@ -6276,6 +6357,8 @@ thread_timeout_secs = 7200
         assert_eq!(current.metadata().model, "claude-opus-4-6");
         assert_eq!(current.metadata().reasoning_effort.as_deref(), Some("high"));
         assert_eq!(current.config_version(), Some(1));
+        let cached = reader.attach_session("session").await.unwrap();
+        assert!(Arc::ptr_eq(&current, &cached));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1260,7 +1260,25 @@ impl SessionManager {
     async fn attach_session(&self, session_id: &str) -> Result<Arc<SessionService>> {
         let gate = self.lifecycle_gate(session_id);
         let _lifecycle = gate.lock().await;
-        self.attach_session_locked(session_id, None).await
+        if let Some(service) = self.inner.active_sessions.read().await.get(session_id) {
+            return Ok(Arc::clone(service));
+        }
+        let operation_lease = match sessions::SessionOperationLease::try_acquire(
+            &self.inner.store_path,
+            session_id,
+        ) {
+            Ok(lease) => Some(lease),
+            Err(sessions::SessionOperationLeaseError::Busy(_)) => None,
+            Err(error) => return Err(error.into()),
+        };
+        if let Some(operation_lease) = operation_lease.as_ref() {
+            self.attach_session_locked(session_id, Some(operation_lease))
+                .await
+        } else {
+            self.resume_session(session_id, None, false)
+                .await
+                .map(Arc::new)
+        }
     }
 
     /// Attaches while the caller holds this session's lifecycle gate. Keeping
@@ -1275,7 +1293,10 @@ impl SessionManager {
             return Ok(Arc::clone(service));
         }
 
-        let service = Arc::new(self.resume_session(session_id, operation_lease).await?);
+        let service = Arc::new(
+            self.resume_session(session_id, operation_lease, true)
+                .await?,
+        );
         let mut active = self.inner.active_sessions.write().await;
         if let Some(existing) = active.get(session_id) {
             return Ok(Arc::clone(existing));
@@ -1896,6 +1917,7 @@ impl SessionManager {
         &self,
         session_id: &str,
         operation_lease: Option<&sessions::SessionOperationLease>,
+        persist_recovery: bool,
     ) -> Result<SessionService> {
         let summary = self
             .list_sessions(false)
@@ -1920,8 +1942,17 @@ impl SessionManager {
                 operation_lease,
             )
             .await?
-        } else {
+        } else if persist_recovery {
             runtime::build_resume_config_for_session(
+                self.inner.store_path.clone(),
+                session_id,
+                &config,
+                self.inner.root_cwd.clone(),
+                Some(self.inner.worker_executable.clone()),
+            )
+            .await?
+        } else {
+            runtime::build_resume_config_for_session_transient(
                 self.inner.store_path.clone(),
                 session_id,
                 &config,
@@ -6190,6 +6221,61 @@ thread_timeout_secs = 7200
 
         stale_manager.cancel_active_run("session").await.unwrap();
         endpoint.abort();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn busy_attachment_is_transient_and_next_attach_observes_durable_config() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
+        let root = temp_root("busy_transient_effort_recovery");
+        let nac_home = root.join("nac-home");
+        let _env = ScopedModelEnv::isolated(&nac_home, Some("server-test-key"));
+        unsafe { std::env::set_var("ANTHROPIC_API_KEY", "server-test-key") };
+        let snapshot = sessions::new_snapshot(
+            "session".to_string(),
+            root.clone(),
+            "claude-sonnet-4-6-20251001".to_string(),
+            "https://api.anthropic.com/v1".to_string(),
+            BackendKind::AnthropicMessages,
+            Some(ReasoningEffort::Xhigh),
+            None,
+            None,
+            Vec::new(),
+            Some("ANTHROPIC_API_KEY".to_string()),
+            BTreeMap::new(),
+        );
+        sessions::create_session(&root.join("store.db"), &snapshot).unwrap();
+        let lease = sessions::SessionOperationLease::try_acquire(&root.join("store.db"), "session")
+            .unwrap();
+        let reader = test_manager(&root);
+        let writer = test_manager(&root);
+
+        let transient = reader.attach_session("session").await.unwrap();
+        assert_eq!(
+            transient.metadata().reasoning_effort.as_deref(),
+            Some("high")
+        );
+        let stored = sessions::load_session(&root.join("store.db"), "session").unwrap();
+        assert_eq!(stored.reasoning_effort, Some(ReasoningEffort::Xhigh));
+        assert_eq!(stored.config_version, 0);
+
+        drop(lease);
+        writer
+            .update_session_config(
+                "session",
+                UpdateConfigRequest {
+                    model: RequestField::Value("claude-opus-4-6".to_string()),
+                    reasoning_effort: RequestField::Value("high".to_string()),
+                    ..UpdateConfigRequest::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let current = reader.attach_session("session").await.unwrap();
+        assert_eq!(current.metadata().model, "claude-opus-4-6");
+        assert_eq!(current.metadata().reasoning_effort.as_deref(), Some("high"));
+        assert_eq!(current.config_version(), Some(1));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1210,6 +1210,47 @@ impl SessionManager {
             model.api_base_url.as_deref(),
             &NacConfig::load_credential_destination_policy(&location.config_cwd)?,
         )?;
+        // Validate the original (pre-remap) reasoning effort before
+        // `build_run_config` → `from_optional` silently remaps unsupported
+        // efforts to the highest supported level. This mirrors the
+        // defense-in-depth check in `update_session_config`.
+        if let Some(backend) = launch_backend {
+            let model_id = model
+                .api_model
+                .clone()
+                .or_else(|| config.model.model.clone());
+            if let Some(ref model_id) = model_id {
+                let selected_managed_base_url = model
+                    .backend
+                    .and_then(managed_backend_base_url)
+                    .map(str::to_string);
+                let validation_base_url = model
+                    .api_base_url
+                    .clone()
+                    .or(selected_managed_base_url);
+                let validation_effort = match &model.reasoning_effort {
+                    OptionalModelOption::Inherit => config.model.reasoning_effort,
+                    OptionalModelOption::Value(v) => Some(v.clone()),
+                    OptionalModelOption::Clear => None,
+                };
+                let validation_api_key_env = match &model.api_key_env {
+                    OptionalModelOption::Value(v) => Some(v.clone()),
+                    OptionalModelOption::Inherit | OptionalModelOption::Clear => None,
+                };
+                let validation_extra_headers = model
+                    .extra_headers
+                    .clone()
+                    .unwrap_or_else(|| config.model.extra_headers.clone());
+                validate_model_configuration(
+                    backend,
+                    model_id,
+                    validation_base_url.as_deref(),
+                    validation_effort,
+                    validation_api_key_env.as_deref(),
+                    &validation_extra_headers,
+                )?;
+            }
+        }
         let run_config = runtime::build_run_config(
             RunOptions {
                 workspace_cwd: location.workspace_cwd,

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1220,14 +1220,15 @@ impl SessionManager {
                 .clone()
                 .or_else(|| config.model.model.clone());
             if let Some(ref model_id) = model_id {
-                let selected_managed_base_url = model
-                    .backend
-                    .and_then(managed_backend_base_url)
-                    .map(str::to_string);
-                let validation_base_url = model
-                    .api_base_url
-                    .clone()
-                    .or(selected_managed_base_url);
+                // Resolve base_url through the full chain (caller-supplied →
+                // catalog default → managed canonical URL) using the resolved
+                // `launch_backend`, matching `EffectiveModelSettings::from_optional`.
+                // The previous narrow resolution (`api_base_url.or(model.backend
+                // .and_then(managed_backend_base_url))`) missed catalog defaults
+                // (arcee-api) and inferred managed backends (codex with no
+                // explicit `backend` field), causing valid creates to be rejected.
+                let validation_base_url =
+                    resolve_model_base_url(backend, model.api_base_url.clone())?;
                 let validation_effort = match &model.reasoning_effort {
                     OptionalModelOption::Inherit => config.model.reasoning_effort,
                     OptionalModelOption::Value(v) => Some(v.clone()),
@@ -1244,7 +1245,7 @@ impl SessionManager {
                 validate_model_configuration(
                     backend,
                     model_id,
-                    validation_base_url.as_deref(),
+                    Some(validation_base_url.as_str()),
                     validation_effort,
                     validation_api_key_env.as_deref(),
                     &validation_extra_headers,

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1210,48 +1210,6 @@ impl SessionManager {
             model.api_base_url.as_deref(),
             &NacConfig::load_credential_destination_policy(&location.config_cwd)?,
         )?;
-        // Validate the original (pre-remap) reasoning effort before
-        // `build_run_config` → `from_optional` silently remaps unsupported
-        // efforts to the highest supported level. This mirrors the
-        // defense-in-depth check in `update_session_config`.
-        if let Some(backend) = launch_backend {
-            let model_id = model
-                .api_model
-                .clone()
-                .or_else(|| config.model.model.clone());
-            if let Some(ref model_id) = model_id {
-                // Resolve base_url through the full chain (caller-supplied →
-                // catalog default → managed canonical URL) using the resolved
-                // `launch_backend`, matching `EffectiveModelSettings::from_optional`.
-                // The previous narrow resolution (`api_base_url.or(model.backend
-                // .and_then(managed_backend_base_url))`) missed catalog defaults
-                // (arcee-api) and inferred managed backends (codex with no
-                // explicit `backend` field), causing valid creates to be rejected.
-                let validation_base_url =
-                    resolve_model_base_url(backend, model.api_base_url.clone())?;
-                let validation_effort = match &model.reasoning_effort {
-                    OptionalModelOption::Inherit => config.model.reasoning_effort,
-                    OptionalModelOption::Value(v) => Some(v.clone()),
-                    OptionalModelOption::Clear => None,
-                };
-                let validation_api_key_env = match &model.api_key_env {
-                    OptionalModelOption::Value(v) => Some(v.clone()),
-                    OptionalModelOption::Inherit | OptionalModelOption::Clear => None,
-                };
-                let validation_extra_headers = model
-                    .extra_headers
-                    .clone()
-                    .unwrap_or_else(|| config.model.extra_headers.clone());
-                validate_model_configuration(
-                    backend,
-                    model_id,
-                    Some(validation_base_url.as_str()),
-                    validation_effort,
-                    validation_api_key_env.as_deref(),
-                    &validation_extra_headers,
-                )?;
-            }
-        }
         let run_config = runtime::build_run_config(
             RunOptions {
                 workspace_cwd: location.workspace_cwd,

--- a/crates/nac-server/src/tests/compaction.rs
+++ b/crates/nac-server/src/tests/compaction.rs
@@ -679,7 +679,7 @@ async fn manager_attached_during_external_compaction_refreshes_before_next_run()
         .get("session")
         .cloned()
         .unwrap();
-    assert!(!cached_b.has_active_operation());
+    assert!(Arc::ptr_eq(&current_b, &cached_b));
     tokio::time::timeout(Duration::from_secs(2), async {
         while current_b.has_active_operation() {
             tokio::task::yield_now().await;

--- a/crates/nac-server/src/tests/compaction.rs
+++ b/crates/nac-server/src/tests/compaction.rs
@@ -679,9 +679,9 @@ async fn manager_attached_during_external_compaction_refreshes_before_next_run()
         .get("session")
         .cloned()
         .unwrap();
-    assert!(Arc::ptr_eq(&cached_b, &current_b));
+    assert!(!cached_b.has_active_operation());
     tokio::time::timeout(Duration::from_secs(2), async {
-        while cached_b.has_active_operation() {
+        while current_b.has_active_operation() {
             tokio::task::yield_now().await;
         }
     })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches validation, stored session config on resume, and server session caching; wrong effort maps or migration could change behavior for existing sessions, though leases and authoritative-only persistence limit blast radius.
> 
> **Overview**
> **Reasoning-effort catalogs** are updated to match provider APIs: DeepSeek V4 uses **`max`** instead of **`xhigh`**; Fireworks/Together drop alias tiers (`medium`/`xhigh`) on GLM 5.2, DeepSeek V4, MiniMax M3, and Kimi K3; new per-model overrides and a regenerated **`catalog.json`**. Arcee passthrough maps now list only effort levels the Arcee API accepts, not full upstream Fireworks/Together sets.
> 
> **Session resume** maps unsupported stored efforts to the nearest supported tier via **`ThinkingLevelMap::closest_supported_effort`**, persists that change only when catalog metadata is **authoritative** (baseline/overlay/user override), and uses **`build_resume_config_for_session_attachment`** with operation leases so migration does not race config updates. **`EffectiveModelSettings`** no longer does a special **`xhigh`→`max`** rewrite at construction.
> 
> **Server attachment** goes through the new resume path, skips caching when a lease is busy (transient in-memory effort fix), and evicts cached **`SessionService`** when **`config_version`** changes after migration.
> 
> Catalog tests split Fireworks/Together checks into **`corrected_provider_effort_maps`** instead of duplicating per-model logic in the old matrix helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d52402374e9e351d6f9b78613414de2ec31ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->