### PR TITLE
feat(web): serve live OpenAPI documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +290,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -477,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "derive_destructure2"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,8 +658,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -700,6 +755,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -995,6 +1051,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1294,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1440,6 +1507,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,7 +1545,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "toml",
 ]
@@ -1498,11 +1575,12 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "toml",
  "toml_edit",
  "url",
+ "utoipa",
  "uuid",
 ]
 
@@ -1524,6 +1602,9 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "utoipa",
+ "utoipa-axum",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -1688,6 +1769,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -1954,6 +2041,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2181,41 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.118",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -2437,7 +2571,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2907,6 +3052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +3098,67 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "utoipa-swagger-ui-vendored",
+ "zip",
+]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"
@@ -3554,7 +3766,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/README.md
+++ b/README.md
@@ -53,60 +53,9 @@ nac-web
 
 It confirms the current working directory as the project folder (`Y` to accept, `n` to type another path), then listens on `http://127.0.0.1:3210` and opens that URL in your browser. Pass `-C /path/to/project` to skip the prompt, or `-y` to accept cwd non-interactively. Pass `-p 4321` or `--port 4321` to choose a custom loopback port in the range `1..=65535`; use `--bind` instead to specify a full IPv4 or IPv6 loopback address. `--port` and `--bind` cannot be combined. The dashboard is a React app whose build output is committed under `crates/nac-server/assets/dist` and embedded in the binary, so a release never needs Node. `nac-web` exposes a central session manager for web clients. It resolves one server store at startup, then can create, resume, inspect, submit prompts to, and stream events from multiple sessions at once.
 
-Server and session lifecycle:
+The current HTTP contract is generated from the Rust handlers and types served by the running process: fetch the OpenAPI 3.1 document at `GET /openapi.json`, or open the embedded Swagger UI at `GET /docs`.
 
-- `GET /health`
-- `GET /store`
-- `GET /sessions`
-- `POST /sessions`
-- `PUT /sessions/order`
-- `GET /sessions/{session_id}`
-- `DELETE /sessions/{session_id}`
-- `PUT /sessions/{session_id}/presentation`
-
-Conversation and runs:
-
-- `GET /sessions/{session_id}/messages`
-- `GET /sessions/{session_id}/threads/{thread_name}/events`
-- `POST /sessions/{session_id}/runs`
-- `POST /sessions/{session_id}/compact`
-- `POST /sessions/{session_id}/steering`
-- `POST /sessions/{session_id}/threads/{thread_name}/steering`
-- `GET /sessions/{session_id}/events?after_sequence_id=0`
-- `GET /sessions/{session_id}/events/stream?after_sequence_id=0`
-- `POST /sessions/{session_id}/cancel-active-run`
-
-Session settings:
-
-- `GET /sessions/{session_id}/config`
-- `PATCH /sessions/{session_id}/config`
-
-Workspace, for browsing what a session changed. In a git checkout every run also freezes the tree as a revision under `refs/nac/revisions/*`, staged through a private index so the user's own index is never touched, which keeps earlier runs inspectable. Capture is a convenience: a workspace nac cannot capture still finishes its runs normally:
-
-- `GET /sessions/{session_id}/workspace/diff`
-- `GET /sessions/{session_id}/workspace/files`
-- `GET /sessions/{session_id}/workspace/file`
-- `GET /sessions/{session_id}/workspace/branches`
-- `POST /sessions/{session_id}/workspace/branches`
-- `GET /sessions/{session_id}/workspace/revisions`
-- `GET /sessions/{session_id}/workspace/revisions/{revision_id}/changes`
-
-Launch support, used by the new-session form. Saved model configurations live in the store; `POST /providers/models` forwards a key once to list the models it may use and never stores it, while `/model-configs/from-file` resolves an on-disk configuration the same way a session launch would:
-
-- `GET /fs/browse`
-- `POST /sessions/launch-defaults`
-- `POST /providers/models`
-- `GET /model-configs`
-- `POST /model-configs`
-- `POST /model-configs/from-file`
-- `DELETE /model-configs/{config_id}`
-- `POST /model-configs/{config_id}/models`
-
-Stored credentials are write-only over HTTP: a caller may add, replace, or drop a key, but the value is never echoed back — only a suffix long enough to tell two keys apart:
-
-- `GET /credentials`
-- `PUT /credentials/{name}`
-- `DELETE /credentials/{name}`
+Stored credentials are write-only over HTTP: a caller may add, replace, or drop a key, but the value is never echoed back — only a suffix long enough to tell two keys apart.
 
 `nac-web` binds only to IPv4/IPv6 loopback and has no built-in authentication. Requests are refused unless the `Host` header names a loopback address or `localhost`, which blocks DNS rebinding; `Origin`, `Sec-Fetch-Site`, and CSRF are still not enforced. Tunnels and reverse proxies can expose the loopback listener remotely; their public name must be listed in `NAC_ALLOWED_HOSTS` (comma-separated, `*` disables the check), and whatever fronts the server must provide strong authentication before forwarding traffic to `nac-web`. Anyone able to reach the server is trusted.
 

--- a/crates/nac-core/Cargo.toml
+++ b/crates/nac-core/Cargo.toml
@@ -9,6 +9,7 @@ name = "nac_core"
 [features]
 default = []
 test-support = []
+openapi = ["dep:utoipa"]
 
 [dependencies]
 tokio = { version = "1", default-features = false, features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
@@ -38,3 +39,4 @@ grep-matcher = "0.1"
 grep-regex = "0.1"
 ignore = "0.4"
 openssh-sftp-client = { version = "0.15", default-features = false }
+utoipa = { version = "5.5", optional = true, features = ["uuid"] }

--- a/crates/nac-core/src/commands.rs
+++ b/crates/nac-core/src/commands.rs
@@ -3,12 +3,14 @@ use serde::{Deserialize, Serialize};
 /// Slash commands understood by NAC.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum SlashCommand {
     Compact,
 }
 
 /// User-facing metadata shared by command parsing and frontend discovery.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SlashCommandDefinition {
     pub command: SlashCommand,
     pub name: &'static str,
