### PR TITLE
nac-onboarding: get users into the dashboard fast, connect MCP, keep auth in the UI

### DIFF
--- a/skills/nac-onboarding/SKILL.md
+++ b/skills/nac-onboarding/SKILL.md
@@ -28,9 +28,9 @@ Keep credentials private: if the user ever needs to enter a key or complete a de
 
 4. Hand the user the dashboard URL (`http://127.0.0.1:3210` by default) and confirm it responds. Everything from here — signing in with Arcee or ChatGPT, picking a model, adding MCP servers from the MCP Library — is done in the UI. Point the user at the dashboard's auth and model picker and let them drive.
 
-## 2. Connect the user's MCP client to nac
+## 2. Connect this MCP client to nac
 
-Ask the user which editor or agent they want to manage nac from — Claude Code, Codex, OpenCode, Cursor, or another MCP client. Then add this streamable-HTTP server to that client's MCP configuration:
+The MCP client is the harness running this session — the agent the user prompted to install the skill. Do not ask which client to use; configure the one you are running in. Add this streamable-HTTP server to your own harness's MCP configuration:
 
 ```text
 URL: http://127.0.0.1:3210/mcp
@@ -47,4 +47,4 @@ Before calling setup complete, confirm that:
 
 - `nac-web` is installed and running, and the dashboard URL responds.
 - The user is in the dashboard and can reach sign-in and the model picker themselves.
-- nac's `/mcp` endpoint is configured in the user's chosen MCP client and the client lists nac's tools.
+- nac's `/mcp` endpoint is configured in this harness's MCP client configuration and nac's tools are visible.

--- a/skills/nac-onboarding/SKILL.md
+++ b/skills/nac-onboarding/SKILL.md
@@ -7,6 +7,8 @@ description: Install and configure Arcee AI nac, then help a user choose and ver
 
 Guide the user to a working nac setup. Keep credentials private: ask the user to enter keys or complete device login themselves; never request a token in chat or write one into a tracked file.
 
+This is an interactive onboarding: ask the user before making choices on their behalf. Use your harness's interactive question mechanism when it has one. The auth path, the model, and whether another editor or agent should control nac are all the user's decisions, not yours.
+
 ## 1. Establish the starting point
 
 1. Check whether `nac-web` is available with `nac-web --version`.
@@ -24,9 +26,9 @@ Guide the user to a working nac setup. Keep credentials private: ask the user to
 
    Use `nac-web -C /path/to/project -y` when a non-interactive launch is useful. The dashboard opens at a loopback URL and provides the model picker, session controls, and MCP library.
 
-## 2. Choose exactly one model-authentication path
+## 2. Ask the user which model-authentication path to use
 
-Explain the trade-off briefly, then let the user choose. Do not configure more than one path unless the user explicitly wants alternatives.
+Present the three paths below and ask the user which one they want. Do not pick for them, and do not configure more than one path unless the user explicitly wants alternatives. Briefly explain the trade-off when asking: managed logins need no API key but tie usage to an account subscription; an API key works with any OpenAI-compatible provider but must be provisioned and kept in the environment.
 
 | User has | Recommended action |
 | --- | --- |
@@ -34,34 +36,42 @@ Explain the trade-off briefly, then let the user choose. Do not configure more t
 | A ChatGPT subscription that includes Codex | Run `nac-web codex-auth login`, then have them complete the browser flow. Confirm with `nac-web codex-auth status`. |
 | An API key for Arcee or another OpenAI-compatible provider | Have the user set the provider's conventional environment variable in their own shell. For Arcee, use `ARCEE_API_KEY`; nac's Arcee API endpoint is `https://api.arcee.ai/api/v1`. |
 
-For managed Arcee login, choose an Arcee model in the dashboard's model picker; `trinity-large-thinking` is a suitable first choice. For API-key access, select the appropriate model/provider in the picker. Prefer the picker over hand-writing a config unless the user asks for a file-based configuration.
+## 3. Ask the user which model to run
 
