### PR TITLE
fix(catalog): seed arcee third-party models with real limits

### DIFF
--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -313,14 +313,18 @@ pub(super) fn map_arcee_api_response(body: &str) -> Result<Vec<ArceeOverlayEntry
 }
 
 fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
+    // Known third-party models fall back to their seeded limits when the API
+    // record omits them, so pre- and post-overlay values agree.
+    let seed_limits = super::seed::third_party_seed_limits(&model.id);
     let context_window = model
         .context_length
         .filter(|&c| c > 0)
+        .or(seed_limits.map(|(context, _)| context))
         .unwrap_or(super::FALLBACK_CONTEXT_WINDOW);
     let max_tokens = model
         .max_output_length
         .filter(|&m| m > 0)
-        .unwrap_or_else(|| arcee_max_tokens_fallback(&model.id, context_window));
+        .unwrap_or_else(|| arcee_max_tokens_fallback(&model.id));
     let max_tokens = max_tokens.min(context_window);
 
     let pricing = model.pricing.as_ref();
@@ -331,22 +335,22 @@ fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
         cache_write: parse_pricing_rate(pricing.and_then(|p| p.input_cache_writes.as_deref())),
     };
 
-    // Known passthrough models get a hardcoded effort map matching the
+    // Known third-party models get a hardcoded effort map matching the
     // underlying model's capabilities (the arcee API's
     // `supported_reasoning_efforts` is always null, so the API-derived map
     // is always empty). Unknown models and trinity-large-thinking fall back
     // to the API-derived map (empty), so validation rejects every explicit
     // effort for them.
-    let passthrough_map = passthrough_effort_map(&model.id);
-    let thinking_level_map = passthrough_map
+    let third_party_map = super::seed::third_party_effort_map(&model.id);
+    let thinking_level_map = third_party_map
         .clone()
         .unwrap_or_else(|| map_reasoning_efforts(model.supported_reasoning_efforts.as_deref()));
 
-    // Passthrough models always produce reasoning_content (confirmed via API
+    // Third-party models always produce reasoning_content (confirmed via API
     // testing); the `supported_features` field is null for some of them
     // (minimax-m3, kimi-k3, deepseek-v4-flash-latest), so the features check
-    // alone is unreliable. Any model with a passthrough effort map reasons.
-    let reasoning = passthrough_map.is_some()
+    // alone is unreliable. Any model with a third-party effort map reasons.
+    let reasoning = third_party_map.is_some()
         || model
             .supported_features
             .as_ref()
@@ -369,13 +373,12 @@ fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
     }
 }
 
-fn arcee_max_tokens_fallback(model_id: &str, context_window: u64) -> u64 {
+fn arcee_max_tokens_fallback(model_id: &str) -> u64 {
     match model_id {
         "trinity-large-thinking" => 80_000,
-        id if passthrough_effort_map(id).is_some() => {
-            262_144.min((context_window / 2).max(1))
-        }
-        _ => super::FALLBACK_MAX_TOKENS,
+        id => super::seed::third_party_seed_limits(id)
+            .map(|(_, max_tokens)| max_tokens)
+            .unwrap_or(super::FALLBACK_MAX_TOKENS),
     }
 }
 
@@ -391,46 +394,6 @@ fn parse_pricing_rate(value: Option<&str>) -> f64 {
     } else {
         per_million
     }
-}
-
-/// Effort map for known arcee passthrough models. The arcee API's
-/// `supported_reasoning_efforts` is always null, so the API-derived map is
-/// always empty. These models pass through to the same underlying models
-/// served by Fireworks/Together, but the arcee API accepts only a subset of
-/// the effort levels that the upstream providers accept (confirmed via API
-/// testing). The maps reflect what the arcee API actually honors.
-///
-/// Returns `None` for unknown models and trinity-large-thinking (arcee's own
-/// model, which rejects all `reasoning_effort` values).
-fn passthrough_effort_map(model_id: &str) -> Option<super::ThinkingLevelMap> {
-    let entries: &[(ReasoningEffort, &str)] = match model_id {
-        "deepseek-ai/deepseek-v4-pro" | "deepseek/deepseek-v4-flash-latest" => &[
-            (ReasoningEffort::None, "none"),
-            (ReasoningEffort::High, "high"),
-            (ReasoningEffort::Max, "max"),
-        ],
-        "zai-org/glm-5.2" => &[
-            (ReasoningEffort::None, "none"),
-            (ReasoningEffort::High, "high"),
-            (ReasoningEffort::Max, "max"),
-        ],
-        "moonshotai/kimi-k3" => &[
-            (ReasoningEffort::Low, "low"),
-            (ReasoningEffort::High, "high"),
-            (ReasoningEffort::Max, "max"),
-        ],
-        "minimaxai/minimax-m3" => &[
-            (ReasoningEffort::None, "none"),
-            (ReasoningEffort::Max, "max"),
-        ],
-        _ => return None,
-    };
-    Some(super::ThinkingLevelMap(
-        entries
-            .iter()
-            .map(|(effort, wire)| (*effort, Some((*wire).to_string())))
-            .collect(),
-    ))
 }
 
 /// Map the API's `supported_reasoning_efforts` array to a