@@ -168,8 +170,7 @@ mod tests {
         let expanded_plan =
             "# /plan: Workset Planning\n\nUser instruction:\nsplit this into reviewable units\n\n\
              Create exactly one durable high-level workset with `workset_define`.";
-        let expanded_run =
-            "# /run: Workset Execution\n\nWorkset id:\nauth-refresh\n\n\
+        let expanded_run = "# /run: Workset Execution\n\nWorkset id:\nauth-refresh\n\n\
              Execute an existing workset.";
 
         assert_eq!(

--- a/crates/nac-core/src/events.rs
+++ b/crates/nac-core/src/events.rs
@@ -20,6 +20,7 @@ pub const ASSISTANT_DELTA_CHANNEL_CAPACITY: usize = 256;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionClientId(String);
 
 impl SessionClientId {
@@ -46,6 +47,7 @@ impl std::fmt::Display for SessionClientId {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionSubscriptionId(String);
 
 impl SessionSubscriptionId {
@@ -72,6 +74,7 @@ impl std::fmt::Display for SessionSubscriptionId {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(transparent)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionRunId(String);
 
 impl SessionRunId {
@@ -98,6 +101,7 @@ impl std::fmt::Display for SessionRunId {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum CompactionReason {
     Auto,
     Manual,
@@ -105,6 +109,7 @@ pub enum CompactionReason {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum CompactionSkipReason {
     NoEligibleBoundary,
     AlreadyCompacted,
@@ -112,6 +117,7 @@ pub enum CompactionSkipReason {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum CompactionFailure {
     SummaryRequestFailed,
     SummaryRejected,
@@ -121,6 +127,7 @@ pub enum CompactionFailure {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum AgentEvent {
     RunStarted {
         thread_name: Option<String>,
@@ -289,6 +296,7 @@ impl AgentEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionEventEnvelope {
     pub session_id: Option<String>,
     pub epoch_id: String,
@@ -301,18 +309,21 @@ pub struct SessionEventEnvelope {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionEventBoundary {
     pub epoch_id: String,
     pub sequence_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionReplayGap {
     pub missing_from_sequence_id: u64,
     pub missing_to_sequence_id: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SubmittedUserMessageSnapshot {
     pub run_id: SessionRunId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -323,6 +334,7 @@ pub struct SubmittedUserMessageSnapshot {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum SessionEvent {
     /// Agent/model progress. The canonical top-level session busy lifecycle is
     /// represented by RunStarted/RunCompleted/RunFailed/RunCancelled. AgentEvent
@@ -375,6 +387,7 @@ pub enum SessionEvent {
 /// no persistence — a subscriber that falls behind just misses text it is about
 /// to receive in full anyway.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct AssistantStreamDelta {
     pub thread_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/nac-core/src/light_model.rs
+++ b/crates/nac-core/src/light_model.rs
@@ -14,6 +14,7 @@ use crate::model::{
 /// id; backend and reasoning effort are typed before entering the domain
 /// model, and the credential is always a selector name, never a key value.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct LightModelSettings {
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/nac-core/src/mcp/library.rs
+++ b/crates/nac-core/src/mcp/library.rs
@@ -15,6 +15,7 @@ use tokio::task::JoinSet;
 /// What a library server needs before it can connect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum McpLibraryAuth {
     /// Works as-is.
     None,
@@ -28,6 +29,7 @@ pub enum McpLibraryAuth {
 /// pre-fill, never a hidden configuration — what is saved is exactly what the
 /// form shows.
 #[derive(Debug, Clone, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct McpLibraryEntry {
     /// Stable identifier, recorded on servers created from the entry.
     pub id: String,

--- a/crates/nac-core/src/mcp/mod.rs
+++ b/crates/nac-core/src/mcp/mod.rs
@@ -48,6 +48,7 @@ pub use registry::{McpRegistry, McpRootPolicy, McpTransportPolicy};
 
 /// A tool a probe discovered on a server, before anything is saved.
 #[derive(Debug, Clone, serde::Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct McpProbedTool {
     pub name: String,
     pub description: Option<String>,

--- a/crates/nac-core/src/model/catalog/types.rs
+++ b/crates/nac-core/src/model/catalog/types.rs
@@ -111,6 +111,7 @@ impl ThinkingLevelMap {
 /// fallback); `calculate_cost` bills unknown pricing as zero. Missing fields
 /// deserialize as zero so partial catalog records stay loadable.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelCostRates {
     #[serde(default)]
     pub input: f64,
@@ -127,6 +128,7 @@ pub struct ModelCostRates {
 /// user-overridden and unrecognized (provider-default) models from it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ModelSource {
     /// Checked-in baseline catalog (S0 seed; generated models.dev data in S1).
     Baseline,
@@ -231,6 +233,7 @@ impl ModelMetadata {
 /// managed providers still read only their stored credential file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum AuthStatus {
     /// A usable credential exists: the provider's conventional env var or
     /// the configured selector names a set variable (API-key providers), or
@@ -245,6 +248,7 @@ pub enum AuthStatus {
 /// *requirements* (drives picker field visibility and hints), not status.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ProviderAuth {
     /// API key read from the environment variable named by `api_key_env`.
     ApiKeyEnv,
@@ -258,6 +262,7 @@ pub enum ProviderAuth {
 /// `GET /models`: powers the frontend's unrecognized-model badge, estimated
 /// context gauge and custom-model effort list without a second resolve call.
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct DefaultLimits {
     pub context_window: u64,
     pub max_tokens: u64,
@@ -267,6 +272,7 @@ pub struct DefaultLimits {
 /// One real catalog entry as served by `GET /models` (never a
 /// ProviderDefault/Fallback synthesis product).
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelEntry {
     pub id: String,
     pub display_name: Option<String>,
@@ -280,6 +286,7 @@ pub struct ModelEntry {
 
 /// One provider group in the `GET /models` listing.
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ProviderListing {
     pub id: BackendKind,
     pub auth: ProviderAuth,
@@ -303,6 +310,7 @@ pub struct ProviderListing {
 
 /// The full catalog listing served by `GET /models`.
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelListing {
     /// Monotonic version of the process-global catalog, bumped on every
     /// reload (the initial load is version 1). Debugging/future-staleness

--- a/crates/nac-core/src/model/providers.rs
+++ b/crates/nac-core/src/model/providers.rs
@@ -48,6 +48,7 @@ pub fn provider_uses_api_key(backend: BackendKind) -> bool {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ProviderModel {
     pub id: String,
     pub display_name: Option<String>,

--- a/crates/nac-core/src/model/types.rs
+++ b/crates/nac-core/src/model/types.rs
@@ -2,6 +2,7 @@ use super::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum BackendKind {
     #[serde(rename = "deepseek-chat")]
     DeepSeekChat,
@@ -84,6 +85,7 @@ impl<'de> Deserialize<'de> for BackendKind {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ReasoningEffort {
     None,
     Minimal,
@@ -368,6 +370,7 @@ pub struct AssistantTurn {
 /// directly. Missing fields deserialize as zero so partial records stay
 /// loadable.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct TokenCostMicros {
     #[serde(default)]
     pub input: u64,
@@ -432,6 +435,7 @@ pub(crate) fn calculate_cost(
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct TokenUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -41,9 +41,12 @@ pub use manual_compaction::{
 pub type AgentEventReceiver = mpsc::UnboundedReceiver<AgentEvent>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionMetadata {
     pub cwd: String,
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub workspace_host_path: Option<PathBuf>,
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub store_path: PathBuf,
     pub model: String,
     pub backend: String,
@@ -61,6 +64,7 @@ pub struct SessionMetadata {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ResponseTimingSnapshot {
     pub last_response_duration_ms: Option<u64>,
     pub previous_response_duration_ms: Option<u64>,
@@ -130,6 +134,7 @@ impl From<&SessionSnapshot> for ResponseTimingSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ActiveRunSnapshot {
     pub run_id: SessionRunId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -141,6 +146,7 @@ pub struct ActiveRunSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ActiveCompactionSnapshot {
     pub compaction_id: Uuid,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -150,6 +156,7 @@ pub struct ActiveCompactionSnapshot {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum ActiveSessionOperationSnapshot {
     Run {
         run: ActiveRunSnapshot,
@@ -167,6 +174,7 @@ pub struct SessionServiceInit {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionFrontendSnapshot {
     pub metadata: SessionMetadata,
     pub messages: Vec<Message>,
@@ -273,6 +281,7 @@ pub struct SessionFrontendSnapshotLoad {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThreadEventPageItem {
     pub id: i64,
     pub created_at: String,
@@ -280,6 +289,7 @@ pub struct ThreadEventPageItem {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThreadEventPage {
     pub events: Vec<ThreadEventPageItem>,
     pub has_older: bool,
@@ -291,6 +301,7 @@ pub struct ThreadEventPage {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThreadEventDecodeDiagnostic {
     pub id: i64,
     pub thread_name: String,

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -36,6 +36,7 @@ use codec::*;
 pub(crate) use summary::{last_user_prompt, visible_message_count};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct RawSessionConfig {
     pub session_id: String,
     pub model: String,

--- a/crates/nac-core/src/store/model_configurations.rs
+++ b/crates/nac-core/src/store/model_configurations.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 /// in the credential store (or the environment), exactly as it does for a
 /// configuration written by hand in `config.toml`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelConfigurationRecord {
     pub config_id: String,
     pub name: String,

--- a/crates/nac-core/src/store/ssh_configurations.rs
+++ b/crates/nac-core/src/store/ssh_configurations.rs
@@ -2,6 +2,7 @@ use super::*;
 
 /// A named, reusable SSH connection offered by the launch modal.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SshConfigurationRecord {
     pub config_id: String,
     pub name: String,

--- a/crates/nac-core/src/store/steering.rs
+++ b/crates/nac-core/src/store/steering.rs
@@ -4,6 +4,7 @@ use super::*;
 pub const ORCHESTRATOR_STEERING_TARGET: &str = "__orchestrator__";
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThreadSteeringRecord {
     pub id: i64,
     pub session_id: String,

--- a/crates/nac-core/src/store/workspace_revisions.rs
+++ b/crates/nac-core/src/store/workspace_revisions.rs
@@ -6,6 +6,7 @@ use super::*;
 /// commit; this row is only the bookkeeping that tells us which commit belongs
 /// to which run, and what it should be compared against.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceRevisionRecord {
     pub id: i64,
     pub session_id: String,

--- a/crates/nac-core/src/terminal/mod.rs
+++ b/crates/nac-core/src/terminal/mod.rs
@@ -26,6 +26,7 @@ pub struct TerminalInfo {
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum CommandStatus {
     Completed,
     TimedOut,

--- a/crates/nac-core/src/types.rs
+++ b/crates/nac-core/src/types.rs
@@ -20,6 +20,7 @@ where
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "role", rename_all = "lowercase")]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub enum Message {
     System {
         content: String,
@@ -30,6 +31,7 @@ pub enum Message {
     #[serde(rename = "assistant")]
     Assistant {
         #[serde(serialize_with = "serialize_nullable_content")]
+        #[cfg_attr(feature = "openapi", schema(required))]
         content: Option<String>,
         #[serde(
             default,
@@ -71,12 +73,14 @@ pub enum Message {
 /// reasoning items, completions reasoning text) are only replayed to the
 /// same origin; a different origin makes the wire normalization strip them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ModelOrigin {
     pub backend: BackendKind,
     pub model: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ToolCall {
     pub id: String,
     #[serde(rename = "type")]
@@ -85,12 +89,14 @@ pub struct ToolCall {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FunctionCall {
     pub name: String,
     pub arguments: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ToolDefinition {
     #[serde(rename = "type")]
     pub def_type: String,
@@ -98,6 +104,7 @@ pub struct ToolDefinition {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct FunctionDef {
     pub name: String,
     pub description: String,

--- a/crates/nac-core/src/view.rs
+++ b/crates/nac-core/src/view.rs
@@ -25,10 +25,13 @@ pub type NumstatPairs = HashMap<String, (Option<u64>, Option<u64>)>;
 pub type NumstatSummary = (NumstatPairs, u64, u64);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct SessionSummarySnapshot {
     pub session_id: String,
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub cwd: PathBuf,
     #[serde(skip)]
+    #[cfg_attr(feature = "openapi", schema(ignore))]
     pub workspace_host_path: Option<PathBuf>,
     pub model: String,
     pub backend: String,
@@ -70,6 +73,7 @@ pub struct SessionSummarySnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ThreadSnapshot {
     pub name: String,
     pub session_id: String,
@@ -80,6 +84,7 @@ pub struct ThreadSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct EpisodeSnapshot {
     pub id: i64,
     pub thread_name: String,
@@ -98,6 +103,7 @@ fn retained_episode_status() -> String {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorksetSummarySnapshot {
     pub id: String,
     pub status: String,
@@ -107,6 +113,7 @@ pub struct WorksetSummarySnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorksetItemSnapshot {
     pub position: i64,
     pub title: String,
@@ -120,6 +127,7 @@ pub struct WorksetItemSnapshot {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorksetSnapshot {
     pub id: String,
     pub session_id: String,
@@ -133,12 +141,14 @@ pub struct WorksetSnapshot {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorksetsSnapshot {
     pub items: Vec<WorksetSnapshot>,
     pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct GitStatusCounts {
     pub modified: usize,
     pub staged: usize,
@@ -149,6 +159,7 @@ pub struct GitStatusCounts {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ChangedFileStat {
     pub status: String,
     pub path: String,
@@ -157,6 +168,7 @@ pub struct ChangedFileStat {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceDiffTotals {
     pub total_additions: u64,
     pub total_deletions: u64,
@@ -164,6 +176,7 @@ pub struct WorkspaceDiffTotals {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceRevisionChanges {
     pub changed_files: Vec<ChangedFileStat>,
     pub total_additions: u64,
@@ -172,7 +185,9 @@ pub struct WorkspaceRevisionChanges {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceSnapshot {
+    #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     pub host_root: Option<PathBuf>,
     pub workspace_display: String,
     pub repo_label: Option<String>,

--- a/crates/nac-core/src/view/workspace_diff.rs
+++ b/crates/nac-core/src/view/workspace_diff.rs
@@ -12,6 +12,7 @@ const WORKSPACE_DIFF_MAX_LINES: usize = 5_000;
 const WORKSPACE_DIFF_MAX_LINE_CHARS: usize = 20_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceFileDiff {
     pub path: String,
     pub old_path: Option<String>,
@@ -20,6 +21,7 @@ pub struct WorkspaceFileDiff {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceDiffSection {
     pub stage: String,
     pub status: String,
@@ -33,6 +35,7 @@ pub struct WorkspaceDiffSection {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceDiffHunk {
     pub old_start: usize,
     pub old_lines: usize,
@@ -43,6 +46,7 @@ pub struct WorkspaceDiffHunk {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceDiffLine {
     pub kind: String,
     pub old_lineno: Option<usize>,

--- a/crates/nac-core/src/view/workspace_files.rs
+++ b/crates/nac-core/src/view/workspace_files.rs
@@ -29,6 +29,7 @@ const MAX_FILE_BYTES: u64 = 512 * 1024;
 const BINARY_SNIFF_BYTES: usize = 8_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceFileList {
     pub files: Vec<String>,
     /// The repository has more files than were returned.
@@ -36,6 +37,7 @@ pub struct WorkspaceFileList {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct WorkspaceFileContent {
     pub path: String,
     /// None whenever the file cannot be shown as text.
@@ -254,6 +256,7 @@ fn run_git_optional(target: &GitTarget, cwd: &Path, args: &[&str]) -> Result<Opt
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct OpenLocalPathResult {
     /// Absolute path handed to the OS opener.
     pub opened: String,

--- a/crates/nac-core/src/workspace.rs
+++ b/crates/nac-core/src/workspace.rs
@@ -20,12 +20,14 @@ pub use revisions::{capture, forget, restore, rewind_ref, RevisionCapture};
 pub(crate) use git::{first_stderr_line, WorktreeRead};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Branch {
     pub name: String,
     pub is_current: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct BranchList {
     /// None on a detached HEAD or in a repository without commits.
     pub current: Option<String>,
@@ -82,6 +84,7 @@ pub fn switch_branch(target: &GitTarget, name: &str) -> Result<BranchList> {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct CommitOutcome {
     pub sha: String,
     /// None on a detached HEAD.

--- a/crates/nac-server/Cargo.toml
+++ b/crates/nac-server/Cargo.toml
@@ -11,7 +11,7 @@ name = "nac-web"
 path = "src/main.rs"
 
 [dependencies]
-nac-core = { path = "../nac-core" }
+nac-core = { path = "../nac-core", features = ["openapi"] }
 anyhow = "1"
 async-stream = "0.3"
 axum = "0.8"
@@ -24,6 +24,9 @@ tokio = { version = "1", default-features = false, features = ["macros", "net", 
 rmcp = { version = "1.3", default-features = false, features = ["server", "macros", "transport-streamable-http-server"] }
 tower-http = { version = "0.6", features = ["compression-gzip"] }
 uuid = { version = "1", features = ["v4"] }
+utoipa = "5.5"
+utoipa-axum = "0.2"
+utoipa-swagger-ui = { version = "9", default-features = false, features = ["axum", "vendored"] }
 
 [dev-dependencies]
 flate2 = "1"

--- a/crates/nac-server/src/compaction.rs
+++ b/crates/nac-server/src/compaction.rs
@@ -13,10 +13,11 @@ use nac_core::{
 };
 use serde::Serialize;
 
-use crate::SessionManager;
+use crate::{ApiErrorBody, SessionManager};
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "status", rename_all = "snake_case")]
+#[derive(utoipa::ToSchema)]
 pub enum CompactSessionResponse {
     Compacted {
         compaction_id: String,
@@ -55,9 +56,9 @@ impl IntoResponse for CompactSessionError {
         };
         (
             status,
-            Json(serde_json::json!({
-                "error": self.to_string(),
-            })),
+            Json(ApiErrorBody {
+                error: self.to_string(),
+            }),
         )
             .into_response()
     }
@@ -159,6 +160,14 @@ fn report_failure(
     CompactSessionError::Failed
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/compact",
+    operation_id = "post_sessions_session_id_compact",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = CompactSessionResponse, content_type = "application/json"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,

--- a/crates/nac-server/src/filesystem.rs
+++ b/crates/nac-server/src/filesystem.rs
@@ -16,6 +16,7 @@ const MAX_ENTRIES: usize = 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(utoipa::ToSchema)]
 pub enum BrowseKind {
     /// Directories only, for picking a working directory.
     #[default]
@@ -27,7 +28,8 @@ pub enum BrowseKind {
     File,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct BrowseQuery {
     /// Absolute path to list. A leading `~` expands to the home directory.
     pub path: Option<String>,
@@ -38,14 +40,14 @@ pub struct BrowseQuery {
     pub hidden: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct BrowseEntry {
     pub name: String,
     pub path: String,
     pub is_directory: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct BrowseListing {
     /// Canonical path of the listed directory.
     pub path: String,

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -40,7 +40,7 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse, Response,
     },
-    routing::{delete, get, patch, post, put},
+    routing::get,
     Json, Router,
 };
 use include_dir::{include_dir, Dir};
@@ -88,6 +88,9 @@ use tower_http::compression::{
     predicate::{DefaultPredicate, NotForContentType, Predicate},
     CompressionLayer,
 };
+use utoipa::OpenApi;
+use utoipa_axum::{router::OpenApiRouter, routes};
+use utoipa_swagger_ui::{Config as SwaggerConfig, SwaggerUi};
 
 const DEFAULT_REPLAY_LIMIT: usize = 256;
 const DEFAULT_MESSAGE_PAGE_LIMIT: usize = 24;
@@ -215,15 +218,29 @@ impl GitProbeCacheEntry {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct HealthResponse {
+    pub status: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct ApiErrorBody {
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct StoreInfo {
+    #[schema(value_type = String)]
     pub root_cwd: PathBuf,
+    #[schema(value_type = String)]
     pub store_path: PathBuf,
+    #[schema(value_type = String)]
     pub worker_executable: PathBuf,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct LaunchModelDefaultsRequest {
+    #[schema(value_type = Option<String>)]
     pub cwd: Option<PathBuf>,
     /// OpenSSH target for remote sessions; remote paths never select local config.
     #[serde(default, alias = "host_id")]
@@ -238,7 +255,7 @@ pub struct LaunchModelDefaultsRequest {
 ///
 /// The connection is described in the request rather than taken from a session,
 /// because this is what the launch form asks *before* there is a session.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct SshBrowseRequest {
     pub ssh_host: Option<String>,
     #[serde(default)]
@@ -254,7 +271,7 @@ pub struct SshBrowseRequest {
     pub hidden: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct LaunchModelDefaults {
     /// Configured model id; lets the launch dialog render the inherited
     /// "from config" selection resolved against the model catalog (the
@@ -265,7 +282,7 @@ pub struct LaunchModelDefaults {
     pub configured_reasoning_effort: Option<ReasoningEffort>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ManagedSessionSummary {
     pub summary: SessionSummarySnapshot,
     pub active: bool,
@@ -274,7 +291,8 @@ pub struct ManagedSessionSummary {
     pub workspace_diff: Option<view::WorkspaceDiffTotals>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ListSessionsQuery {
     #[serde(default)]
     pub workspace_stats: bool,
@@ -305,6 +323,45 @@ where
             Some(value) => Self::Value(value),
             None => Self::Null,
         })
+    }
+}
+
+impl<T> utoipa::__dev::ComposeSchema for RequestField<T>
+where
+    T: utoipa::__dev::ComposeSchema,
+{
+    fn compose(
+        schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+    ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        let value = schemas
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| T::compose(Vec::new()));
+        utoipa::openapi::schema::OneOfBuilder::new()
+            .item(
+                utoipa::openapi::schema::ObjectBuilder::new()
+                    .schema_type(utoipa::openapi::schema::Type::Null),
+            )
+            .item(value)
+            .into()
+    }
+}
+
+impl<T> utoipa::ToSchema for RequestField<T>
+where
+    T: utoipa::ToSchema + utoipa::__dev::ComposeSchema,
+{
+    fn name() -> std::borrow::Cow<'static, str> {
+        format!("RequestField_{}", T::name()).into()
+    }
+
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
     }
 }
 
@@ -343,8 +400,41 @@ impl<'de> Deserialize<'de> for HeadersRequest {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+impl utoipa::__dev::ComposeSchema for HeadersRequest {
+    fn compose(
+        _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+    ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        use utoipa::openapi::schema::{ObjectBuilder, OneOfBuilder};
+
+        OneOfBuilder::new()
+            .item(
+                ObjectBuilder::new()
+                    .additional_properties(Some(<String as utoipa::PartialSchema>::schema())),
+            )
+            .item(
+                ObjectBuilder::new()
+                    .schema_type(utoipa::openapi::schema::Type::String)
+                    .pattern(Some(r".*\S.*"))
+                    .description(Some(
+                        "Compatibility form: a nonblank string containing a JSON object with string values.",
+                    )),
+            )
+            .description(Some(
+                "Prefer an object of header names to values. The JSON-encoded string form is accepted for compatibility.",
+            ))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for HeadersRequest {
+    fn name() -> std::borrow::Cow<'static, str> {
+        "HeadersRequest".into()
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct CreateSessionRequest {
+    #[schema(value_type = Option<String>)]
     pub cwd: Option<PathBuf>,
     #[serde(default)]
     pub model: RequestField<String>,
@@ -380,7 +470,7 @@ pub struct CreateSessionRequest {
     pub sandbox: SandboxRequest,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct SandboxRequest {
     #[serde(default)]
     pub enabled: bool,
@@ -401,14 +491,14 @@ pub struct SandboxRequest {
     pub memory_mib: Option<u32>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct StoredCredentialSummary {
     pub name: String,
     /// Empty when the secret is too short for a suffix to be safe to show.
     pub last_four: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct StoredCredentialList {
     pub credentials: Vec<StoredCredentialSummary>,
 }
@@ -417,13 +507,14 @@ pub struct StoredCredentialList {
 /// deleting one never removes a key the operator manages themselves.
 const GENERATED_CREDENTIAL_PREFIX: &str = "NAC_CONFIG_";
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct CreateModelConfigurationRequest {
     pub name: String,
     pub backend: BackendKind,
     pub model: String,
     /// Defaults to the provider's canonical URL.
     pub base_url: Option<String>,
+    #[schema(write_only, example = "fake-api-key")]
     pub api_key: Option<String>,
     pub reasoning_effort: Option<ReasoningEffort>,
     pub extra_headers: Option<BTreeMap<String, String>>,
@@ -443,7 +534,7 @@ pub struct CreateModelConfigurationRequest {
 /// `api_key` is the exception that cannot be read back — the secret lives in
 /// the credential store — so omitting it keeps the credential the row already
 /// points at, and sending one files a fresh credential in its place.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct UpdateModelConfigurationRequest {
     #[serde(default)]
     pub name: RequestField<String>,
@@ -454,6 +545,7 @@ pub struct UpdateModelConfigurationRequest {
     #[serde(default)]
     pub base_url: RequestField<String>,
     #[serde(default)]
+    #[schema(write_only, example = "fake-replacement-key")]
     pub api_key: RequestField<String>,
     #[serde(default)]
     pub reasoning_effort: RequestField<ReasoningEffort>,
@@ -467,12 +559,12 @@ pub struct UpdateModelConfigurationRequest {
     pub light_model: RequestField<LightModelSettings>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ModelConfigurationList {
     pub configurations: Vec<ModelConfigurationRecord>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct CreateSshConfigurationRequest {
     pub name: String,
     pub ssh_host: String,
@@ -482,7 +574,7 @@ pub struct CreateSshConfigurationRequest {
 
 /// Edits a saved SSH setup in place. Every field is tri-state: omit it to keep
 /// what is stored, send null to clear it, send a value to replace it.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct UpdateSshConfigurationRequest {
     #[serde(default)]
     pub name: RequestField<String>,
@@ -494,12 +586,12 @@ pub struct UpdateSshConfigurationRequest {
     pub ssh_identity_file: RequestField<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct SshConfigurationList {
     pub configurations: Vec<SshConfigurationRecord>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct ModelConfigFromFileRequest {
     pub path: String,
 }
@@ -507,7 +599,7 @@ pub struct ModelConfigFromFileRequest {
 /// A configuration that has been checked end to end: the destination is
 /// approved, the credential resolves, and the provider answered with the
 /// models it allows.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ResolvedModelConfiguration {
     pub backend: BackendKind,
     pub model: Option<String>,
@@ -520,9 +612,10 @@ pub struct ResolvedModelConfiguration {
     pub models_error: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct ProviderModelsRequest {
     pub backend: BackendKind,
+    #[schema(write_only, example = "fake-provider-key")]
     pub api_key: Option<String>,
     /// Names a key already held in the environment or in NAC home, for a caller
     /// that has one on file and no copy of the secret to send.
@@ -531,7 +624,7 @@ pub struct ProviderModelsRequest {
     pub base_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ProviderModelList {
     /// The URL the models were actually read from, so the caller can persist
     /// the same destination it validated against.
@@ -539,17 +632,18 @@ pub struct ProviderModelList {
     pub models: Vec<ProviderModel>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct StoreCredentialRequest {
+    #[schema(write_only, example = "fake-credential-value")]
     pub value: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct GeneratedCredential {
     pub name: String,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct UpdateConfigRequest {
     #[serde(default)]
     pub model: RequestField<String>,
@@ -588,32 +682,32 @@ impl UpdateConfigRequest {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct UpdateSessionPresentationRequest {
     pub title: String,
     pub pinned: bool,
     pub expected_version: i64,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct ReorderSessionsRequest {
     pub pinned: bool,
     pub session_ids: Vec<String>,
     pub expected_versions: BTreeMap<String, i64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ReorderSessionsResponse {
     pub pinned: bool,
     pub sessions: Vec<SessionSummarySnapshot>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct SubmitPromptRequest {
     pub prompt: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct SwitchBranchRequest {
     pub name: String,
     /// Make the branch first, off the current HEAD.
@@ -621,36 +715,36 @@ pub struct SwitchBranchRequest {
     pub create: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct CommitWorkspaceRequest {
     pub message: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct SubmitPromptResponse {
     pub run_id: String,
     pub client_id: Option<String>,
     pub display_prompt: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct OrchestratorSteeringRequest {
     pub instruction: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct OrchestratorSteeringResponse {
     pub steering_id: i64,
     pub status: String,
     pub instruction_preview: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct ThreadSteeringRequest {
     pub instruction: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ThreadSteeringResponse {
     pub steering_id: i64,
     pub thread_name: String,
@@ -658,13 +752,15 @@ pub struct ThreadSteeringResponse {
     pub instruction_preview: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct EventsQuery {
     pub after_sequence_id: Option<u64>,
     pub limit: Option<usize>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct SessionSnapshotQuery {
     pub message_limit: Option<usize>,
     pub thread_event_limit: Option<usize>,
@@ -673,7 +769,8 @@ pub struct SessionSnapshotQuery {
     pub include_system: bool,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct MessagesQuery {
     pub before: Option<usize>,
     pub limit: Option<usize>,
@@ -681,13 +778,14 @@ pub struct MessagesQuery {
     pub include_system: bool,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ThreadEventsQuery {
     pub before_id: Option<i64>,
     pub limit: Option<usize>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct MessagePageMetadata {
     pub start: usize,
     pub end: usize,
@@ -695,20 +793,20 @@ pub struct MessagePageMetadata {
     pub has_older: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct MessagesPageResponse {
     pub messages: Vec<Message>,
     pub created_at: Vec<Option<String>>,
     pub page: MessagePageMetadata,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct MessageCycleMetadata {
     pub marker: String,
     pub thread_names: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct SessionSnapshotResponse {
     #[serde(flatten)]
     pub snapshot: SessionFrontendSnapshot,
@@ -748,12 +846,13 @@ impl From<MessagesPageSnapshot> for MessagesPageResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct RecentEventsResponse {
     pub events: Vec<SessionEventEnvelope>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct WorkspaceDiffQuery {
     pub path: String,
     pub stage: Option<String>,
@@ -762,31 +861,38 @@ pub struct WorkspaceDiffQuery {
     pub revision: Option<i64>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct WorkspaceFileQuery {
     pub path: String,
     pub revision: Option<i64>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct OpenWorkspacePathRequest {
     pub path: String,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct WorkspaceRevisionQuery {
     pub revision: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ReplayBoundaryEvent {
     pub epoch_id: String,
     pub replay_boundary_sequence_id: u64,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ReplayGapEvent {
     pub replay_gap: SessionReplayGap,
+}
+
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct LaggedEvent {
+    pub missed: u64,
 }
 
 impl SessionManager {
@@ -816,6 +922,7 @@ impl SessionManager {
                 store_path,
                 worker_executable,
                 active_sessions: RwLock::new(HashMap::new()),
+
                 lifecycle_gates: StdMutex::new(HashMap::new()),
                 workspace_diff_cache: RwLock::new(HashMap::new()),
                 git_probe_cache: RwLock::new(HashMap::new()),
@@ -2208,12 +2315,50 @@ async fn reject_foreign_host(
         _ => next.run(request).await,
     }
 }
+async fn secure_docs(request: axum::extract::Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    response.headers_mut().insert(
+        header::HeaderName::from_static("content-security-policy"),
+        header::HeaderValue::from_static("frame-ancestors 'none'"),
+    );
+    response.headers_mut().insert(
+        header::HeaderName::from_static("x-frame-options"),
+        header::HeaderValue::from_static("DENY"),
+    );
+    response
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "nac-web HTTP API",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Live OpenAPI 3.1 contract for nac-web's REST and SSE surface. nac-web binds to loopback by default and rejects foreign Host values unless NAC_ALLOWED_HOSTS permits an authenticating proxy; the API itself has no authentication. Finite JSON responses may be gzip-compressed. The SSE stream is text/event-stream and is never gzip-compressed. Credential values are write-only. /mcp is streamable-HTTP MCP (JSON-RPC), not REST, and is intentionally out of band."
+    ),
+    components(schemas(
+        filesystem::BrowseKind,
+        ReplayBoundaryEvent,
+        ReplayGapEvent,
+        SessionEventEnvelope,
+        AssistantStreamDelta,
+        LaggedEvent
+    ))
+)]
+struct ApiDoc;
 
 pub fn router(manager: SessionManager) -> Router {
     // The registry answer takes a few seconds, so it is warmed in the
     // background rather than on the first picker open.
     tokio::spawn(mcp_api::warm_library_cache());
-    api_router(manager)
+    let (api, openapi) = api_router(manager);
+    let docs = Router::new()
+        .merge(
+            SwaggerUi::new("/docs")
+                .url("/openapi.json", openapi)
+                .config(SwaggerConfig::default().validator_url("none")),
+        )
+        .layer(middleware::from_fn(secure_docs));
+    api.merge(docs)
         .merge(embedded_frontend_router())
         .layer(response_compression_layer())
         .layer(middleware::from_fn_with_state(
@@ -2229,142 +2374,83 @@ fn embedded_frontend_router() -> Router {
         .route("/assets/{*path}", get(serve_asset))
 }
 
-fn api_router(manager: SessionManager) -> Router {
-    Router::new()
-        .route("/health", get(health))
-        .route("/store", get(store_info))
-        .route("/fs/browse", get(browse_filesystem_handler))
-        .route("/ssh/browse", post(browse_ssh_handler))
-        .route("/providers/models", post(provider_models_handler))
-        .route(
-            "/model-configs",
-            get(list_model_configs_handler).post(create_model_config_handler),
-        )
-        .route(
-            "/model-configs/from-file",
-            post(model_config_from_file_handler),
-        )
-        .route(
-            "/model-configs/{config_id}",
-            patch(update_model_config_handler).delete(delete_model_config_handler),
-        )
-        .route(
-            "/model-configs/{config_id}/models",
-            post(saved_model_config_models_handler),
-        )
-        .route(
-            "/ssh-configs",
-            get(list_ssh_configs_handler).post(create_ssh_config_handler),
-        )
-        .route(
-            "/ssh-configs/{config_id}",
-            patch(update_ssh_config_handler).delete(delete_ssh_config_handler),
-        )
-        .route("/mcp_library/library", get(mcp_api::library_handler))
-        .route(
-            "/mcp_library/servers",
-            get(mcp_api::list_servers_handler).post(mcp_api::create_server_handler),
-        )
-        .route(
-            "/mcp_library/servers/test",
-            post(mcp_api::test_server_handler),
-        )
-        .route(
-            "/mcp_library/servers/{server_name}",
-            patch(mcp_api::update_server_handler).delete(mcp_api::delete_server_handler),
-        )
-        .route("/auth", get(managed_auth::list_handler))
-        .route("/auth/{provider}", delete(managed_auth::logout_handler))
-        .route(
-            "/auth/{provider}/login",
-            post(managed_auth::start_login_handler),
-        )
-        .route(
-            "/auth/{provider}/login/{login_id}",
-            get(managed_auth::poll_login_handler).delete(managed_auth::cancel_login_handler),
-        )
-        .route(
-            "/credentials",
-            get(list_credentials_handler).post(store_generated_credential_handler),
-        )
-        .route(
-            "/credentials/{name}",
-            put(store_credential_handler).delete(delete_credential_handler),
-        )
-        .route(
-            "/sessions/launch-defaults",
-            post(launch_model_defaults_handler),
-        )
-        .route("/models", get(models_handler))
-        .route("/commands", get(commands_handler))
-        .route("/sessions", get(list_sessions).post(create_session))
-        .route("/sessions/order", put(reorder_sessions_handler))
-        .route(
-            "/sessions/{session_id}/presentation",
-            put(update_session_presentation_handler),
-        )
-        .route("/sessions/{session_id}/messages", get(session_messages))
-        .route(
-            "/sessions/{session_id}/threads/{thread_name}/events",
-            get(thread_events),
-        )
-        .route("/sessions/{session_id}/workspace/diff", get(workspace_diff))
-        .route(
-            "/sessions/{session_id}/workspace/files",
-            get(workspace_files),
-        )
-        .route("/sessions/{session_id}/workspace/file", get(workspace_file))
-        .route(
-            "/sessions/{session_id}/workspace/open",
-            post(open_workspace_path),
-        )
-        .route(
-            "/sessions/{session_id}/workspace/branches",
-            get(workspace_branches).post(switch_workspace_branch),
-        )
-        .route(
-            "/sessions/{session_id}/workspace/commit",
-            post(commit_workspace),
-        )
-        .route(
-            "/sessions/{session_id}/workspace/revisions",
-            get(workspace_revisions),
-        )
-        .route(
-            "/sessions/{session_id}/workspace/revisions/{revision_id}/changes",
-            get(workspace_revision_changes),
-        )
-        .route(
-            "/sessions/{session_id}",
-            get(session_snapshot).delete(delete_session_handler),
-        )
-        .route(
-            "/sessions/{session_id}/config",
-            get(session_config_handler).patch(update_config_handler),
-        )
-        .route("/sessions/{session_id}/runs", post(submit_prompt))
-        .route("/sessions/{session_id}/compact", post(compaction::handler))
-        .route("/sessions/{session_id}/revert", post(revert::handler))
-        .route(
-            "/sessions/{session_id}/regenerate",
-            post(revert::regenerate_handler),
-        )
-        .route(
-            "/sessions/{session_id}/steering",
-            post(queue_orchestrator_steering_handler),
-        )
-        .route(
-            "/sessions/{session_id}/threads/{thread_name}/steering",
-            post(queue_thread_steering_handler),
-        )
-        .route("/sessions/{session_id}/events", get(recent_events))
-        .route("/sessions/{session_id}/events/stream", get(stream_events))
-        .route(
-            "/sessions/{session_id}/cancel-active-run",
-            post(cancel_active_run),
-        )
-        .nest_service("/mcp", mcp::streamable_http_service(manager.clone()))
-        .with_state(manager)
+fn api_router(manager: SessionManager) -> (Router, utoipa::openapi::OpenApi) {
+    let documented = OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .routes(routes!(health))
+        .routes(routes!(store_info))
+        .routes(routes!(browse_filesystem_handler))
+        .routes(routes!(browse_ssh_handler))
+        .routes(routes!(provider_models_handler))
+        .routes(routes!(
+            list_model_configs_handler,
+            create_model_config_handler
+        ))
+        .routes(routes!(model_config_from_file_handler))
+        .routes(routes!(
+            update_model_config_handler,
+            delete_model_config_handler
+        ))
+        .routes(routes!(saved_model_config_models_handler))
+        .routes(routes!(list_ssh_configs_handler, create_ssh_config_handler))
+        .routes(routes!(
+            update_ssh_config_handler,
+            delete_ssh_config_handler
+        ))
+        .routes(routes!(mcp_api::library_handler))
+        .routes(routes!(
+            mcp_api::list_servers_handler,
+            mcp_api::create_server_handler
+        ))
+        .routes(routes!(mcp_api::test_server_handler))
+        .routes(routes!(
+            mcp_api::update_server_handler,
+            mcp_api::delete_server_handler
+        ))
+        .routes(routes!(managed_auth::list_handler))
+        .routes(routes!(managed_auth::logout_handler))
+        .routes(routes!(managed_auth::start_login_handler))
+        .routes(routes!(
+            managed_auth::poll_login_handler,
+            managed_auth::cancel_login_handler
+        ))
+        .routes(routes!(
+            list_credentials_handler,
+            store_generated_credential_handler
+        ))
+        .routes(routes!(store_credential_handler, delete_credential_handler))
+        .routes(routes!(launch_model_defaults_handler))
+        .routes(routes!(models_handler))
+        .routes(routes!(commands_handler))
+        .routes(routes!(list_sessions, create_session))
+        .routes(routes!(reorder_sessions_handler))
+        .routes(routes!(update_session_presentation_handler))
+        .routes(routes!(session_messages))
+        .routes(routes!(thread_events))
+        .routes(routes!(workspace_diff))
+        .routes(routes!(workspace_files))
+        .routes(routes!(workspace_file))
+        .routes(routes!(open_workspace_path))
+        .routes(routes!(workspace_branches, switch_workspace_branch))
+        .routes(routes!(commit_workspace))
+        .routes(routes!(workspace_revisions))
+        .routes(routes!(workspace_revision_changes))
+        .routes(routes!(session_snapshot, delete_session_handler))
+        .routes(routes!(session_config_handler, update_config_handler))
+        .routes(routes!(submit_prompt))
+        .routes(routes!(compaction::handler))
+        .routes(routes!(revert::handler))
+        .routes(routes!(revert::regenerate_handler))
+        .routes(routes!(queue_orchestrator_steering_handler))
+        .routes(routes!(queue_thread_steering_handler))
+        .routes(routes!(recent_events))
+        .routes(routes!(stream_events))
+        .routes(routes!(cancel_active_run))
+        .with_state(manager.clone());
+    let (router, openapi) = documented.split_for_parts();
+    (
+        router.nest_service("/mcp", mcp::streamable_http_service(manager)),
+        openapi,
+    )
 }
 
 pub async fn serve(addr: SocketAddr, manager: SessionManager) -> Result<()> {
@@ -2394,8 +2480,15 @@ pub async fn serve_with(
         .context("server stopped unexpectedly")
 }
 
-async fn health() -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "status": "ok" }))
+#[utoipa::path(
+    get,
+    path = "/health",
+    operation_id = "get_health",
+    tag = "system",
+    responses((status = 200, description = "Success", body = HealthResponse, content_type = "application/json"))
+)]
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse { status: "ok" })
 }
 
 // The frontend is a Vite/React app built from `web/` into `assets/dist/`. That
@@ -2458,12 +2551,27 @@ async fn serve_asset(AxumPath(path): AxumPath<String>) -> Response {
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/store",
+    operation_id = "get_store",
+    tag = "system",
+    responses((status = 200, description = "Success", body = StoreInfo, content_type = "application/json"))
+)]
 async fn store_info(State(manager): State<SessionManager>) -> Json<StoreInfo> {
     Json(manager.store_info())
 }
 
 /// The picker starts wherever the caller last was; with no path yet it opens on
 /// the server root the session would default to anyway.
+#[utoipa::path(
+    get,
+    path = "/fs/browse",
+    operation_id = "get_fs_browse",
+    tag = "filesystem",
+    params(filesystem::BrowseQuery),
+    responses((status = 200, description = "Success", body = filesystem::BrowseListing, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 403, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn browse_filesystem_handler(
     State(manager): State<SessionManager>,
     Query(query): Query<filesystem::BrowseQuery>,
@@ -2474,6 +2582,14 @@ async fn browse_filesystem_handler(
 
 /// The same listing for a directory on an SSH host, which is also how the launch
 /// form tests the connection before it offers the rest of the form.
+#[utoipa::path(
+    post,
+    path = "/ssh/browse",
+    operation_id = "post_ssh_browse",
+    tag = "filesystem",
+    request_body(content = SshBrowseRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = filesystem::BrowseListing, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 403, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 502, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn browse_ssh_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<SshBrowseRequest>, JsonRejection>,
@@ -2490,6 +2606,14 @@ async fn browse_ssh_handler(
 /// check as a session launch. A provider signed in through the browser has no
 /// key to send, so the stored login answers instead — and its answer is the
 /// same evidence the launch UI needs that the login still works.
+#[utoipa::path(
+    post,
+    path = "/providers/models",
+    operation_id = "post_providers_models",
+    tag = "models",
+    request_body(content = ProviderModelsRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = ProviderModelList, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 502, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn provider_models_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<ProviderModelsRequest>, JsonRejection>,
@@ -2569,6 +2693,13 @@ async fn provider_models_handler(
     Ok(Json(ProviderModelList { base_url, models }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/model-configs",
+    operation_id = "get_model_configs",
+    tag = "model-configs",
+    responses((status = 200, description = "Success", body = ModelConfigurationList, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn list_model_configs_handler(
     State(manager): State<SessionManager>,
 ) -> std::result::Result<Json<ModelConfigurationList>, ApiError> {
@@ -2582,6 +2713,14 @@ async fn list_model_configs_handler(
 /// The key is filed in the credential store under a generated name that the
 /// row then points at, so the secret stays out of the database and a launched
 /// session resolves it through the ordinary `api_key_env` path.
+#[utoipa::path(
+    post,
+    path = "/model-configs",
+    operation_id = "post_model_configs",
+    tag = "model-configs",
+    request_body(content = CreateModelConfigurationRequest, content_type = "application/json"),
+    responses((status = 201, description = "Success", body = ModelConfigurationRecord, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn create_model_config_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<CreateModelConfigurationRequest>, JsonRejection>,
@@ -2712,6 +2851,15 @@ fn settle_configuration_base_url(
 /// it; the credential it replaces is dropped only once the row has actually
 /// moved, so a failed edit never leaves the configuration pointing at a secret
 /// that is gone.
+#[utoipa::path(
+    patch,
+    path = "/model-configs/{config_id}",
+    operation_id = "patch_model_configs_config_id",
+    tag = "model-configs",
+    params(("config_id" = String, Path)),
+    request_body(content = UpdateModelConfigurationRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = ModelConfigurationRecord, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn update_model_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(config_id): AxumPath<String>,
@@ -2895,6 +3043,14 @@ fn replaceable_text(field: RequestField<String>, current: &str) -> String {
 /// The key is never sent by the client here: the file names an environment
 /// variable or stored credential, and the server resolves it the same way a
 /// session would.
+#[utoipa::path(
+    post,
+    path = "/model-configs/from-file",
+    operation_id = "post_model_configs_from_file",
+    tag = "model-configs",
+    request_body(content = ModelConfigFromFileRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = ResolvedModelConfiguration, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 502, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn model_config_from_file_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<ModelConfigFromFileRequest>, JsonRejection>,
@@ -2941,6 +3097,14 @@ async fn model_config_from_file_handler(
     .await
 }
 
+#[utoipa::path(
+    post,
+    path = "/model-configs/{config_id}/models",
+    operation_id = "post_model_configs_config_id_models",
+    tag = "model-configs",
+    params(("config_id" = String, Path)),
+    responses((status = 200, description = "Success", body = ResolvedModelConfiguration, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 502, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn saved_model_config_models_handler(
     State(manager): State<SessionManager>,
     AxumPath(config_id): AxumPath<String>,
@@ -3037,6 +3201,14 @@ async fn resolve_configuration(
     }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/model-configs/{config_id}",
+    operation_id = "delete_model_configs_config_id",
+    tag = "model-configs",
+    params(("config_id" = String, Path)),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn delete_model_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(config_id): AxumPath<String>,
@@ -3067,6 +3239,13 @@ async fn delete_model_config_handler(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    get,
+    path = "/ssh-configs",
+    operation_id = "get_ssh_configs",
+    tag = "ssh-configs",
+    responses((status = 200, description = "Success", body = SshConfigurationList, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn list_ssh_configs_handler(
     State(manager): State<SessionManager>,
 ) -> std::result::Result<Json<SshConfigurationList>, ApiError> {
@@ -3075,6 +3254,14 @@ async fn list_ssh_configs_handler(
 }
 
 /// Save a named SSH connection under a reusable setup.
+#[utoipa::path(
+    post,
+    path = "/ssh-configs",
+    operation_id = "post_ssh_configs",
+    tag = "ssh-configs",
+    request_body(content = CreateSshConfigurationRequest, content_type = "application/json"),
+    responses((status = 201, description = "Success", body = SshConfigurationRecord, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn create_ssh_config_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<CreateSshConfigurationRequest>, JsonRejection>,
@@ -3096,6 +3283,15 @@ async fn create_ssh_config_handler(
 }
 
 /// Edit a saved SSH setup, keeping whatever the request leaves out.
+#[utoipa::path(
+    patch,
+    path = "/ssh-configs/{config_id}",
+    operation_id = "patch_ssh_configs_config_id",
+    tag = "ssh-configs",
+    params(("config_id" = String, Path)),
+    request_body(content = UpdateSshConfigurationRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = SshConfigurationRecord, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn update_ssh_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(config_id): AxumPath<String>,
@@ -3128,6 +3324,14 @@ async fn update_ssh_config_handler(
     Ok(Json(record))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/ssh-configs/{config_id}",
+    operation_id = "delete_ssh_configs_config_id",
+    tag = "ssh-configs",
+    params(("config_id" = String, Path)),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn delete_ssh_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(config_id): AxumPath<String>,
@@ -3140,6 +3344,13 @@ async fn delete_ssh_config_handler(
 /// Stored credentials are write-only over HTTP: a caller may add, replace or
 /// drop a key, but the value is never echoed back. Only enough of a suffix to
 /// tell two keys apart leaves the process.
+#[utoipa::path(
+    get,
+    path = "/credentials",
+    operation_id = "get_credentials",
+    tag = "credentials",
+    responses((status = 200, description = "Success", body = StoredCredentialList, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn list_credentials_handler() -> std::result::Result<Json<StoredCredentialList>, ApiError> {
     let credentials = list_stored_api_keys()?
         .into_iter()
@@ -3151,6 +3362,15 @@ async fn list_credentials_handler() -> std::result::Result<Json<StoredCredential
     Ok(Json(StoredCredentialList { credentials }))
 }
 
+#[utoipa::path(
+    put,
+    path = "/credentials/{name}",
+    operation_id = "put_credentials_name",
+    tag = "credentials",
+    params(("name" = String, Path)),
+    request_body(content = StoreCredentialRequest, content_type = "application/json"),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn store_credential_handler(
     AxumPath(name): AxumPath<String>,
     payload: std::result::Result<Json<StoreCredentialRequest>, JsonRejection>,
@@ -3163,6 +3383,14 @@ async fn store_credential_handler(
 /// Files a key away without the caller having to name it. The generated name is
 /// what a session stores in place of the secret, and its prefix marks the key as
 /// this server's to clean up rather than one the operator manages by hand.
+#[utoipa::path(
+    post,
+    path = "/credentials",
+    operation_id = "post_credentials",
+    tag = "credentials",
+    request_body(content = StoreCredentialRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = GeneratedCredential, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn store_generated_credential_handler(
     payload: std::result::Result<Json<StoreCredentialRequest>, JsonRejection>,
 ) -> std::result::Result<Json<GeneratedCredential>, ApiError> {
@@ -3175,6 +3403,14 @@ async fn store_generated_credential_handler(
     Ok(Json(GeneratedCredential { name }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/credentials/{name}",
+    operation_id = "delete_credentials_name",
+    tag = "credentials",
+    params(("name" = String, Path)),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn delete_credential_handler(
     AxumPath(name): AxumPath<String>,
 ) -> std::result::Result<StatusCode, ApiError> {
@@ -3188,6 +3424,14 @@ async fn delete_credential_handler(
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/launch-defaults",
+    operation_id = "post_sessions_launch_defaults",
+    tag = "sessions",
+    request_body(content = LaunchModelDefaultsRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = LaunchModelDefaults, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn launch_model_defaults_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<LaunchModelDefaultsRequest>, JsonRejection>,
@@ -3202,14 +3446,36 @@ async fn launch_model_defaults_handler(
 /// synchronous, local-only, never fails. `auth_status`/`auth_hint` are
 /// computed per request from the process environment and the managed
 /// credential files.
+#[utoipa::path(
+    get,
+    path = "/models",
+    operation_id = "get_models",
+    tag = "models",
+    responses((status = 200, description = "Success", body = ModelListing, content_type = "application/json"))
+)]
 async fn models_handler() -> Json<ModelListing> {
     Json(nac_core::model::api_listing())
 }
 
+#[utoipa::path(
+    get,
+    path = "/commands",
+    operation_id = "get_commands",
+    tag = "system",
+    responses((status = 200, description = "Success", body = Vec<SlashCommandDefinition>, content_type = "application/json"))
+)]
 async fn commands_handler() -> Json<&'static [SlashCommandDefinition]> {
     Json(slash_command_definitions())
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions",
+    operation_id = "get_sessions",
+    tag = "sessions",
+    params(ListSessionsQuery),
+    responses((status = 200, description = "Success", body = Vec<ManagedSessionSummary>, content_type = "application/json"), (status = 400, description = "Query extraction failed", body = String, content_type = "text/plain"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn list_sessions(
     State(manager): State<SessionManager>,
     Query(query): Query<ListSessionsQuery>,
@@ -3217,6 +3483,15 @@ async fn list_sessions(
     Ok(Json(manager.list_sessions(query.workspace_stats).await?))
 }
 
+#[utoipa::path(
+    put,
+    path = "/sessions/{session_id}/presentation",
+    operation_id = "put_sessions_session_id_presentation",
+    tag = "sessions",
+    params(("session_id" = String, Path)),
+    request_body(content = UpdateSessionPresentationRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = SessionSummarySnapshot, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn update_session_presentation_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3234,6 +3509,14 @@ async fn update_session_presentation_handler(
     Ok(Json(summary))
 }
 
+#[utoipa::path(
+    put,
+    path = "/sessions/order",
+    operation_id = "put_sessions_order",
+    tag = "sessions",
+    request_body(content = ReorderSessionsRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = ReorderSessionsResponse, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn reorder_sessions_handler(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<ReorderSessionsRequest>, JsonRejection>,
@@ -3252,6 +3535,14 @@ async fn reorder_sessions_handler(
     }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions",
+    operation_id = "post_sessions",
+    tag = "sessions",
+    request_body(content = CreateSessionRequest, content_type = "application/json"),
+    responses((status = 201, description = "Success", body = SessionFrontendSnapshot, content_type = "application/json"), (status = 400, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn create_session(
     State(manager): State<SessionManager>,
     payload: std::result::Result<Json<CreateSessionRequest>, JsonRejection>,
@@ -3263,6 +3554,14 @@ async fn create_session(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}",
+    operation_id = "get_sessions_session_id",
+    tag = "sessions",
+    params(SessionSnapshotQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = SessionSnapshotResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn session_snapshot(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3289,6 +3588,14 @@ async fn session_snapshot(
     }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/messages",
+    operation_id = "get_sessions_session_id_messages",
+    tag = "conversation",
+    params(MessagesQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = MessagesPageResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn session_messages(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3310,6 +3617,14 @@ async fn session_messages(
     Ok(Json(page.into()))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/threads/{thread_name}/events",
+    operation_id = "get_sessions_session_id_threads_thread_name_events",
+    tag = "conversation",
+    params(ThreadEventsQuery, ("session_id" = String, Path), ("thread_name" = String, Path)),
+    responses((status = 200, description = "Success", body = ThreadEventPage, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn thread_events(
     State(manager): State<SessionManager>,
     AxumPath((session_id, thread_name)): AxumPath<(String, String)>,
@@ -3330,6 +3645,14 @@ async fn thread_events(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/diff",
+    operation_id = "get_sessions_session_id_workspace_diff",
+    tag = "workspace",
+    params(WorkspaceDiffQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = view::WorkspaceFileDiff, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_diff(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3338,6 +3661,14 @@ async fn workspace_diff(
     Ok(Json(manager.workspace_file_diff(&session_id, query).await?))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/files",
+    operation_id = "get_sessions_session_id_workspace_files",
+    tag = "workspace",
+    params(WorkspaceRevisionQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = view::WorkspaceFileList, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_files(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3348,6 +3679,14 @@ async fn workspace_files(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/file",
+    operation_id = "get_sessions_session_id_workspace_file",
+    tag = "workspace",
+    params(WorkspaceFileQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = view::WorkspaceFileContent, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_file(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3360,6 +3699,15 @@ async fn workspace_file(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/workspace/open",
+    operation_id = "post_sessions_session_id_workspace_open",
+    tag = "workspace",
+    params(("session_id" = String, Path)),
+    request_body(content = OpenWorkspacePathRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = view::OpenLocalPathResult, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 501, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn open_workspace_path(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3373,6 +3721,14 @@ async fn open_workspace_path(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/revisions",
+    operation_id = "get_sessions_session_id_workspace_revisions",
+    tag = "workspace",
+    params(("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = Vec<view::WorkspaceRevisionRecord>, content_type = "application/json"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_revisions(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3380,6 +3736,14 @@ async fn workspace_revisions(
     Ok(Json(manager.workspace_revisions(&session_id)?))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/revisions/{revision_id}/changes",
+    operation_id = "get_sessions_session_id_workspace_revisions_revision_id_changes",
+    tag = "workspace",
+    params(("session_id" = String, Path), ("revision_id" = i64, Path)),
+    responses((status = 200, description = "Success", body = view::WorkspaceRevisionChanges, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_revision_changes(
     State(manager): State<SessionManager>,
     AxumPath((session_id, revision_id)): AxumPath<(String, i64)>,
@@ -3391,6 +3755,14 @@ async fn workspace_revision_changes(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/workspace/branches",
+    operation_id = "get_sessions_session_id_workspace_branches",
+    tag = "workspace",
+    params(("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = workspace::BranchList, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn workspace_branches(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3398,6 +3770,15 @@ async fn workspace_branches(
     Ok(Json(manager.workspace_branches(&session_id).await?))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/workspace/branches",
+    operation_id = "post_sessions_session_id_workspace_branches",
+    tag = "workspace",
+    params(("session_id" = String, Path)),
+    request_body(content = SwitchBranchRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = workspace::BranchList, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn switch_workspace_branch(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3411,6 +3792,15 @@ async fn switch_workspace_branch(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/workspace/commit",
+    operation_id = "post_sessions_session_id_workspace_commit",
+    tag = "workspace",
+    params(("session_id" = String, Path)),
+    request_body(content = CommitWorkspaceRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = workspace::CommitOutcome, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn commit_workspace(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3420,6 +3810,15 @@ async fn commit_workspace(
     Ok(Json(manager.commit_workspace(&session_id, request).await?))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/runs",
+    operation_id = "post_sessions_session_id_runs",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    request_body(content = SubmitPromptRequest, content_type = "application/json"),
+    responses((status = 202, description = "Success", body = SubmitPromptResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 413, description = "Request body too large", body = String, content_type = "text/plain"), (status = 415, description = "Unsupported media type", body = String, content_type = "text/plain"), (status = 422, description = "JSON body validation failed", body = String, content_type = "text/plain"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 501, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn submit_prompt(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3431,6 +3830,15 @@ async fn submit_prompt(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/steering",
+    operation_id = "post_sessions_session_id_steering",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    request_body(content = OrchestratorSteeringRequest, content_type = "application/json"),
+    responses((status = 202, description = "Success", body = OrchestratorSteeringResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn queue_orchestrator_steering_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3448,6 +3856,15 @@ async fn queue_orchestrator_steering_handler(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/threads/{thread_name}/steering",
+    operation_id = "post_sessions_session_id_threads_thread_name_steering",
+    tag = "conversation",
+    params(("session_id" = String, Path), ("thread_name" = String, Path)),
+    request_body(content = ThreadSteeringRequest, content_type = "application/json"),
+    responses((status = 202, description = "Success", body = ThreadSteeringResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn queue_thread_steering_handler(
     State(manager): State<SessionManager>,
     AxumPath((session_id, thread_name)): AxumPath<(String, String)>,
@@ -3465,6 +3882,14 @@ async fn queue_thread_steering_handler(
     ))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/events",
+    operation_id = "get_sessions_session_id_events",
+    tag = "events",
+    params(EventsQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = RecentEventsResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn recent_events(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3480,6 +3905,14 @@ async fn recent_events(
     Ok(Json(RecentEventsResponse { events }))
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/events/stream",
+    operation_id = "get_sessions_session_id_events_stream",
+    tag = "events",
+    params(EventsQuery, ("session_id" = String, Path)),
+    responses((status = 200, description = "Server-sent events. Event names and JSON data schemas: replay_boundary (ReplayBoundaryEvent), replay_gap (ReplayGapEvent), session_event (SessionEventEnvelope), assistant_delta (AssistantStreamDelta), and lagged (LaggedEvent). Only session_event carries an SSE id. This response is never gzip-compressed.", body = String, content_type = "text/event-stream"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn stream_events(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3518,6 +3951,14 @@ async fn stream_events(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/cancel-active-run",
+    operation_id = "post_sessions_session_id_cancel_active_run",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    responses((status = 202, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 501, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn cancel_active_run(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3526,6 +3967,14 @@ async fn cancel_active_run(
     Ok(StatusCode::ACCEPTED)
 }
 
+#[utoipa::path(
+    delete,
+    path = "/sessions/{session_id}",
+    operation_id = "delete_sessions_session_id",
+    tag = "sessions",
+    params(("session_id" = String, Path)),
+    responses((status = 200, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn delete_session_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3534,6 +3983,14 @@ async fn delete_session_handler(
     Ok(StatusCode::OK)
 }
 
+#[utoipa::path(
+    get,
+    path = "/sessions/{session_id}/config",
+    operation_id = "get_sessions_session_id_config",
+    tag = "sessions",
+    params(("session_id" = String, Path)),
+    responses((status = 200, description = "Success", body = sessions::RawSessionConfig, content_type = "application/json"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn session_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3541,6 +3998,15 @@ async fn session_config_handler(
     Ok(Json(manager.session_config(&session_id)?))
 }
 
+#[utoipa::path(
+    patch,
+    path = "/sessions/{session_id}/config",
+    operation_id = "patch_sessions_session_id_config",
+    tag = "sessions",
+    params(("session_id" = String, Path)),
+    request_body(content = UpdateConfigRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success with no response body"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = ApiErrorBody, content_type = "application/json"))
+)]
 async fn update_config_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -3914,9 +4380,8 @@ fn session_event_stream(
             };
             match next {
                 StreamItem::Session(Ok(envelope)) => yield Ok(sse_envelope_event(&envelope)),
-                StreamItem::Session(Err(tokio::sync::broadcast::error::RecvError::Lagged(count))) => {
-                    let payload = serde_json::json!({ "missed": count });
-                    yield Ok(sse_json_event("lagged", None, &payload));
+                StreamItem::Session(Err(tokio::sync::broadcast::error::RecvError::Lagged(missed))) => {
+                    yield Ok(sse_json_event("lagged", None, &LaggedEvent { missed }));
                 }
                 StreamItem::Session(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
                 StreamItem::Delta(Ok(delta)) => {
@@ -4165,9 +4630,9 @@ impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         (
             self.status,
-            Json(serde_json::json!({
-                "error": self.message,
-            })),
+            Json(ApiErrorBody {
+                error: self.message,
+            }),
         )
             .into_response()
     }
@@ -4184,6 +4649,479 @@ mod tests {
     };
     use flate2::read::GzDecoder;
     use tower::ServiceExt;
+
+    const EXPECTED_OPENAPI_OPERATIONS: &[(&str, &str)] = &[
+        ("DELETE", "/auth/{provider}"),
+        ("DELETE", "/auth/{provider}/login/{login_id}"),
+        ("DELETE", "/credentials/{name}"),
+        ("DELETE", "/mcp_library/servers/{server_name}"),
+        ("DELETE", "/model-configs/{config_id}"),
+        ("DELETE", "/sessions/{session_id}"),
+        ("DELETE", "/ssh-configs/{config_id}"),
+        ("GET", "/auth"),
+        ("GET", "/auth/{provider}/login/{login_id}"),
+        ("GET", "/commands"),
+        ("GET", "/credentials"),
+        ("GET", "/fs/browse"),
+        ("GET", "/health"),
+        ("GET", "/mcp_library/library"),
+        ("GET", "/mcp_library/servers"),
+        ("GET", "/model-configs"),
+        ("GET", "/models"),
+        ("GET", "/sessions"),
+        ("GET", "/sessions/{session_id}"),
+        ("GET", "/sessions/{session_id}/config"),
+        ("GET", "/sessions/{session_id}/events"),
+        ("GET", "/sessions/{session_id}/events/stream"),
+        ("GET", "/sessions/{session_id}/messages"),
+        ("GET", "/sessions/{session_id}/threads/{thread_name}/events"),
+        ("GET", "/sessions/{session_id}/workspace/branches"),
+        ("GET", "/sessions/{session_id}/workspace/diff"),
+        ("GET", "/sessions/{session_id}/workspace/file"),
+        ("GET", "/sessions/{session_id}/workspace/files"),
+        ("GET", "/sessions/{session_id}/workspace/revisions"),
+        (
+            "GET",
+            "/sessions/{session_id}/workspace/revisions/{revision_id}/changes",
+        ),
+        ("GET", "/ssh-configs"),
+        ("GET", "/store"),
+        ("PATCH", "/mcp_library/servers/{server_name}"),
+        ("PATCH", "/model-configs/{config_id}"),
+        ("PATCH", "/sessions/{session_id}/config"),
+        ("PATCH", "/ssh-configs/{config_id}"),
+        ("POST", "/auth/{provider}/login"),
+        ("POST", "/credentials"),
+        ("POST", "/mcp_library/servers"),
+        ("POST", "/mcp_library/servers/test"),
+        ("POST", "/model-configs"),
+        ("POST", "/model-configs/from-file"),
+        ("POST", "/model-configs/{config_id}/models"),
+        ("POST", "/providers/models"),
+        ("POST", "/sessions"),
+        ("POST", "/sessions/launch-defaults"),
+        ("POST", "/sessions/{session_id}/cancel-active-run"),
+        ("POST", "/sessions/{session_id}/compact"),
+        ("POST", "/sessions/{session_id}/regenerate"),
+        ("POST", "/sessions/{session_id}/revert"),
+        ("POST", "/sessions/{session_id}/runs"),
+        ("POST", "/sessions/{session_id}/steering"),
+        (
+            "POST",
+            "/sessions/{session_id}/threads/{thread_name}/steering",
+        ),
+        ("POST", "/sessions/{session_id}/workspace/branches"),
+        ("POST", "/sessions/{session_id}/workspace/commit"),
+        ("POST", "/sessions/{session_id}/workspace/open"),
+        ("POST", "/ssh-configs"),
+        ("POST", "/ssh/browse"),
+        ("PUT", "/credentials/{name}"),
+        ("PUT", "/sessions/order"),
+        ("PUT", "/sessions/{session_id}/presentation"),
+    ];
+
+    fn concrete_api_path(path: &str) -> String {
+        path.replace("{provider}", "arcee")
+            .replace("{login_id}", "missing-login")
+            .replace("{name}", "MISSING_CREDENTIAL")
+            .replace("{server_name}", "missing-server")
+            .replace("{config_id}", "missing-config")
+            .replace("{session_id}", "missing-session")
+            .replace("{thread_name}", "missing-thread")
+            .replace("{revision_id}", "1")
+    }
+
+    fn assert_local_refs_resolve(document: &serde_json::Value, value: &serde_json::Value) {
+        match value {
+            serde_json::Value::Object(object) => {
+                if let Some(reference) = object.get("$ref").and_then(serde_json::Value::as_str) {
+                    let pointer = reference
+                        .strip_prefix('#')
+                        .expect("only local OpenAPI references are expected");
+                    assert!(
+                        document.pointer(pointer).is_some(),
+                        "unresolved OpenAPI reference {reference}"
+                    );
+                }
+                for child in object.values() {
+                    assert_local_refs_resolve(document, child);
+                }
+            }
+            serde_json::Value::Array(array) => {
+                for child in array {
+                    assert_local_refs_resolve(document, child);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    #[tokio::test]
+    async fn openapi_document_matches_the_running_api_router() {
+        let root = temp_root("openapi_contract");
+        let app = router(test_manager(&root));
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/openapi.json")
+                    .header(header::HOST, "127.0.0.1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static("application/json"))
+        );
+        let document: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+        assert_eq!(document["openapi"], "3.1.0");
+
+        let mut documented = std::collections::BTreeSet::new();
+        for (path, item) in document["paths"].as_object().expect("OpenAPI paths") {
+            let item = item.as_object().expect("OpenAPI path item");
+            for method in ["get", "post", "put", "patch", "delete"] {
+                if item.contains_key(method) {
+                    documented.insert((method.to_uppercase(), path.clone()));
+                }
+            }
+        }
+        let expected: std::collections::BTreeSet<_> = EXPECTED_OPENAPI_OPERATIONS
+            .iter()
+            .map(|(method, path)| ((*method).to_string(), (*path).to_string()))
+            .collect();
+        assert_eq!(documented, expected);
+
+        let mut operation_ids = std::collections::BTreeSet::new();
+        for (method, path) in EXPECTED_OPENAPI_OPERATIONS {
+            let operation = &document["paths"][path][method.to_ascii_lowercase()];
+            let operation_id = operation["operationId"].as_str().expect("operation id");
+            assert!(
+                operation_ids.insert(operation_id),
+                "duplicate operation id {operation_id}"
+            );
+            for parameter_name in path
+                .split('{')
+                .skip(1)
+                .filter_map(|tail| tail.split_once('}').map(|(name, _)| name))
+            {
+                let matches = operation["parameters"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter(|parameter| {
+                        parameter["name"] == parameter_name
+                            && parameter["in"] == "path"
+                            && parameter["required"] == true
+                    })
+                    .count();
+                assert_eq!(
+                    matches, 1,
+                    "{method} {path} must document required path parameter {parameter_name}"
+                );
+            }
+        }
+        assert_local_refs_resolve(&document, &document);
+
+        for path in expected
+            .iter()
+            .map(|(_, path)| path)
+            .collect::<std::collections::BTreeSet<_>>()
+        {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(axum::http::Method::OPTIONS)
+                        .uri(concrete_api_path(path))
+                        .header(header::HOST, "127.0.0.1")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_ne!(
+                response.status(),
+                StatusCode::NOT_FOUND,
+                "documented runtime path {path} is not routed"
+            );
+            let allow = response
+                .headers()
+                .get(header::ALLOW)
+                .expect("method router must report Allow")
+                .to_str()
+                .unwrap();
+            for (method, expected_path) in &expected {
+                if expected_path == path {
+                    assert!(
+                        allow.split(',').any(|allowed| allowed.trim() == method),
+                        "{path} runtime Allow={allow:?} is missing {method}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn openapi_special_wire_schemas_and_docs_are_live() {
+        let root = temp_root("openapi_special_schemas");
+        let app = router(test_manager(&root));
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/openapi.json")
+                    .header(header::HOST, "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let document: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap())
+                .unwrap();
+
+        let create = &document["components"]["schemas"]["CreateSessionRequest"];
+        assert!(!create["required"]
+            .as_array()
+            .is_some_and(|required| required.iter().any(|field| field == "model")));
+        let model = &create["properties"]["model"];
+        let model_ref = model["$ref"].as_str().expect("model schema reference");
+        let variants = document
+            .pointer(
+                model_ref
+                    .strip_prefix('#')
+                    .expect("local model schema reference"),
+            )
+            .and_then(|schema| schema["oneOf"].as_array())
+            .expect("nullable model oneOf");
+        assert!(variants.iter().any(|variant| variant["type"] == "null"));
+        assert!(variants.iter().any(|variant| variant["type"] == "string"));
+        let headers_ref = create["properties"]["extra_headers"]["$ref"]
+            .as_str()
+            .expect("tri-state headers reference");
+        let headers_variants = document
+            .pointer(
+                headers_ref
+                    .strip_prefix('#')
+                    .expect("local headers schema reference"),
+            )
+            .and_then(|schema| schema["oneOf"].as_array())
+            .expect("nullable headers oneOf");
+        assert!(headers_variants
+            .iter()
+            .any(|variant| variant["type"] == "null"));
+        let headers = headers_variants
+            .iter()
+            .find_map(|variant| variant["oneOf"].as_array())
+            .expect("HeadersRequest object/string oneOf");
+        assert_eq!(headers.len(), 2);
+        assert!(headers.iter().any(|schema| schema["type"] == "object"));
+        assert!(headers.iter().any(|schema| schema["type"] == "string"));
+        let model_headers_ref = document["components"]["schemas"]
+            ["UpdateModelConfigurationRequest"]["properties"]["extra_headers"]["$ref"]
+            .as_str()
+            .expect("model header map schema reference");
+        let mcp_env_ref = document["components"]["schemas"]["UpdateMcpServerRequest"]["properties"]
+            ["env"]["$ref"]
+            .as_str()
+            .expect("MCP environment map schema reference");
+        assert_ne!(model_headers_ref, mcp_env_ref);
+        let model_headers = document
+            .pointer(model_headers_ref.strip_prefix('#').unwrap())
+            .and_then(|schema| schema["oneOf"].as_array())
+            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
+            .expect("model header map variant");
+        assert_eq!(model_headers["additionalProperties"]["type"], "string");
+        let mcp_env = document
+            .pointer(mcp_env_ref.strip_prefix('#').unwrap())
+            .and_then(|schema| schema["oneOf"].as_array())
+            .and_then(|variants| variants.iter().find(|variant| variant["type"] == "object"))
+            .expect("MCP environment map variant");
+        assert!(mcp_env["additionalProperties"]["oneOf"]
+            .as_array()
+            .is_some_and(|variants| variants.iter().any(|variant| variant["type"] == "null")));
+
+        let assistant_message = document["components"]["schemas"]["Message"]["oneOf"]
+            .as_array()
+            .and_then(|variants| {
+                variants.iter().find(|variant| {
+                    variant["properties"]["role"]["enum"]
+                        .as_array()
+                        .is_some_and(|roles| roles.iter().any(|role| role == "assistant"))
+                })
+            })
+            .expect("assistant message variant");
+        assert!(assistant_message["required"]
+            .as_array()
+            .is_some_and(|required| required.iter().any(|field| field == "content")));
+
+        for (schema, field, example) in [
+            ("StoreCredentialRequest", "value", "fake-credential-value"),
+            ("ProviderModelsRequest", "api_key", "fake-provider-key"),
+            ("CreateModelConfigurationRequest", "api_key", "fake-api-key"),
+        ] {
+            let property = &document["components"]["schemas"][schema]["properties"][field];
+            assert_eq!(property["writeOnly"], true, "{schema}.{field}");
+            assert_eq!(property["example"], example, "{schema}.{field}");
+        }
+
+        let stream =
+            &document["paths"]["/sessions/{session_id}/events/stream"]["get"]["responses"]["200"];
+        assert!(stream["content"]["text/event-stream"].is_object());
+        let description = stream["description"].as_str().unwrap();
+        for event in [
+            "replay_boundary",
+            "replay_gap",
+            "session_event",
+            "assistant_delta",
+            "lagged",
+        ] {
+            assert!(description.contains(event), "missing SSE event {event}");
+        }
+        for (method, path, status) in [
+            ("get", "/sessions", "400"),
+            ("post", "/providers/models", "500"),
+            ("post", "/sessions/{session_id}/runs", "501"),
+            ("delete", "/model-configs/{config_id}", "400"),
+            ("delete", "/ssh-configs/{config_id}", "400"),
+            ("delete", "/credentials/{name}", "400"),
+            ("get", "/sessions/{session_id}/workspace/revisions", "400"),
+            ("post", "/sessions/{session_id}/cancel-active-run", "400"),
+            ("delete", "/sessions/{session_id}", "400"),
+            ("get", "/sessions/{session_id}/config", "400"),
+            ("post", "/sessions/{session_id}/compact", "400"),
+            ("delete", "/mcp_library/servers/{server_name}", "400"),
+        ] {
+            assert!(
+                document["paths"][path][method]["responses"][status].is_object(),
+                "missing {method} {path} response {status}"
+            );
+        }
+        for (method, path) in [
+            ("post", "/model-configs"),
+            ("patch", "/model-configs/{config_id}"),
+            ("post", "/mcp_library/servers"),
+            ("patch", "/mcp_library/servers/{server_name}"),
+            ("post", "/mcp_library/servers/test"),
+            ("post", "/auth/{provider}/login"),
+        ] {
+            assert!(
+                document["paths"][path][method]["responses"]["502"].is_null(),
+                "unexpected {method} {path} response 502"
+            );
+        }
+
+        let invalid_query = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/sessions?workspace_stats=not-a-bool")
+                    .header(header::HOST, "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid_query.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            invalid_query.headers().get(header::CONTENT_TYPE),
+            Some(&header::HeaderValue::from_static(
+                "text/plain; charset=utf-8"
+            ))
+        );
+
+        let redirect = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/docs")
+                    .header(header::HOST, "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(redirect.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            redirect.headers().get(header::LOCATION),
+            Some(&header::HeaderValue::from_static("/docs/"))
+        );
+        let docs = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/docs/")
+                    .header(header::HOST, "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(docs.status(), StatusCode::OK);
+        assert_eq!(
+            docs.headers().get("content-security-policy"),
+            Some(&header::HeaderValue::from_static("frame-ancestors 'none'"))
+        );
+        assert_eq!(
+            docs.headers().get("x-frame-options"),
+            Some(&header::HeaderValue::from_static("DENY"))
+        );
+        let html = String::from_utf8(
+            to_bytes(docs.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(html.contains("swagger-initializer.js"));
+        let initializer = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/docs/swagger-initializer.js")
+                    .header(header::HOST, "localhost")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(initializer.status(), StatusCode::OK);
+        let initializer = String::from_utf8(
+            to_bytes(initializer.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert!(initializer.contains("/openapi.json"));
+        assert!(initializer.contains("\"validatorUrl\": \"none\""));
+
+        for uri in ["/openapi.json", "/docs"] {
+            let rejected = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(uri)
+                        .header(header::HOST, "example.com")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(rejected.status(), StatusCode::FORBIDDEN, "{uri}");
+            assert_eq!(
+                rejected.headers().get(header::CONTENT_TYPE),
+                Some(&header::HeaderValue::from_static(
+                    "text/plain; charset=utf-8"
+                ))
+            );
+        }
+    }
 
     #[path = "compaction.rs"]
     mod compaction;

--- a/crates/nac-server/src/managed_auth.rs
+++ b/crates/nac-server/src/managed_auth.rs
@@ -33,7 +33,7 @@ use crate::{ApiError, SessionManager};
 /// abandoned one does not sit around.
 const COMPLETED_RETENTION: Duration = Duration::from_secs(120);
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ManagedAuthStatusResponse {
     pub provider: String,
     /// The backend a session selects to use this login.
@@ -61,12 +61,12 @@ impl From<ManagedAuthSnapshot> for ManagedAuthStatusResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct ManagedAuthListResponse {
     pub providers: Vec<ManagedAuthStatusResponse>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct DeviceLoginStartedResponse {
     /// Handle for polling this login; it names nothing on disk.
     pub login_id: String,
@@ -82,6 +82,7 @@ pub struct DeviceLoginStartedResponse {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
+#[derive(utoipa::ToSchema)]
 pub enum DeviceLoginStateResponse {
     /// The provider has not seen the user approve it yet.
     Pending,
@@ -275,6 +276,13 @@ impl SessionManager {
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/auth",
+    operation_id = "get_auth",
+    tag = "auth",
+    responses((status = 200, description = "Success", body = ManagedAuthListResponse, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn list_handler(
     State(manager): State<SessionManager>,
 ) -> Result<Json<ManagedAuthListResponse>, ApiError> {
@@ -305,6 +313,14 @@ fn browser_shares_this_machine(headers: &HeaderMap) -> bool {
     )
 }
 
+#[utoipa::path(
+    post,
+    path = "/auth/{provider}/login",
+    operation_id = "post_auth_provider_login",
+    tag = "auth",
+    params(("provider" = String, Path)),
+    responses((status = 200, description = "Success", body = DeviceLoginStartedResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn start_login_handler(
     State(manager): State<SessionManager>,
     AxumPath(provider): AxumPath<String>,
@@ -336,6 +352,14 @@ pub(crate) async fn start_login_handler(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/auth/{provider}/login/{login_id}",
+    operation_id = "get_auth_provider_login_login_id",
+    tag = "auth",
+    params(("provider" = String, Path), ("login_id" = String, Path)),
+    responses((status = 200, description = "Success", body = DeviceLoginStateResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn poll_login_handler(
     State(manager): State<SessionManager>,
     AxumPath((provider, login_id)): AxumPath<(String, String)>,
@@ -344,6 +368,14 @@ pub(crate) async fn poll_login_handler(
     Ok(Json(manager.poll_managed_login(provider, &login_id)?))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/auth/{provider}/login/{login_id}",
+    operation_id = "delete_auth_provider_login_login_id",
+    tag = "auth",
+    params(("provider" = String, Path), ("login_id" = String, Path)),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn cancel_login_handler(
     State(manager): State<SessionManager>,
     AxumPath((provider, login_id)): AxumPath<(String, String)>,
@@ -359,6 +391,14 @@ pub(crate) async fn cancel_login_handler(
     }
 }
 
+#[utoipa::path(
+    delete,
+    path = "/auth/{provider}",
+    operation_id = "delete_auth_provider",
+    tag = "auth",
+    params(("provider" = String, Path)),
+    responses((status = 200, description = "Success", body = ManagedAuthStatusResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn logout_handler(
     AxumPath(provider): AxumPath<String>,
 ) -> Result<Json<ManagedAuthStatusResponse>, ApiError> {

--- a/crates/nac-server/src/mcp_api.rs
+++ b/crates/nac-server/src/mcp_api.rs
@@ -23,14 +23,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ApiError, RequestField, SessionManager};
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct McpLibraryResponse {
     pub entries: Vec<mcp::McpLibraryEntry>,
 }
 
 /// A saved server as the dashboard sees it: env and header values are
 /// redacted, everything else round-trips.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct McpServerView {
     pub name: String,
     pub enabled: bool,
@@ -43,12 +43,12 @@ pub struct McpServerView {
     pub library_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct McpServerList {
     pub servers: Vec<McpServerView>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct CreateMcpServerRequest {
     pub name: String,
     #[serde(default = "default_enabled")]
@@ -58,9 +58,11 @@ pub struct CreateMcpServerRequest {
     #[serde(default)]
     pub args: Vec<String>,
     #[serde(default)]
+    #[schema(write_only, example = json!({"TOKEN": "fake-token"}))]
     pub env: BTreeMap<String, String>,
     pub url: Option<String>,
     #[serde(default)]
+    #[schema(write_only, example = json!({"Authorization": "Bearer fake-token"}))]
     pub headers: BTreeMap<String, String>,
     pub library_id: Option<String>,
 }
@@ -75,7 +77,7 @@ fn default_enabled() -> bool {
 /// `env` and `headers` replace the whole map when sent, except that a null
 /// value under a key keeps the stored value for that key — the stored value
 /// is never echoed back, so this is how an untouched secret survives an edit.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct UpdateMcpServerRequest {
     #[serde(default)]
     pub name: RequestField<String>,
@@ -88,10 +90,12 @@ pub struct UpdateMcpServerRequest {
     #[serde(default)]
     pub args: RequestField<Vec<String>>,
     #[serde(default)]
+    #[schema(write_only, example = json!({"TOKEN": "fake-replacement-token"}))]
     pub env: RequestField<BTreeMap<String, Option<String>>>,
     #[serde(default)]
     pub url: RequestField<String>,
     #[serde(default)]
+    #[schema(write_only, example = json!({"Authorization": "Bearer fake-replacement-token"}))]
     pub headers: RequestField<BTreeMap<String, Option<String>>>,
     #[serde(default)]
     pub library_id: RequestField<String>,
@@ -100,19 +104,21 @@ pub struct UpdateMcpServerRequest {
 /// Probes a server before anything is saved. Either names a saved server or
 /// carries the draft inline; inline map values may be null to borrow the
 /// stored value when `stored_name` is also given.
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, utoipa::ToSchema)]
 pub struct TestMcpServerRequest {
     pub stored_name: Option<String>,
     pub name: Option<String>,
     pub transport: Option<String>,
     pub command: Option<String>,
     pub args: Option<Vec<String>>,
+    #[schema(write_only, example = json!({"TOKEN": "fake-probe-token"}))]
     pub env: Option<BTreeMap<String, Option<String>>>,
     pub url: Option<String>,
+    #[schema(write_only, example = json!({"Authorization": "Bearer fake-probe-token"}))]
     pub headers: Option<BTreeMap<String, Option<String>>>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct TestMcpServerResponse {
     pub tools: Vec<McpProbedTool>,
 }
@@ -215,6 +221,13 @@ static LIBRARY_CACHE: tokio::sync::Mutex<Option<(Instant, Vec<mcp::McpLibraryEnt
 
 /// The embedded catalog, extended by verified servers from the Smithery
 /// registry when it answers in time.
+#[utoipa::path(
+    get,
+    path = "/mcp_library/library",
+    operation_id = "get_mcp_library_library",
+    tag = "mcp-library",
+    responses((status = 200, description = "Success", body = McpLibraryResponse, content_type = "application/json"))
+)]
 pub async fn library_handler() -> Json<McpLibraryResponse> {
     Json(McpLibraryResponse {
         entries: library_entries().await,
@@ -281,6 +294,13 @@ async fn refresh_library_cache(
     entries
 }
 
+#[utoipa::path(
+    get,
+    path = "/mcp_library/servers",
+    operation_id = "get_mcp_library_servers",
+    tag = "mcp-library",
+    responses((status = 200, description = "Success", body = McpServerList, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub async fn list_servers_handler(
     State(manager): State<SessionManager>,
 ) -> Result<Json<McpServerList>, ApiError> {
@@ -291,6 +311,14 @@ pub async fn list_servers_handler(
     Ok(Json(McpServerList { servers }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/mcp_library/servers",
+    operation_id = "post_mcp_library_servers",
+    tag = "mcp-library",
+    request_body(content = CreateMcpServerRequest, content_type = "application/json"),
+    responses((status = 201, description = "Success", body = McpServerView, content_type = "application/json"), (status = 400, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub async fn create_server_handler(
     State(manager): State<SessionManager>,
     payload: Result<Json<CreateMcpServerRequest>, JsonRejection>,
@@ -312,6 +340,15 @@ pub async fn create_server_handler(
     Ok((StatusCode::CREATED, Json(view(record))))
 }
 
+#[utoipa::path(
+    patch,
+    path = "/mcp_library/servers/{server_name}",
+    operation_id = "patch_mcp_library_servers_server_name",
+    tag = "mcp-library",
+    params(("server_name" = String, Path)),
+    request_body(content = UpdateMcpServerRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = McpServerView, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub async fn update_server_handler(
     State(manager): State<SessionManager>,
     AxumPath(server_name): AxumPath<String>,
@@ -371,6 +408,14 @@ pub async fn update_server_handler(
     Ok(Json(view(record)))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/mcp_library/servers/{server_name}",
+    operation_id = "delete_mcp_library_servers_server_name",
+    tag = "mcp-library",
+    params(("server_name" = String, Path)),
+    responses((status = 204, description = "Success with no response body"), (status = 400, description = "Path extraction failed", body = String, content_type = "text/plain"), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub async fn delete_server_handler(
     State(manager): State<SessionManager>,
     AxumPath(server_name): AxumPath<String>,
@@ -382,6 +427,14 @@ pub async fn delete_server_handler(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[utoipa::path(
+    post,
+    path = "/mcp_library/servers/test",
+    operation_id = "post_mcp_library_servers_test",
+    tag = "mcp-library",
+    request_body(content = TestMcpServerRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = TestMcpServerResponse, content_type = "application/json"), (status = 400, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub async fn test_server_handler(
     State(manager): State<SessionManager>,
     payload: Result<Json<TestMcpServerRequest>, JsonRejection>,
@@ -492,7 +545,7 @@ pub async fn test_server_handler(
         other => {
             return Err(ApiError::bad_request(format!(
                 "transport must be '{MCP_TRANSPORT_STDIO}' or \
-                 '{MCP_TRANSPORT_STREAMABLE_HTTP}', not '{other}'"
+             '{MCP_TRANSPORT_STREAMABLE_HTTP}', not '{other}'"
             )));
         }
     };

--- a/crates/nac-server/src/revert.rs
+++ b/crates/nac-server/src/revert.rs
@@ -18,23 +18,25 @@ use axum::{
 use nac_core::{commands::PreparedUserInput, session_service::RevertOutcome, sessions};
 use serde::{Deserialize, Serialize};
 
-use crate::{frontend_command_name, submit_response, SessionManager, SubmitPromptResponse};
+use crate::{
+    frontend_command_name, submit_response, ApiErrorBody, SessionManager, SubmitPromptResponse,
+};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct RevertSessionRequest {
     /// Transcript index of the user message to go back to. That message and
     /// everything after it are dropped.
     pub message_idx: usize,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, utoipa::ToSchema)]
 pub struct RegenerateSessionRequest {
     /// Transcript index of the user message to answer again. It and everything
     /// after it are dropped before the same prompt is submitted afresh.
     pub message_idx: usize,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct RevertSessionResponse {
     pub transcript_len: usize,
     pub messages_removed: usize,
@@ -114,7 +116,9 @@ impl IntoResponse for RegenerateSessionError {
         };
         (
             status,
-            Json(serde_json::json!({ "error": self.to_string() })),
+            Json(ApiErrorBody {
+                error: self.to_string(),
+            }),
         )
             .into_response()
     }
@@ -130,7 +134,9 @@ impl IntoResponse for RevertSessionError {
         };
         (
             status,
-            Json(serde_json::json!({ "error": self.to_string() })),
+            Json(ApiErrorBody {
+                error: self.to_string(),
+            }),
         )
             .into_response()
     }
@@ -311,6 +317,15 @@ fn report_failure(
     RevertSessionError::Failed
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/revert",
+    operation_id = "post_sessions_session_id_revert",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    request_body(content = RevertSessionRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = RevertSessionResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 413, description = "Request body too large", body = String, content_type = "text/plain"), (status = 415, description = "Unsupported media type", body = String, content_type = "text/plain"), (status = 422, description = "JSON body validation failed", body = String, content_type = "text/plain"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,
@@ -323,6 +338,15 @@ pub(crate) async fn handler(
     ))
 }
 
+#[utoipa::path(
+    post,
+    path = "/sessions/{session_id}/regenerate",
+    operation_id = "post_sessions_session_id_regenerate",
+    tag = "conversation",
+    params(("session_id" = String, Path)),
+    request_body(content = RegenerateSessionRequest, content_type = "application/json"),
+    responses((status = 200, description = "Success", body = crate::SubmitPromptResponse, content_type = "application/json"), (status = 400, description = "Bad request or rejected path/query/body extraction", content((crate::ApiErrorBody = "application/json"), (String = "text/plain"))), (status = 404, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 409, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"), (status = 413, description = "Request body too large", body = String, content_type = "text/plain"), (status = 415, description = "Unsupported media type", body = String, content_type = "text/plain"), (status = 422, description = "JSON body validation failed", body = String, content_type = "text/plain"), (status = 500, description = "Request failed", body = crate::ApiErrorBody, content_type = "application/json"))
+)]
 pub(crate) async fn regenerate_handler(
     State(manager): State<SessionManager>,
     AxumPath(session_id): AxumPath<String>,


### PR DESCRIPTION
## Description

**What.** Serves an OpenAPI 3.1 document and embedded Swagger UI from the running `nac-web` process.

**Why.** The README route list and handwritten frontend types can drift from the Rust handlers that actually accept requests.

- Builds the REST/SSE router with `utoipa_axum::routes!`, coupling every registered method and path to its handler annotation.
- Derives schemas from the existing request, query, event, and response types, including tri-state patch fields, object-or-string headers, write-only credentials, plain-text extractor failures, and SSE media types.
- Serves `/openapi.json` and vendored Swagger UI at `/docs`; streamable-HTTP MCP at `/mcp` and frontend assets remain outside the REST description.
- Preserves loopback/Host filtering for both endpoints, disables Swagger's external validator, and prevents framing of the interactive docs.
- Adds bidirectional route/spec parity checks and focused wire-schema/status assertions.
- Replaces the README route inventory with pointers to the live contract.

## Usage

With `nac-web` running:

```bash
curl -sS http://127.0.0.1:3210/openapi.json
open http://127.0.0.1:3210/docs
```

The document is generated at compile time from the same handlers and Rust wire types used by the running router.

<img width="1604" height="1307" alt="image" src="https://github.com/user-attachments/assets/f0185d6c-e2a4-43b5-a892-b2eaf0a7225a" />

<img width="1797" height="967" alt="image" src="https://github.com/user-attachments/assets/6ab515d4-7824-452d-837f-6175f329c4ab" />


## Changelog

- Adds a live OpenAPI 3.1 endpoint at `/openapi.json`.
- Adds an embedded, same-origin Swagger UI at `/docs`.
- Adds CI-enforced bidirectional parity between the REST/SSE router and generated specification.

## Validation

`cargo test -p nac-server` passed all 107 tests, including the bidirectional route/spec parity and special wire-schema/docs tests. A live `nac-web` smoke run returned OpenAPI 3.1 with 48 paths and rendered 61 operations in Swagger UI with no UI errors or external validator requests; `/docs/` returned the expected anti-framing headers, SSE and MCP-library operations were present, and foreign Host requests to `/openapi.json` and `/docs` returned 403.

`cargo test --workspace` was also run twice. Both runs passed 802 nac-core tests and failed only the untouched timing-sensitive `tools::discovery::tests::aborting_native_search_stops_promptly` under concurrent suite load; that test passed when rerun alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and routing wiring only; no change to core session/auth business logic beyond consistent error JSON and optional schema derives.
> 
> **Overview**
> **Live HTTP contract** replaces the README’s hand-maintained route list: clients use `GET /openapi.json` and `GET /docs` on a running `nac-web` process.
> 
> The REST/SSE router is built with **`utoipa_axum`** so each handler carries `#[utoipa::path(...)]` annotations and stays tied to registered routes. **`nac-core`** gains an optional `openapi` feature (`utoipa::ToSchema` on shared wire types); **`nac-server`** enables it and adds **`utoipa-swagger-ui`** (vendored). Request/response models document tri-state patch fields (`RequestField`), object-or-string headers, write-only credentials, path types, and SSE event shapes (including a typed **`LaggedEvent`**). Errors standardize on **`ApiErrorBody`** instead of ad hoc JSON.
> 
> **`/docs`** gets CSP `frame-ancestors 'none'` and `X-Frame-Options: DENY`; Swagger’s external validator is disabled. **`/mcp`** streamable HTTP remains nested outside the OpenAPI router. New tests assert bidirectional parity between the router and the spec (~48 paths / 61 operations) plus focused wire-schema and docs behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f0655765703f5cfd22c2efeaf83b8f213a6365e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->