### PR TITLE
feat(cli): add --version flag with build identity

### DIFF
--- a/crates/nac-server/build.rs
+++ b/crates/nac-server/build.rs
@@ -3,4 +3,41 @@
 // binary serving the previous assets.
 fn main() {
     println!("cargo:rerun-if-changed=assets");
+
+    // Embed the source revision so `--version` can distinguish two `edge`
+    // builds (the release channel is a mutable tag). Falls back to "unknown"
+    // when building from a source archive without git metadata.
+    let revision = git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=NAC_BUILD_REVISION={revision}");
+
+    // Re-run this script when the revision moves, otherwise incremental
+    // rebuilds keep a stale embedded revision. Watch HEAD plus the ref it
+    // points at (branch commits rewrite only the ref) and packed-refs (fresh
+    // clones may not have a loose ref file yet). Missing paths simply make
+    // Cargo re-run the script, which is cheap when nothing changed.
+    if let Some(git_dir) = git(&["rev-parse", "--git-dir"]) {
+        let git_dir = std::path::PathBuf::from(git_dir);
+        let head = git_dir.join("HEAD");
+        println!("cargo:rerun-if-changed={}", head.display());
+        println!("cargo:rerun-if-changed={}", git_dir.join("packed-refs").display());
+        if let Ok(contents) = std::fs::read_to_string(&head) {
+            if let Some(reference) = contents.trim().strip_prefix("ref: ") {
+                println!("cargo:rerun-if-changed={}", git_dir.join(reference).display());
+            }
+        }
+    }
+}
+
+/// Runs git with the given arguments and returns its trimmed stdout, or `None`
+/// when git is unavailable or the command fails.
+fn git(args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new("git").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stdout.is_empty() {
+        return None;
+    }
+    Some(stdout)
 }

--- a/crates/nac-server/build.rs
+++ b/crates/nac-server/build.rs
@@ -11,20 +11,25 @@ fn main() {
     println!("cargo:rustc-env=NAC_BUILD_REVISION={revision}");
 
     // Re-run this script when the revision moves, otherwise incremental
-    // rebuilds keep a stale embedded revision. Watch HEAD plus the ref it
-    // points at (branch commits rewrite only the ref) and packed-refs (fresh
-    // clones may not have a loose ref file yet). Missing paths simply make
-    // Cargo re-run the script, which is cheap when nothing changed.
-    if let Some(git_dir) = git(&["rev-parse", "--git-dir"]) {
-        let git_dir = std::path::PathBuf::from(git_dir);
-        let head = git_dir.join("HEAD");
+    // rebuilds keep a stale embedded revision. `--git-path` resolves HEAD in
+    // the per-worktree git directory while resolving refs and packed-refs in
+    // the common git directory shared by all worktrees.
+    if let Some(head) = git(&["rev-parse", "--git-path", "HEAD"]) {
+        let head = std::path::PathBuf::from(head);
         println!("cargo:rerun-if-changed={}", head.display());
-        println!("cargo:rerun-if-changed={}", git_dir.join("packed-refs").display());
+        watch_git_path("packed-refs");
         if let Ok(contents) = std::fs::read_to_string(&head) {
             if let Some(reference) = contents.trim().strip_prefix("ref: ") {
-                println!("cargo:rerun-if-changed={}", git_dir.join(reference).display());
+                watch_git_path(reference);
             }
         }
+    }
+}
+
+/// Tells Cargo to watch a path after Git resolves its worktree-aware location.
+fn watch_git_path(path: &str) {
+    if let Some(path) = git(&["rev-parse", "--git-path", path]) {
+        println!("cargo:rerun-if-changed={path}");
     }
 }
 

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -21,8 +21,17 @@ use nac_core::{
 };
 use nac_server::{serve_with, ServerOptions, SessionManager};
 
+/// Build identity for `--version`: package version plus the source revision,
+/// so two builds of the mutable `edge` release can be told apart.
+const BUILD_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("NAC_BUILD_REVISION"),
+    ")"
+);
+
 #[derive(Parser)]