@@ -500,8 +463,7 @@ pub(super) fn merge_arcee_overlay(
     let mut models = BTreeMap::new();
     for mut entry in entries {
         if entry.model.max_tokens == super::FALLBACK_MAX_TOKENS {
-            entry.model.max_tokens =
-                arcee_max_tokens_fallback(&entry.id, entry.model.context_window);
+            entry.model.max_tokens = arcee_max_tokens_fallback(&entry.id);
         }
         models.insert(entry.id.clone(), entry.model);
     }

--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -465,6 +465,9 @@ pub(super) fn merge_arcee_overlay(
         if entry.model.max_tokens == super::FALLBACK_MAX_TOKENS {
             entry.model.max_tokens = arcee_max_tokens_fallback(&entry.id);
         }
+        // Same cap as `map_arcee_model`: a stale or sparse cache entry must
+        // never carry max_tokens above its context window.
+        entry.model.max_tokens = entry.model.max_tokens.min(entry.model.context_window);
         models.insert(entry.id.clone(), entry.model);
     }
 

--- a/crates/nac-core/src/model/catalog/overlay_tests.rs
+++ b/crates/nac-core/src/model/catalog/overlay_tests.rs
@@ -1085,3 +1085,42 @@ fn overlay_provider_snapshot_retires_missing_baseline_models() {
     assert_eq!(provider.models.len(), 1);
     assert!(!provider.models.contains_key("deepseek-chat"));
 }
+
+#[test]
+fn arcee_overlay_load_caps_healed_max_tokens_at_context_window() {
+    let _guard = TEST_ENV_LOCK.lock().unwrap();
+    let home = TempHome::new("arcee-heal-cap");
+    // A stale cache entry from before the fallback heal existed: sparse
+    // context window with the old 16k fallback max_tokens. The heal replaces
+    // 16k with the seeded 256k, which must then be capped at the entry's
+    // context window (mirroring `map_arcee_model`).
+    let dir = overlay_dir(home.path());
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("arcee-overlay.json"),
+        serde_json::json!([{
+            "id": "deepseek/deepseek-v4-flash-latest",
+            "display_name": "DeepSeek-V4-Flash",
+            "context_window": 128_000,
+            "max_tokens": 16_384,
+            "cost": { "input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0 },
+            "reasoning": true,
+            "thinking_level_map": {},
+            "adaptive_thinking": false,
+            "enabled_thinking": false,
+            "context_management": false,
+            "clear_thinking": false
+        }])
+        .to_string(),
+    )
+    .unwrap();
+
+    let (catalog, warnings) = ModelCatalog::load_from_home(Some(home.path()));
+
+    assert!(warnings.is_empty(), "{warnings:?}");
+    let metadata = catalog.resolve(
+        BackendKind::ArceeAuth,
+        "deepseek/deepseek-v4-flash-latest",
+    );
+    assert_eq!(metadata.max_tokens, 128_000);
+}

--- a/crates/nac-core/src/model/catalog/seed.rs
+++ b/crates/nac-core/src/model/catalog/seed.rs
@@ -17,7 +17,9 @@
 //! standard OpenAI API's 1.05M for the same GPT-5.6 models; max output
 //! tokens and pricing match the models.dev openai baseline. Every entry's
 //! thinking map still matches the provider's matrix behavior exactly —
-//! codex all-levels verbatim, arcee rejects every explicit effort.
+//! codex all-levels verbatim, arcee rejects every explicit effort except on
+//! the seeded third-party models (whose maps come from
+//! [`ARCEE_THIRD_PARTY_SEED_MODELS`]).
 
 use super::{
     api_kind_for, Compat, CompletionsThinkingFormat, ModelCatalog, ModelCostRates, ModelMetadata,
@@ -236,6 +238,107 @@ fn codex_seed_models() -> Vec<ModelMetadata> {
     ]
 }
 
+/// Effort tiers for the seeded arcee third-party models. The arcee API's
+/// `supported_reasoning_efforts` is always null, so the API-derived map is
+/// always empty; these tiers are what the arcee API actually honors for each
+/// model family (confirmed via API testing, PR #128): deepseek/glm take
+/// none/high/max, kimi low/high/max (thinking is always enabled), minimax
+/// none/max (a thinking toggle, not graduated efforts).
+const THIRD_PARTY_NONE_HIGH_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
+    (ReasoningEffort::None, "none"),
+    (ReasoningEffort::High, "high"),
+    (ReasoningEffort::Max, "max"),
+];
+const THIRD_PARTY_LOW_HIGH_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
+    (ReasoningEffort::Low, "low"),
+    (ReasoningEffort::High, "high"),
+    (ReasoningEffort::Max, "max"),
+];
+const THIRD_PARTY_NONE_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
+    (ReasoningEffort::None, "none"),
+    (ReasoningEffort::Max, "max"),
+];
+
+/// One seeded arcee third-party model.
+pub(super) struct ThirdPartySeedModel {
+    /// Model id exactly as the arcee API lists it.
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub context_window: u64,
+    pub max_tokens: u64,
+    /// Effort levels the arcee API honors for this model (see the tier
+    /// consts above).
+    pub efforts: &'static [(ReasoningEffort, &'static str)],
+}
+
+/// The seeded arcee third-party lineup. This table is the single source of
+/// truth for the class: the seed catalog registers these entries, the arcee
+/// overlay derives effort maps and fallback limits from it, and the catalog
+/// tests read it (including the pre-S4 validation-matrix exemption).
+///
+/// To release a new model or drop an old one, add or remove a row here —
+/// that one edit is complete. Limits follow the underlying models' published
+/// values (max output capped at 256k); pricing is unpublished (zero =
+/// unknown) and arrives with the live overlay.
+pub(super) const ARCEE_THIRD_PARTY_SEED_MODELS: &[ThirdPartySeedModel] = &[
+    ThirdPartySeedModel {
+        id: "deepseek/deepseek-v4-flash-latest",
+        display_name: "DeepSeek-V4-Flash",
+        context_window: 1_000_000,
+        max_tokens: 262_144,
+        efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
+    },
+    ThirdPartySeedModel {
+        id: "deepseek-ai/deepseek-v4-pro",
+        display_name: "DeepSeek-V4-Pro",
+        context_window: 1_000_000,
+        max_tokens: 262_144,
+        efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
+    },
+    ThirdPartySeedModel {
+        id: "zai-org/glm-5.2",
+        display_name: "GLM-5.2",
+        context_window: 524_288,
+        max_tokens: 164_000,
+        efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
+    },
+    ThirdPartySeedModel {
+        id: "moonshotai/kimi-k3",
+        display_name: "Kimi-K3",
+        context_window: 1_048_576,
+        max_tokens: 131_072,
+        efforts: THIRD_PARTY_LOW_HIGH_MAX_LEVELS,
+    },
+    ThirdPartySeedModel {
+        id: "minimaxai/minimax-m3",
+        display_name: "MiniMax-M3",
+        context_window: 524_288,
+        max_tokens: 250_000,
+        efforts: THIRD_PARTY_NONE_MAX_LEVELS,
+    },
+];
+
+/// Effort map for a known arcee third-party model, looked up from
+/// [`ARCEE_THIRD_PARTY_SEED_MODELS`]. Returns `None` for unknown models and
+/// trinity-large-thinking (arcee's own model, which rejects all
+/// `reasoning_effort` values).
+pub(super) fn third_party_effort_map(model_id: &str) -> Option<ThinkingLevelMap> {
+    ARCEE_THIRD_PARTY_SEED_MODELS
+        .iter()
+        .find(|model| model.id == model_id)
+        .map(|model| levels(model.efforts))
+}
+
+/// Seeded (context window, max output) for a known arcee third-party model.
+/// The arcee overlay falls back to these when the API record omits the
+/// fields, so pre- and post-overlay limits agree for the same model.
+pub(super) fn third_party_seed_limits(model_id: &str) -> Option<(u64, u64)> {
+    ARCEE_THIRD_PARTY_SEED_MODELS
+        .iter()
+        .find(|model| model.id == model_id)
+        .map(|model| (model.context_window, model.max_tokens))
+}
+
 /// Arcee known models (shared by arcee-auth and arcee-api): the Trinity
 /// lineup from Arcee's own docs (docs.arcee.ai/get-started/models-overview
 /// and /pricing). `trinity-large-thinking` is the documented hosted API id