-For an explicit Arcee API-key configuration, use this minimal shape and keep the key itself out of the file:
+Ask the user which model they want; do not assume a default. Verify availability before suggesting specific models — model lineups change, and a model named in older documentation may no longer exist.
+
+- For Arcee (managed login or API key), check the currently supported models against the Arcee API docs at https://docs.arcee.ai and, when the user has an Arcee key or login available, the live model list at `GET https://api.arcee.ai/api/v1/models` (OpenAI-compatible, Bearer auth). Only suggest models that appear there.
+- For ChatGPT Codex login, the Codex backend accepts only specific models; unsupported choices fail with an HTTP 400 from the Codex backend. Offer models from the dashboard's model picker or from the `chatgpt-codex-responses` provider group in `list_models`, and treat the backend's response as the final word.
+- For another OpenAI-compatible provider, confirm the model id against that provider's own list endpoint or docs.
+
+Prefer the dashboard's model picker over hand-writing a config unless the user asks for a file-based configuration. For an explicit Arcee API-key configuration, use this minimal shape with the model the user confirmed, and keep the key itself out of the file:
 
 ```toml
 [model]
-model = "trinity-large-thinking"
+model = "<model confirmed with the user>"
 ```
 
 With `ARCEE_API_KEY` set, nac resolves the `arcee-api` backend and endpoint from its catalog. If a custom OpenAI-compatible endpoint is needed, use nac's session settings or model configuration UI to set the model, backend, base URL, and the *name* of the environment variable containing the key.
 
-## 3. Verify before handing off
+## 4. Verify before handing off
 
 Create a short test session in the dashboard and send a harmless prompt such as "Describe this repository in three bullets." Confirm that a response arrives. If it fails:
 
 - Re-run the relevant `*-auth status` command for managed auth and repeat login if needed.
 - For API keys, verify that the required environment variable is exported in the shell that launched `nac-web`; do not print its value.
-- Check that the selected model matches the selected provider and endpoint.
+- Check that the selected model matches the selected provider and endpoint, and that the provider actually supports it (see section 3).
 
-## 4. Add MCP capabilities to nac
+## 5. Add MCP capabilities to nac
 
 Show the dashboard's MCP Library. It includes curated entries and can discover verified remote servers; add any MCP server the user needs from there, or configure a `stdio` or `streamable_http` server directly. Explain any server's data access and authentication before enabling it.
 
 Use only values the user has authorized for headers or environment variables. MCP strings support `${ENV_VAR}` expansion, so secrets can stay in the environment rather than in `config.toml`.
 
-## 5. Let another agent control nac through MCP
+## 6. Ask whether another agent should control nac through MCP
 
-Keep `nac-web` running, then add this streamable-HTTP server to the other agent's MCP client:
+Do not assume the user wants this. Ask whether they want to manage nac from their favorite coding editor or agent — Claude Code, Codex, OpenCode, Cursor, or another MCP client — and if so, which one. If they decline, skip this section.
+
+If they opt in, keep `nac-web` running and add this streamable-HTTP server to their chosen client's MCP configuration:
 
 ```text
 URL: http://127.0.0.1:3210/mcp
@@ -70,13 +80,14 @@ Transport: streamable HTTP
 
 This exposes nac session-management tools to the client agent. The listener is intended for the same machine and has no built-in authentication; do not expose it through a tunnel or reverse proxy unless the user adds strong access control.
 
-For Claude Code, Codex, OpenCode, or another MCP client, use that client's normal MCP configuration mechanism and adapt its configuration syntax around the URL above. Restart or reload the client if it does not pick up the server automatically.
+Use the client's normal MCP configuration mechanism and adapt its configuration syntax around the URL above. Restart or reload the client if it does not pick up the server automatically.
 
 ## Completion checklist
 
 Before calling setup complete, confirm that:
 
 - `nac-web` is installed and a dashboard session can run.
-- The chosen auth path or API-key environment variable validates.
-- The user has selected a model successfully.
-- Any requested MCP server is connected, including nac's own `/mcp` endpoint when another agent should control it.
+- The user explicitly chose an auth path, and that path or API-key environment variable validates.
+- The user explicitly chose a model, verified against the provider's currently supported models, and a test session with it returns a response.
+- Any requested MCP server is connected.
+- nac's own `/mcp` endpoint is connected to the user's chosen editor or agent — only if they asked for that.

--- a/skills/nac-onboarding/SKILL.md
+++ b/skills/nac-onboarding/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: nac-onboarding
-description: Install and configure Arcee AI nac, then help a user choose and verify Arcee managed login, ChatGPT Codex login, or an OpenAI-compatible API-key model. Use when a user asks to get started with nac, connect nac to an agent, configure a model or provider, add MCP servers, or expose nac's MCP server to Claude Code, Codex, OpenCode, or another MCP client.
+description: Install and configure Arcee AI nac, get the user into the nac dashboard, and connect their MCP client to nac. Use when a user asks to get started with nac, connect nac to an agent, add MCP servers, or expose nac's MCP server to Claude Code, Codex, OpenCode, or another MCP client.
 ---
 
 # NAC onboarding
 
-Guide the user to a working nac setup. Keep credentials private: ask the user to enter keys or complete device login themselves; never request a token in chat or write one into a tracked file.
+Get the user to a running nac dashboard as fast as possible, then connect their MCP client. Authentication, model choice, and MCP server setup all happen in the dashboard UI — do not walk the user through them in chat.
 
-This is an interactive onboarding: ask the user before making choices on their behalf. Use your harness's interactive question mechanism when it has one. The auth path, the model, and whether another editor or agent should control nac are all the user's decisions, not yours.
+Keep credentials private: if the user ever needs to enter a key or complete a device login, they do it themselves in the UI or their own shell; never request a token in chat or write one into a tracked file.
 
-## 1. Establish the starting point
+## 1. Install and launch
 
 1. Check whether `nac-web` is available with `nac-web --version`.
 2. If it is missing, install the current edge build:
@@ -24,54 +24,13 @@ This is an interactive onboarding: ask the user before making choices on their b
    nac-web
    ```
 
