### PR TITLE
Use curl for public skill setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The installer places one binary in `$HOME/.local/bin` by default:
 
 Simplify nac setup by letting your existing coding agent handle it. Nac provides a portable onboarding skill and MCP integration; paste this into your chosen agent harness to install nac, configure it, and connect the MCP:
 
-> Install the nac onboarding skill with `gh api -H 'Accept: application/vnd.github.raw+json' repos/arcee-ai/nac/contents/scripts/install-skill.sh | sh -s -- --target agents`, load `nac-onboarding`, and walk me through installing nac, selecting Arcee login, ChatGPT Codex login, or an OpenAI-compatible API key, adding MCP servers, and connecting your MCP client to nac.
+> Install the nac onboarding skill with `curl -fsSL https://raw.githubusercontent.com/arcee-ai/nac/main/scripts/install-skill.sh | sh -s -- --target agents`, load `nac-onboarding`, and walk me through installing nac, selecting Arcee login, ChatGPT Codex login, or an OpenAI-compatible API key, adding MCP servers, and connecting your MCP client to nac.
 
 ### Choose auth
 


### PR DESCRIPTION
## Summary

Replace the onboarding prompt’s GitHub CLI bootstrap command with a public-release-friendly `curl` command.

## Validation

- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the onboarding copy-paste command; no runtime or security-sensitive code paths.
> 
> **Overview**
> The **“Set up nac from another coding agent”** paste prompt now bootstraps the onboarding skill with **`curl -fsSL`** against the public `raw.githubusercontent.com` URL instead of **`gh api`** against the GitHub API.
> 
> That matches how **`install.sh`** and **`uninstall.sh`** are documented and avoids requiring the GitHub CLI for copy-paste setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2daa07e80f489da651741d59da62739c37a98e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->