@@ -248,9 +351,15 @@ fn codex_seed_models() -> Vec<ModelMetadata> {
 /// conservative fallback. Cache pricing is undocumented (zero = unknown).
 /// Effort maps stay empty for the Trinity models: trinity-large-thinking
 /// always reasons (no effort knob), and the non-thinking variants accept no
-/// reasoning control. The Arcee passthrough models (deepseek-v4-pro, glm-5.2,
-/// etc.) get their effort maps from the arcee overlay's
-/// `passthrough_effort_map`. `reasoning` marks the thinking variant's
+/// reasoning control. The Arcee third-party models (deepseek-v4-pro, glm-5.2,
+/// etc.) are seeded too — from [`ARCEE_THIRD_PARTY_SEED_MODELS`], which the
+/// arcee overlay also reads — so the frontend's default pick resolves real
+/// limits even before the live overlay loads; without a seed entry they fall
+/// through to the provider `_default` clone and requests go out with the 16k
+/// fallback max_tokens (issue #124). Their limits follow the underlying
+/// models' published values (max output capped at 256k); third-party pricing
+/// is unpublished (zero = unknown). The overlay still upgrades every field
+/// once live data arrives. `reasoning` marks the thinking variant's
 /// reasoning_content output.
 fn arcee_seed_models(provider: BackendKind) -> Vec<ModelMetadata> {
     let model =
@@ -271,7 +380,24 @@ fn arcee_seed_models(provider: BackendKind) -> Vec<ModelMetadata> {
                 ),
             )
         };
