### PR TITLE
fix(catalog): third-party context windows from the arcee API; omit wire max_tokens for unknown models

### DIFF
--- a/crates/nac-core/src/model/catalog/seed.rs
+++ b/crates/nac-core/src/model/catalog/seed.rs
@@ -277,28 +277,31 @@ pub(super) struct ThirdPartySeedModel {
 /// tests read it (including the pre-S4 validation-matrix exemption).
 ///
 /// To release a new model or drop an old one, add or remove a row here —
-/// that one edit is complete. Limits follow the underlying models' published
-/// values (max output capped at 256k); pricing is unpublished (zero =
-/// unknown) and arrives with the live overlay.
+/// that one edit is complete. Context windows are the arcee API's advertised
+/// values (`/v1/models` `context_length`, verified 2026-08-13); the API
+/// leaves `max_output_length` null for these models, so max output follows
+/// the underlying models' published values, capped at 256k. Pricing is
+/// unpublished in the seed (zero = unknown) and arrives with the live
+/// overlay.
 pub(super) const ARCEE_THIRD_PARTY_SEED_MODELS: &[ThirdPartySeedModel] = &[
     ThirdPartySeedModel {
         id: "deepseek/deepseek-v4-flash-latest",
         display_name: "DeepSeek-V4-Flash",
-        context_window: 1_000_000,
+        context_window: 1_048_576,
         max_tokens: 262_144,
         efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
     },
     ThirdPartySeedModel {
         id: "deepseek-ai/deepseek-v4-pro",
         display_name: "DeepSeek-V4-Pro",
-        context_window: 1_000_000,
+        context_window: 512_000,
         max_tokens: 262_144,
         efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
     },
     ThirdPartySeedModel {
         id: "zai-org/glm-5.2",
         display_name: "GLM-5.2",
-        context_window: 524_288,
+        context_window: 262_144,
         max_tokens: 164_000,
         efforts: THIRD_PARTY_NONE_HIGH_MAX_LEVELS,
     },
@@ -312,7 +315,7 @@ pub(super) const ARCEE_THIRD_PARTY_SEED_MODELS: &[ThirdPartySeedModel] = &[
     ThirdPartySeedModel {
         id: "minimaxai/minimax-m3",
         display_name: "MiniMax-M3",
-        context_window: 524_288,
+        context_window: 512_000,
         max_tokens: 250_000,
         efforts: THIRD_PARTY_NONE_MAX_LEVELS,
     },

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -411,7 +411,13 @@ impl ModelClient {
                 CompletionsMessageShape::Standard
             },
         );
-        request["max_tokens"] = json!(self.resolved_model.max_tokens.min(262_144));
+        // Clamp output only when the catalog carries a real limit for this
+        // model. A synthetic provider-default value (the 16k fallback) would
+        // silently truncate models whose true limit the provider knows
+        // better than we do (issue #124).
+        if self.resolved_model.source.is_authoritative() {
+            request["max_tokens"] = json!(self.resolved_model.max_tokens.min(262_144));
+        }
         if self.backend == BackendKind::TogetherChat {
             request["context_length_exceeded_behavior"] = json!("truncate");
         }

--- a/crates/nac-core/src/model/client/tests/http_contract.rs
+++ b/crates/nac-core/src/model/client/tests/http_contract.rs
@@ -118,6 +118,9 @@ async fn arcee_inference_sends_expected_contract_and_parses_chat_response() {
         resolved_model: catalog::resolve(BackendKind::ArceeApi, "arcee-test-model"),
     };
     client.resolved_model.max_tokens = 500_000;
+    // The wire cap only applies to authoritative catalog values; a synthetic
+    // provider-default limit is omitted from the request instead.
+    client.resolved_model.source = catalog::ModelSource::Baseline;
     let messages = vec![
         Message::System {
             content: "Follow instructions".to_string(),
@@ -201,6 +204,40 @@ async fn arcee_inference_sends_expected_contract_and_parses_chat_response() {
         body["tools"],
         serde_json::to_value(&tools).expect("tool definitions serialize")
     );
+}
+
+#[tokio::test]
+async fn completions_request_omits_max_tokens_for_unknown_models() {
+    // An unknown model resolves through the provider `_default` clone; the
+    // synthetic fallback limit must not hit the wire (the provider knows the
+    // model's real limit better than a guess — issue #124).
+    let server = ScriptedServer::start(vec![ScriptedResponse::json(
+        "200 OK",
+        r#"{"choices": [{"message": {"role": "assistant", "content": "done"}, "finish_reason": "stop"}], "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}"#,
+    )]);
+    let client = test_model_client(
+        BackendKind::DeepSeekChat,
+        server.base_url.clone(),
+        std::collections::BTreeMap::new(),
+    );
+    assert_eq!(
+        client.resolved_model.source,
+        catalog::ModelSource::ProviderDefault
+    );
+
+    client
+        .send_turn(
+            vec![Message::User {
+                content: "hello".to_string(),
+            }],
+            vec![],
+        )
+        .await
+        .expect("response parses");
+
+    let requests = server.finish();
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("request JSON");
+    assert!(body.get("max_tokens").is_none(), "{body}");
 }
 
 #[tokio::test]

--- a/crates/nac-core/src/model/client/tests/s5_wire.rs
+++ b/crates/nac-core/src/model/client/tests/s5_wire.rs
@@ -282,11 +282,14 @@ async fn together_reasoning_round_trips_under_the_reasoning_field() {
         ),
         s5_completions_response(),
     ]);
-    let client = test_model_client(
+    let mut client = test_model_client(
         BackendKind::TogetherChat,
         server.base_url.clone(),
         std::collections::BTreeMap::new(),
     );
+    // max_tokens is only sent for authoritative catalog values; pretend the
+    // unknown test model is catalog-known so the contract keeps covering it.
+    client.resolved_model.source = catalog::ModelSource::Baseline;
 
     let first = client
         .send_turn(


### PR DESCRIPTION
## Description

**What.** Two follow-ups to #132 (which fixed the hidden 16k max_tokens clamp, #124):

1. Matches the seeded third-party context windows to the values the arcee API actually advertises via `/v1/models` `context_length` (verified live 2026-08-13): flash-latest 1_048_576, pro 512_000, glm-5.2 262_144, kimi-k3 1_048_576, minimax-m3 512_000.
2. Stops sending `max_tokens` on the completions path when the resolved catalog value is synthetic (`ModelSource::ProviderDefault`/`Fallback`, i.e. the 16k fallback). Real catalog values (baseline, overlay, user override) are still sent, capped at 256k as before.

**Why.** The arcee API exposes `context_length` for every model but leaves `max_output_length` null, so context windows have an authoritative source and should match it. For output limits the opposite holds: any client-invented number is a hidden clamp below the model's true limit — the exact bug class from #124. Omitting the field lets the provider apply the model's real limit (e.g. deepseek's true 384k rather than a 16k or 256k guess).

The Anthropic messages path is unchanged: that API requires `max_tokens`, so it continues to send the resolved value.

Trade-off accepted deliberately: for a model id no catalog layer knows, the provider's server-side default now applies instead of our 16k guess. For arcee (the default backend) this is strictly better; for direct providers an unknown custom id now gets the provider default rather than 16k.

## Changelog

- Seeded arcee third-party context windows now match the arcee API's advertised values.
- Completions requests no longer send a synthetic fallback `max_tokens` for unknown models; known models keep their catalog limit (256k cap).

## Validation

Live-checked `GET /v1/models` with an API key: `context_length` present for all six arcee models, `max_output_length` null for all — motivating both halves of this PR. Ran `cargo test -p nac-core --lib` (761 passed, 0 failed), including the new `completions_request_omits_max_tokens_for_unknown_models` contract test (asserts the field is absent for a provider-default model) and the updated cap test (asserts 256k is still sent for an authoritative value).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default output behavior for unknown model IDs on completions (provider default instead of 16k); authoritative catalog paths unchanged. Context window updates affect routing/limits UI and validation for arcee third-party models.
> 
> **Overview**
> Aligns seeded **arcee third-party** `context_window` values with what the arcee API advertises in `/v1/models` `context_length` (e.g. flash-latest and kimi at 1_048_576, pro and minimax at 512_000, glm-5.2 at 262_144). Seed docs now describe that source and that max output still comes from published limits when the API leaves `max_output_length` null.
> 
> On the **chat completions** path, `max_tokens` is only added when `resolved_model.source` is authoritative (`Baseline`, `Overlay`, or `UserOverride`), still capped at 256k. Synthetic limits from `ProviderDefault` / `Fallback` (the 16k guess) are **not** sent, so providers can apply the model’s real output cap (#124). Anthropic messages behavior is unchanged.
> 
> Tests assert omission for provider-default models, keep the 256k wire cap when source is baseline, and adjust existing contract tests that assumed `max_tokens` always appeared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968c99d708127e4fa3b448740f54ce91922c6f8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->