### PR TITLE
Added year and company to license

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS file for AFM-Application
+# This file assigns reviewers to all pull requests
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Global owners - these users will be assigned to all PRs
+*       @Ssapiosaturn @Cecocho @Crystalcareai @eric-tramel
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Global owners - these users will be assigned to all PRs
-*       @Ssapiosaturn @Cecocho @Crystalcareai @eric-tramel
+*       @sapiosaturn @Cecocho @Crystalcareai @eric-tramel
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 - Arcee AI
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Repository metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Adds a **`.github/CODEOWNERS`** file so every PR is automatically associated with global reviewers (`@sapiosaturn`, `@Cecocho`, `@Crystalcareai`, `@eric-tramel`).
> 
> Updates the Apache **`LICENSE`** appendix boilerplate from the generic placeholder to **`Copyright 2026 - Arcee AI`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66b0ca396f857f387ef7cd54c000e10a8af2089c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->