### PR TITLE
fix(ci): authenticate CLA storage with GitHub App

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,14 +14,24 @@ permissions:
 
 jobs:
   CLAAssistant:
+    if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
+      - name: "Generate CLA signatures token"
+        id: cla-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CLA_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_APP_PRIVATE_KEY }}
+          owner: arcee-ai
+          repositories: cla-signatures
+          permission-contents: write
+
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.cla-token.outputs.token }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/arcee-ai/mergekit/blob/main/CLA.md'


### PR DESCRIPTION
## Description

**What.** Replaces the CLA workflow's missing personal access token with a short-lived token from the org-owned Arcee CLA Signatures GitHub App.

**Why.** CLA Assistant currently receives an empty `PERSONAL_ACCESS_TOKEN`, so it cannot read or update the shared signature store and every contributor check fails before signature evaluation.

The workflow mints an installation token only for `arcee-ai/cla-signatures`, requests only `contents: write`, and passes that token to the existing SHA-pinned CLA action. The App private key and Client ID are organization Actions configuration restricted to `nac`.

## Usage

No contributor-facing command changes. Contributors continue to sign by posting the existing CLA acceptance phrase; maintainers can still comment `recheck`.

## Changelog

- Fixes CLA checks by authenticating the shared signature store with a least-privilege, org-owned GitHub App.
- Removes the dependency on a personal access token.

## Bug Evidence

Before this change, PR #137 failed with `Parameter token or opts.auth is required` because `PERSONAL_ACCESS_TOKEN` was empty. The workflow now generates a scoped installation token before invoking CLA Assistant.

## Operational Impact

The GitHub App is installed only on `arcee-ai/cla-signatures`. Its Actions private-key secret and Client ID variable are exposed only to `arcee-ai/nac`. Generated installation tokens are restricted to the signature repository, have Contents write plus implicit Metadata read, and are revoked after the job.

## Validation

Parsed `.github/workflows/cla.yml` with Ruby YAML, ran `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cla.yml`, and ran `git diff --check` successfully. Independently exchanged the App Client ID and private key for an installation token, verified the token was limited to `arcee-ai/cla-signatures` with `contents: write` and `metadata: read`, then revoked it successfully. End-to-end CLA validation will run from `main` after this PR merges, using a fresh `recheck` comment on PR #137.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with narrower, repo-scoped credentials; no application runtime or contributor flow changes.
> 
> **Overview**
> **Fixes broken CLA checks** by giving CLA Assistant a real credential for the remote `cla-signatures` repo instead of an empty `PERSONAL_ACCESS_TOKEN`.
> 
> The workflow adds a **Generate CLA signatures token** step that mints a short-lived installation token via the org GitHub App (`CLA_APP_CLIENT_ID` / `CLA_APP_PRIVATE_KEY`), scoped to `arcee-ai/cla-signatures` with `contents: write`. That token replaces the old `CLA_ACCESS_TOKEN` secret on `PERSONAL_ACCESS_TOKEN`. The job-level `if` that used to gate only the CLA Assistant step now applies to the whole job so the token step runs under the same triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211f5e9fdf5dc7944ffd1365f37b8584db1fc79e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->