-    vec![
+    let third_party = |seed: &ThirdPartySeedModel| {
+        seeded_model(
+            provider,
+            seed.id,
+            seed.display_name,
+            seed.context_window,
+            seed.max_tokens,
+            rates(0.0, 0.0, 0.0, 0.0),
+            true,
+            levels(seed.efforts),
+            completions_compat(
+                Some(CompletionsThinkingFormat::Arcee),
+                "reasoning_content",
+                Some(0.0),
+            ),
+        )
+    };
+    let mut models = vec![
         model(
             "trinity-large-thinking",
             "Trinity-Large-Thinking",
@@ -293,7 +419,9 @@ fn arcee_seed_models(provider: BackendKind) -> Vec<ModelMetadata> {
             rates(0.45, 0.15, 0.0, 0.0),
             false,
         ),
-    ]
+    ];
+    models.extend(ARCEE_THIRD_PARTY_SEED_MODELS.iter().map(third_party));
+    models
 }
 
 pub(super) fn seed_catalog() -> ModelCatalog {
@@ -433,7 +561,7 @@ pub(super) fn seed_catalog() -> ModelCatalog {
     );
     for backend in [BackendKind::ArceeAuth, BackendKind::ArceeApi] {
         register(
-            // Arcee passthrough models accept bare `reasoning_effort`; the
+            // Arcee third-party models accept bare `reasoning_effort`; the
             // Arcee thinking format sends it without wrapper objects. The
             // seed models (trinity-*) keep an empty thinking_level_map, so
             // validation rejects every explicit effort and the format is

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -317,7 +317,7 @@ fn wire_level_special_cases_are_encoded_in_data() {
 
     // Arcee's _default entry has the Arcee thinking format (bare
     // reasoning_effort) but an empty thinking_level_map, so unknown models
-    // accept no explicit effort levels. The passthrough models get their
+    // accept no explicit effort levels. The third-party models get their
     // effort maps from the arcee overlay at runtime.
     for backend in [BackendKind::ArceeAuth, BackendKind::ArceeApi] {
         let arcee = resolve(backend, "arcee-model");
@@ -486,13 +486,71 @@ fn hand_seeded_arcee_and_codex_entries_carry_documented_values() {
             assert_eq!(metadata.cost.cache_write, 0.0, "{backend}/{id}");
             assert_eq!(metadata.reasoning, *reasoning, "{backend}/{id}");
             // Trinity models accept no explicit effort levels (empty map).
-            // The passthrough models get their maps from the arcee overlay.
+            // The seeded third-party models carry their own maps (see the
+            // arcee_third-party_models_are_seeded_with_real_limits test).
             assert!(metadata.thinking_level_map.0.is_empty(), "{backend}/{id}");
             // The completions compat matches the provider default.
             let default = resolve(backend, "model-with-no-catalog-entry");
             assert_eq!(metadata.compat, default.compat, "{backend}/{id}");
         }
     }
+}
+
+#[test]
+fn arcee_third_party_models_are_seeded_with_real_limits() {
+    // The frontend's default pick (deepseek/deepseek-v4-flash-latest) and the
+    // other third-party models must resolve to real seeded limits even before
+    // the live arcee overlay loads — otherwise they fall through to the
+    // provider `_default` clone and requests go out with the 16k fallback
+    // max_tokens (issue #124). Limits follow the underlying models' published
+    // values, max output capped at 256k.
+    for backend in [BackendKind::ArceeAuth, BackendKind::ArceeApi] {
+        for seed in super::seed::ARCEE_THIRD_PARTY_SEED_MODELS {
+            let id = seed.id;
+            let metadata = resolve(backend, id);
+            assert_eq!(metadata.id, id, "{backend}/{id}");
+            assert_eq!(metadata.source, ModelSource::Baseline, "{backend}/{id}");
+            assert_eq!(
+                metadata.display_name.as_deref(),
+                Some(seed.display_name),
+                "{backend}/{id}"
+            );
+            assert_eq!(metadata.context_window, seed.context_window, "{backend}/{id}");
+            assert_eq!(metadata.max_tokens, seed.max_tokens, "{backend}/{id}");
+            assert!(metadata.reasoning, "{backend}/{id}");
+            // The seeded map carries exactly the table's effort tiers.
+            for (effort, wire) in seed.efforts {
+                assert_eq!(
+                    metadata.thinking_level_map.wire_value(*effort),
+                    Some(*wire),
+                    "{backend}/{id} {}",
+                    effort.as_str()
+                );
+            }
+            assert_eq!(
+                metadata.thinking_level_map.0.len(),
+                seed.efforts.len(),
+                "{backend}/{id}"
+            );
+            // The completions compat matches the provider default.
+            let default = resolve(backend, "model-with-no-catalog-entry");
+            assert_eq!(metadata.compat, default.compat, "{backend}/{id}");
+        }
+    }
+    // Spot-check the family differences: deepseek tops out at max, kimi has
+    // no `none` (thinking is always enabled), minimax is a none/max toggle.
+    let flash = resolve(BackendKind::ArceeAuth, "deepseek/deepseek-v4-flash-latest");
+    assert_eq!(
+        flash.thinking_level_map.wire_value(ReasoningEffort::Max),
+        Some("max")
+    );
+    let kimi = resolve(BackendKind::ArceeAuth, "moonshotai/kimi-k3");
+    assert_eq!(kimi.thinking_level_map.wire_value(ReasoningEffort::None), None);
+    let minimax = resolve(BackendKind::ArceeAuth, "minimaxai/minimax-m3");
+    assert_eq!(
+        minimax.thinking_level_map.wire_value(ReasoningEffort::High),
+        None
+    );
 }
 
 #[test]
@@ -548,13 +606,16 @@ fn generated_baseline_merges_real_models_dev_data_over_the_seeds() {
 }
 
 #[test]
-fn arcee_passthrough_without_output_limit_gets_a_large_safe_default() {
+fn arcee_third_party_without_output_limit_gets_a_large_safe_default() {
+    // A third-party id with a sparse API record falls back to its seeded
+    // limits (262_144 for deepseek-v4-pro), so pre- and post-overlay values
+    // agree; trinity-large-thinking keeps its documented 80k.
     let entries = arcee_overlay::map_arcee_api_response(
         r#"{"data":[{"id":"deepseek-ai/deepseek-v4-pro","context_length":512000},{"id":"trinity-large-thinking","context_length":128000}]}"#,
     )
     .unwrap();
     let entry = serde_json::to_value(&entries[0]).unwrap();
-    assert_eq!(entry["max_tokens"], 256_000);
+    assert_eq!(entry["max_tokens"], 262_144);
     assert_eq!(
         serde_json::to_value(&entries[1]).unwrap()["max_tokens"],
         80_000
@@ -616,10 +677,10 @@ fn generated_entries_satisfy_catalog_invariants() {
             }
         }
     }
-    // Snapshot pin: 78 agent-compatible generated models plus 11 hand-seeded
+    // Snapshot pin: 79 agent-compatible generated models plus 21 hand-seeded
     // entries (2 deprecated deepseek models removed). Drift fails loudly here
     // at regen/seed-edit time, forcing a deliberate review.
-    assert_eq!(entry_count, 90, "catalog model count drifted");
+    assert_eq!(entry_count, 100, "catalog model count drifted");
 }
 
 /// The S4 guard: every generated catalog entry — not just the S0 spot-check
@@ -640,6 +701,16 @@ fn every_generated_entry_preserves_the_validation_matrix() {
     // because every writer is serialized by TEST_ENV_LOCK, which this test
     // holds.)
     let catalog = current();
+    // Seeded arcee third-party models are the documented exception: the
+    // pre-S4 matrix rejects every explicit effort on arcee, but these models
+    // accept effort in production whenever the live arcee overlay is loaded
+    // (the overlay stamps the same maps). Seeding the maps makes the
+    // pre-overlay behavior match the post-overlay behavior instead of
+    // flipping validation when the overlay lands.
+    let matrix_exempt: Vec<&str> = super::seed::ARCEE_THIRD_PARTY_SEED_MODELS
+        .iter()
+        .map(|model| model.id)
+        .collect();
     for (provider, provider_catalog) in &catalog.providers {
         if matches!(
             provider,
@@ -650,6 +721,11 @@ fn every_generated_entry_preserves_the_validation_matrix() {
         for (id, metadata) in &provider_catalog.models {
             assert_eq!(metadata.id, *id, "{provider}/{id}");
             assert_eq!(metadata.source, ModelSource::Baseline, "{provider}/{id}");
+            if matches!(*provider, BackendKind::ArceeAuth | BackendKind::ArceeApi)
+                && matrix_exempt.contains(&id.as_str())
+            {
+                continue;
+            }
             for effort in ALL_EFFORTS {
                 let matrix = pre_s4_matrix_accepts(*provider, id, effort);
                 let supported = metadata.thinking_level_map.is_supported(effort);
@@ -1100,7 +1176,7 @@ fn api_listing_lists_only_real_entries_with_defaults_in_default_limits() {
         total += provider.models.len();
     }
     // Same snapshot pin as `generated_entries_satisfy_catalog_invariants`.
-    assert_eq!(total, 90, "catalog model count drifted");
+    assert_eq!(total, 100, "catalog model count drifted");
 
     // The hand-seeded providers serve their maintained entries (the picker's
     // model lists) while their `_default` limits stay conservative fallbacks
@@ -1127,7 +1203,7 @@ fn api_listing_lists_only_real_entries_with_defaults_in_default_limits() {
             .iter()
             .find(|provider| provider.id == backend)
             .unwrap();
-        assert_eq!(provider.models.len(), 3, "{backend}");
+        assert_eq!(provider.models.len(), 8, "{backend}");
         assert!(
             provider
                 .models

--- a/crates/nac-core/src/model/tests/completions.rs
+++ b/crates/nac-core/src/model/tests/completions.rs
@@ -189,11 +189,11 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
         "Arcee: effort-free shape (bare reasoning_effort dialect)"
     );
 
-    // Arcee passthrough models: the Arcee format sends bare
+    // Arcee third-party models: the Arcee format sends bare
     // `reasoning_effort` — no `thinking`, `reasoning_history`, or
     // `chat_template_kwargs` wrapper objects. The wire value comes from the
-    // catalog map (max → "max" for deepseek passthrough models).
-    let arcee_passthrough_levels = ThinkingLevelMap(std::collections::BTreeMap::from([
+    // catalog map (max → "max" for deepseek third-party models).
+    let arcee_third_party_levels = ThinkingLevelMap(std::collections::BTreeMap::from([
         (ReasoningEffort::None, Some("none".to_string())),
         (ReasoningEffort::High, Some("high".to_string())),
         (ReasoningEffort::Max, Some("max".to_string())),
@@ -208,7 +208,7 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
         Some(ReasoningEffort::None),
         &messages,
         &[],
-        &arcee_passthrough_levels,
+        &arcee_third_party_levels,
         &arcee_compat,
         CompletionsMessageShape::Standard,
     );
@@ -223,7 +223,7 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
         Some(ReasoningEffort::High),
         &messages,
         &[],
-        &arcee_passthrough_levels,
+        &arcee_third_party_levels,
         &arcee_compat,
         CompletionsMessageShape::Standard,
     );
@@ -238,7 +238,7 @@ fn one_completions_builder_reproduces_every_provider_shape_from_compat() {
         Some(ReasoningEffort::Max),
         &messages,
         &[],
-        &arcee_passthrough_levels,
+        &arcee_third_party_levels,
         &arcee_compat,
         CompletionsMessageShape::Standard,
     );


### PR DESCRIPTION
## Description

**What.** Seeds the five known arcee third-party models (deepseek-v4-flash-latest, deepseek-v4-pro, glm-5.2, kimi-k3, minimax-m3) into the hand-written seed catalog with real limits and effort maps, so they resolve correct max_tokens even before the live arcee overlay loads.

**Why.** Requests for the frontend's default model went out with `max_tokens: 16384` and came back `finish_reason: "length"`, truncating long responses.

Closes #124.

Root cause: the third-party models only existed in the live arcee overlay, which is fetched from the API after startup — and skipped entirely when the user isn't authenticated yet (with no retry until the next process start). In that window, these models resolve through the provider `_default` clone, which carries `FALLBACK_MAX_TOKENS = 16384`; the completions request path then sends `max_tokens.min(262_144)`, so 16384 hit the wire. The frontend's default pick (`deepseek/deepseek-v4-flash-latest`, catalog.ts) lands in exactly this window on a fresh install: start server, log in via the UI, send a message — the overlay was never fetched.

Implementation:

- `crates/nac-core/src/model/catalog/seed.rs`: new `ARCEE_THIRD_PARTY_SEED_MODELS` table — (id, display name, context window, max output, effort tiers) — the single source of truth for the class. Limits follow the underlying models' deepseek/fireworks/together catalog values, max output capped at 256k; pricing is unpublished (zero = unknown). `third_party_effort_map` and `third_party_seed_limits` are lookups into this table.
- `crates/nac-core/src/model/catalog/arcee_overlay.rs`: the overlay's own effort-map match arms and the `262_144.min(ctx/2)` fallback heuristic are deleted; both now read the seed table, so pre- and post-overlay limits agree by construction and the id list exists in exactly one place. The live overlay still replaces these entries wholesale when it loads — seeding changes nothing about overlay precedence.

Behavior changes to be aware of:

- The model picker now lists 5 additional arcee models per backend before the first overlay refresh (previously only the 3 Trinity models appeared until the overlay landed).
- Pre-overlay validation now accepts explicit reasoning effort for these 5 models — matching what already happened once the overlay loaded (previously validation flipped when the overlay landed).
- Seeded pricing is zero (unknown) until the overlay supplies live rates.
- When the arcee API record omits `max_output_length`, the overlay fallback for glm-5.2 / kimi-k3 / minimax-m3 now yields the grounded seeded values (164_000 / 131_072 / 250_000) instead of the old heuristic's 262_144; deepseek flash/pro stay at 262_144.

## Bug Evidence

Before this PR, resolving the default pick on a fresh catalog (no overlay) fell through to the provider default:

```text
resolve(arcee-auth, "deepseek/deepseek-v4-flash-latest").source == ProviderDefault
max_tokens == 16_384   // sent on the wire as max_tokens.min(262_144)
```

The new test `arcee_third_party_models_are_seeded_with_real_limits` failed on exactly this assertion (`ProviderDefault` vs `Baseline`) before the fix and passes after; the wire path now sends 262_144 for the default pick.

## Changelog

- Fixes hidden 16k max_tokens truncation for arcee third-party models (including the default model) when the live model overlay has not loaded yet.

## Validation

Ran `cargo test -p nac-core --lib model::catalog` (64/64) and the full workspace suite (`cargo test --workspace`: 745 nac-core lib tests plus all other targets, 0 failures). The reproduction test was verified to fail before the fix (`source == ProviderDefault`) and pass after. Baseline comparison on an unmodified checkout confirmed the only pre-existing-behavior change during development was the deliberate snapshot-pin updates (90→100 catalog entries, 3→8 arcee models per backend listing) and the sparse-record fallback expectation (256_000→262_144 for deepseek-v4-pro).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model catalog resolution, request `max_tokens`, and reasoning-effort validation for a heavily used default path; behavior is intentional but wider than a one-line fix.
> 
> **Overview**
> Fixes **16k `max_tokens` truncation** for Arcee third-party models (including the default `deepseek/deepseek-v4-flash-latest`) when the live Arcee overlay has not loaded yet—e.g. fresh install before login when overlay refresh is skipped.
> 
> Introduces **`ARCEE_THIRD_PARTY_SEED_MODELS`** in `seed.rs` as the single source of truth for five third-party models (limits, effort maps). Those entries are registered in the hand-seeded Arcee catalog; **`arcee_overlay.rs` drops duplicated `passthrough_effort_map` logic** and reads `third_party_effort_map` / `third_party_seed_limits` instead so seed and overlay agree. Cached overlay load **heals stale 16k fallbacks** and **caps `max_tokens` at `context_window`**.
> 
> Pre-overlay behavior shifts: the picker shows five more models per Arcee backend, reasoning effort validates for them before overlay lands, and sparse API fallbacks use per-model seeded caps instead of the old `min(ctx/2, 262_144)` heuristic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9ecf63f5b5211eac96d24f82c761ee15d9c109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->