-#[command(name = "nac-web", about = "web dashboard for managing nac sessions")]
+#[command(name = "nac-web", about = "web dashboard for managing nac sessions", version, long_version = BUILD_VERSION)]
 struct ServerCli {
     /// Address to bind (default: localhost only).
     #[arg(long, default_value = "127.0.0.1:3210")]
@@ -82,7 +91,7 @@ impl ServerCli {
 }
 
 #[derive(Parser)]
-#[command(name = "nac-web codex-auth", about = "manage ChatGPT Codex auth")]
+#[command(name = "nac-web codex-auth", about = "manage ChatGPT Codex auth", version, long_version = BUILD_VERSION)]
 struct CodexAuthCli {
     #[command(subcommand)]
     command: Option<CodexAuthCommand>,
@@ -99,7 +108,7 @@ enum CodexAuthCommand {
 }
 
 #[derive(Parser)]
-#[command(name = "nac-web arcee-auth", about = "manage Arcee auth")]
+#[command(name = "nac-web arcee-auth", about = "manage Arcee auth", version, long_version = BUILD_VERSION)]
 struct ArceeAuthCli {
     #[command(subcommand)]
     command: Option<ArceeAuthCommand>,
@@ -118,7 +127,9 @@ enum ArceeAuthCommand {
 #[derive(Parser)]
 #[command(
     name = "nac-web upgrade",
-    about = "reinstall the latest nac-web release"
+    about = "reinstall the latest nac-web release",
+    version,
+    long_version = BUILD_VERSION
 )]
 struct UpgradeCli {
     /// Install directory to replace (default: current nac-web executable directory)
@@ -886,6 +897,29 @@ thread_timeout_secs = 7200
                 .expect("out-of-range port must be rejected");
             assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
         }
+    }
+
+    #[test]
+    fn server_cli_version_reports_build_identity() {
+        let error = ServerCli::try_parse_from(["nac-web", "--version"])
+            .err()
+            .expect("--version must short-circuit parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+        let rendered = error.to_string();
+        assert!(rendered.contains(env!("CARGO_PKG_VERSION")), "{rendered}");
+        assert!(rendered.contains(env!("NAC_BUILD_REVISION")), "{rendered}");
+
+        // Rust CLI convention: the short flag prints the bare package version.
+        let short = ServerCli::try_parse_from(["nac-web", "-V"])
+            .err()
+            .expect("-V must short-circuit parsing");
+        assert_eq!(short.kind(), clap::error::ErrorKind::DisplayVersion);
+        let short_rendered = short.to_string();
+        assert!(
+            short_rendered.contains(env!("CARGO_PKG_VERSION")),
+            "{short_rendered}"
+        );
+        assert!(!short_rendered.contains('('), "{short_rendered}");
     }
 
     #[test]


### PR DESCRIPTION
## Description

**What.** Adds a standard `--version` flag with build identity to `nac-web` and its subcommand entry points.

**Why.** The documented installer uses the mutable `edge` release, so a report that says "installed edge" does not identify the exact binary; there was no way to distinguish two materially different builds.

Closes #45.

Note on scope: #45 was filed against the TUI `nac` binary, which was removed from main in the end-of-July UI cleanup (7a3c2d3). `nac-web` is now the only shipped binary, so the flag is implemented there. The acceptance criteria carry over unchanged.

Implementation:

- `crates/nac-server/build.rs` embeds the short source revision as `NAC_BUILD_REVISION` (falling back to `unknown` for source-archive builds without git metadata), and watches `HEAD`, the ref it points to, and `packed-refs` so incremental rebuilds cannot silently keep a stale revision.
- `crates/nac-server/src/main.rs` wires clap `version` / `long_version` on the four user-facing parsers (`ServerCli`, `CodexAuthCli`, `ArceeAuthCli`, `UpgradeCli`). The hidden internal `__worker` parser is deliberately excluded. Following Rust CLI convention, `-V` prints the bare package version while `--version` prints the full build identity.

## Usage

```console
$ nac-web --version
nac-web 0.1.0 (8285836)

$ nac-web -V
nac-web 0.1.0
```

Both flags short-circuit in clap before any session or model configuration is touched, so they work on a fresh install with an empty `NAC_HOME`.

## Changelog

- `nac-web` and its `codex-auth`, `arcee-auth`, and `upgrade` entry points now support `--version` (full build identity) and `-V` (bare version).

## Bug Evidence

Before this PR:

```console
$ nac-web --version
error: unexpected argument '--version' found

Usage: nac-web [OPTIONS]

For more information, try '--help'.
```

(exit status 2)

Root cause: the clap parsers declared no version metadata, so clap never generated the flag. After this PR the command exits 0 and prints the package version plus the source revision, which distinguishes two builds of the mutable `edge` tag.

## Validation

Ran `cargo test -p nac-server --bin nac-web`: 11/11 tests pass, including the new `server_cli_version_reports_build_identity` test, which asserts that `--version` short-circuits with `DisplayVersion` and renders both the package version and the embedded revision, and that `-V` renders the bare version. Manually verified the built binary: `--version` prints `nac-web 0.1.0 (8285836)` and exits 0, including with an empty `NAC_HOME` (no session init, no model configuration required); `-V` prints `nac-web 0.1.0`. Also verified the build script re-runs when its inputs change so the embedded revision cannot go stale on rebuilds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time git embedding and clap version metadata only; no runtime auth, networking, or session behavior changes.
> 
> **Overview**
> Adds **`--version` / `-V`** on `nac-web` and the **`codex-auth`**, **`arcee-auth`**, and **`upgrade`** entry points so installs from the mutable **`edge`** channel can be identified by source revision, not just package version.
> 
> **`build.rs`** now sets **`NAC_BUILD_REVISION`** from `git rev-parse --short HEAD` (or **`unknown`** without git) and registers **`cargo:rerun-if-changed`** on **`HEAD`**, its ref, and **`packed-refs`** so incremental builds don’t keep a stale revision.
> 
> **`main.rs`** defines **`BUILD_VERSION`** as `version (revision)` for clap **`long_version`**; **`--version`** prints the full string, **`-V`** the bare package version per Rust CLI convention. The internal **`__worker`** parser is unchanged. A unit test asserts both flags short-circuit with **`DisplayVersion`** and the expected output shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1504204c6d7c033f13a030ff816816ffc735b4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->