-   Use `nac-web -C /path/to/project -y` when a non-interactive launch is useful. The dashboard opens at a loopback URL and provides the model picker, session controls, and MCP library.
+   Use `nac-web -C /path/to/project -y` when a non-interactive launch is useful. Keep the process running.
 
-## 2. Ask the user which model-authentication path to use
+4. Hand the user the dashboard URL (`http://127.0.0.1:3210` by default) and confirm it responds. Everything from here — signing in with Arcee or ChatGPT, picking a model, adding MCP servers from the MCP Library — is done in the UI. Point the user at the dashboard's auth and model picker and let them drive.
 
-Present the three paths below and ask the user which one they want. Do not pick for them, and do not configure more than one path unless the user explicitly wants alternatives. Briefly explain the trade-off when asking: managed logins need no API key but tie usage to an account subscription; an API key works with any OpenAI-compatible provider but must be provisioned and kept in the environment.
+## 2. Connect the user's MCP client to nac
 
-| User has | Recommended action |
-| --- | --- |
-| An Arcee account or wants hosted Arcee models | Run `nac-web arcee-auth login`, then have them complete the device-code flow in the browser. They can create an Arcee account during that flow if needed. Confirm with `nac-web arcee-auth status`. |
-| A ChatGPT subscription that includes Codex | Run `nac-web codex-auth login`, then have them complete the browser flow. Confirm with `nac-web codex-auth status`. |
-| An API key for Arcee or another OpenAI-compatible provider | Have the user set the provider's conventional environment variable in their own shell. For Arcee, use `ARCEE_API_KEY`; nac's Arcee API endpoint is `https://api.arcee.ai/api/v1`. |
-
-## 3. Ask the user which model to run
-
-Ask the user which model they want; do not assume a default. Verify availability before suggesting specific models — model lineups change, and a model named in older documentation may no longer exist.
-
-- For Arcee (managed login or API key), check the currently supported models against the Arcee API docs at https://docs.arcee.ai and, when the user has an Arcee key or login available, the live model list at `GET https://api.arcee.ai/api/v1/models` (OpenAI-compatible, Bearer auth). Only suggest models that appear there.
-- For ChatGPT Codex login, the Codex backend accepts only specific models; unsupported choices fail with an HTTP 400 from the Codex backend. Offer models from the dashboard's model picker or from the `chatgpt-codex-responses` provider group in `list_models`, and treat the backend's response as the final word.
-- For another OpenAI-compatible provider, confirm the model id against that provider's own list endpoint or docs.
-
-Prefer the dashboard's model picker over hand-writing a config unless the user asks for a file-based configuration. For an explicit Arcee API-key configuration, use this minimal shape with the model the user confirmed, and keep the key itself out of the file:
-
-```toml
-[model]
-model = "<model confirmed with the user>"
-```
-
-With `ARCEE_API_KEY` set, nac resolves the `arcee-api` backend and endpoint from its catalog. If a custom OpenAI-compatible endpoint is needed, use nac's session settings or model configuration UI to set the model, backend, base URL, and the *name* of the environment variable containing the key.
-
-## 4. Verify before handing off
-
-Create a short test session in the dashboard and send a harmless prompt such as "Describe this repository in three bullets." Confirm that a response arrives. If it fails:
-
-- Re-run the relevant `*-auth status` command for managed auth and repeat login if needed.
-- For API keys, verify that the required environment variable is exported in the shell that launched `nac-web`; do not print its value.
-- Check that the selected model matches the selected provider and endpoint, and that the provider actually supports it (see section 3).
-
-## 5. Add MCP capabilities to nac
-
-Show the dashboard's MCP Library. It includes curated entries and can discover verified remote servers; add any MCP server the user needs from there, or configure a `stdio` or `streamable_http` server directly. Explain any server's data access and authentication before enabling it.
-
-Use only values the user has authorized for headers or environment variables. MCP strings support `${ENV_VAR}` expansion, so secrets can stay in the environment rather than in `config.toml`.
-
-## 6. Ask whether another agent should control nac through MCP
-
-Do not assume the user wants this. Ask whether they want to manage nac from their favorite coding editor or agent — Claude Code, Codex, OpenCode, Cursor, or another MCP client — and if so, which one. If they decline, skip this section.
-
-If they opt in, keep `nac-web` running and add this streamable-HTTP server to their chosen client's MCP configuration:
+Ask the user which editor or agent they want to manage nac from — Claude Code, Codex, OpenCode, Cursor, or another MCP client. Then add this streamable-HTTP server to that client's MCP configuration:
 
 ```text
 URL: http://127.0.0.1:3210/mcp
@@ -80,14 +39,12 @@ Transport: streamable HTTP
 
 This exposes nac session-management tools to the client agent. The listener is intended for the same machine and has no built-in authentication; do not expose it through a tunnel or reverse proxy unless the user adds strong access control.
 
-Use the client's normal MCP configuration mechanism and adapt its configuration syntax around the URL above. Restart or reload the client if it does not pick up the server automatically.
+Use the client's normal MCP configuration mechanism and adapt its configuration syntax around the URL above. Restart or reload the client if it does not pick up the server automatically, then confirm the client can see nac's tools.
 
 ## Completion checklist
 
 Before calling setup complete, confirm that:
 
-- `nac-web` is installed and a dashboard session can run.
-- The user explicitly chose an auth path, and that path or API-key environment variable validates.
-- The user explicitly chose a model, verified against the provider's currently supported models, and a test session with it returns a response.
-- Any requested MCP server is connected.
-- nac's own `/mcp` endpoint is connected to the user's chosen editor or agent — only if they asked for that.
+- `nac-web` is installed and running, and the dashboard URL responds.
+- The user is in the dashboard and can reach sign-in and the model picker themselves.
+- nac's `/mcp` endpoint is configured in the user's chosen MCP client and the client lists nac's tools.


### PR DESCRIPTION
## Why

A full walkthrough of the onboarding skill showed it was doing in chat what the dashboard already does well — managed Arcee/ChatGPT login, the model picker, and the MCP Library are all in the UI. The chat walkthrough added friction (and failure modes, like suggesting models the provider no longer supports) before the user ever saw the product.

## What changed (`skills/nac-onboarding/SKILL.md` only)

The skill is now three moves:

1. **Install and launch** — install `nac-web` if missing, start it on the user's repo, hand over the dashboard URL. Auth, model choice, and MCP servers all happen in the UI; the skill explicitly stays out of it.
2. **Connect the current harness to nac's MCP server** — the MCP client is whatever agent harness is running the skill, so there's nothing to ask: add nac's streamable-HTTP `/mcp` endpoint through the harness's own MCP configuration and confirm nac's tools show up.
3. **Checklist** — dashboard reachable, user can sign in and pick a model themselves, MCP client connected.

Removed: the chat-based auth-path selection table, hardcoded model suggestions (`trinity-large-thinking`), the manual TOML config walkthrough, and the chat-driven test-prompt verification — all superseded by the dashboard.

## Verification

Walked the previous skill end-to-end against current `main`: install via `install-skill.sh`/`install.sh` (edge `c73607c`), `arcee-auth login` device flow, `codex-auth status`, dashboard, a live test session over the `/mcp` endpoint with managed Codex auth, and the MCP Library endpoints — which is how the above failure modes were found.