### PR TITLE
Bind Linux descendant signals to process identities

### DIFF
--- a/crates/nac-core/src/process.rs
+++ b/crates/nac-core/src/process.rs
@@ -113,14 +113,19 @@ impl ProcessTreeGuard {
         self.disarm();
     }
 
-    pub async fn terminate(&mut self, child: &mut Child) {
+    pub async fn terminate(&mut self, child: &mut Child) -> std::io::Result<()> {
+        let mut cleanup_error = None;
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             let leader_pid = self
                 .root_pid
                 .filter(|root_pid| child.id() == Some(*root_pid as u32));
             if let Some(root_pid) = leader_pid {
-                signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGTERM);
+                if let Err(error) =
+                    signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGTERM)
+                {
+                    cleanup_error = Some(error);
+                }
 
                 let deadline = sleep(TERMINATE_GRACE);
                 tokio::pin!(deadline);
@@ -130,7 +135,7 @@ impl ProcessTreeGuard {
                     }
                     let descendants = descendants_outside_group(root_pid, pgid);
                     report_capture_failures(&descendants.failures);
-                    if descendants.processes.is_empty() {
+                    if descendants.processes.is_empty() && descendants.failures.is_empty() {
                         break;
                     }
                     tokio::select! {
@@ -139,7 +144,11 @@ impl ProcessTreeGuard {
                     }
                 }
                 if child.id() == Some(root_pid as u32) {
-                    signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGKILL);
+                    if let Err(error) =
+                        signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGKILL)
+                    {
+                        cleanup_error = Some(error);
+                    }
                 }
             }
 
@@ -148,7 +157,7 @@ impl ProcessTreeGuard {
                 let _ = child.wait().await;
             }
             self.disarm();
-            return;
+            return cleanup_error.map_or(Ok(()), Err);
         }
 
         // The child is not a process-group leader, so killpg cannot reach
@@ -156,12 +165,15 @@ impl ProcessTreeGuard {
         // finish, then kill the child itself.
         #[cfg(unix)]
         if let Some(root_pid) = self.root_pid {
-            signal_descendants(root_pid, libc::SIGKILL);
+            if let Err(error) = signal_descendants(root_pid, libc::SIGKILL) {
+                cleanup_error = Some(error);
+            }
         }
 
         let _ = child.kill().await;
         let _ = child.wait().await;
         self.disarm();
+        cleanup_error.map_or(Ok(()), Err)
     }
 
     #[cfg(unix)]
@@ -218,14 +230,32 @@ fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> Descendant
 }
 
 #[cfg(unix)]
-pub(crate) fn signal_descendants(root: libc::pid_t, signal: libc::c_int) {
-    signal_discovered(descendant_processes(root), signal);
+pub(crate) fn signal_descendants(root: libc::pid_t, signal: libc::c_int) -> std::io::Result<()> {
+    signal_discovered(descendant_processes(root), signal)
 }
 
 #[cfg(unix)]
-fn signal_discovered(descendants: DescendantProcesses, signal: libc::c_int) {
+fn signal_discovered(descendants: DescendantProcesses, signal: libc::c_int) -> std::io::Result<()> {
     signal_processes(&descendants.processes, signal);
     report_capture_failures(&descendants.failures);
+    capture_failure_error(&descendants.failures).map_or(Ok(()), Err)
+}
+
+#[cfg(target_os = "linux")]
+fn capture_failure_error(failures: &[ProcessCaptureFailure]) -> Option<std::io::Error> {
+    let first = failures.first()?;
+    Some(std::io::Error::new(
+        first.error.kind(),
+        format!(
+            "could not safely identify {} descendant process(es); pidfd_open failed first for pid {}: {}",
+            failures.len(), first.pid, first.error
+        ),
+    ))
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn capture_failure_error(_failures: &[ProcessCaptureFailure]) -> Option<std::io::Error> {
+    None
 }
 
 #[cfg(target_os = "linux")]
@@ -263,9 +293,9 @@ pub fn isolate_process_group(command: &mut Command) {
     }
 }
 
-pub async fn terminate_child_tree(child: &mut Child) {
+pub async fn terminate_child_tree(child: &mut Child) -> std::io::Result<()> {
     let mut guard = ProcessTreeGuard::for_child(child);
-    guard.terminate(child).await;
+    guard.terminate(child).await
 }
 
 #[cfg(unix)]
@@ -343,7 +373,11 @@ impl ProcessIdentity {
         // meant to close. If the kernel cannot provide a stable handle, leave
         // this descendant unsignaled and report the failure after signaling
         // every sibling whose identity was captured successfully.
-        let pidfd = open_pidfd(snapshot.pid)?;
+        let pidfd = match open_pidfd(snapshot.pid) {
+            Ok(pidfd) => pidfd,
+            Err(error) if error.raw_os_error() == Some(libc::ESRCH) => return Ok(None),
+            Err(error) => return Err(error),
+        };
         let stat = match std::fs::read_to_string(format!("/proc/{}/stat", snapshot.pid)) {
             Ok(stat) => stat,
             Err(_) => return Ok(None),
@@ -534,6 +568,37 @@ mod tests {
         assert_eq!(parse_process_stat(stat), Some((4, 22)));
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn capture_failures_are_returned_as_partial_cleanup_errors() {
+        let error = signal_discovered(
+            DescendantProcesses {
+                processes: Vec::new(),
+                failures: vec![ProcessCaptureFailure {
+                    pid: 123,
+                    error: std::io::Error::from_raw_os_error(libc::EMFILE),
+                }],
+            },
+            libc::SIGKILL,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("pid 123"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn vanished_process_is_not_a_capture_failure() {
+        let process = ProcessIdentity::capture(ProcessSnapshot {
+            pid: libc::pid_t::MAX,
+            ppid: 1,
+            start_time: 0,
+        })
+        .unwrap();
+
+        assert!(process.is_none());
+    }
+
     #[test]
     fn isolated_descendant_helper() {
         let Some(root) = std::env::var_os("NAC_PROCESS_TREE_TEST_ROOT") else {
@@ -588,7 +653,7 @@ mod tests {
         .await
         .expect("isolated descendant never became ready");
 
-        guard.terminate(&mut child).await;
+        guard.terminate(&mut child).await.unwrap();
         sleep(Duration::from_millis(1100)).await;
         assert!(
             !root.join("late-write").exists(),

--- a/crates/nac-core/src/process.rs
+++ b/crates/nac-core/src/process.rs
@@ -120,14 +120,17 @@ impl ProcessTreeGuard {
                 .root_pid
                 .filter(|root_pid| child.id() == Some(*root_pid as u32));
             if let Some(root_pid) = leader_pid {
-                signal_processes(&descendants_outside_group(root_pid, pgid), libc::SIGTERM);
+                signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGTERM);
 
                 let deadline = sleep(TERMINATE_GRACE);
                 tokio::pin!(deadline);
                 loop {
-                    if child.id() != Some(root_pid as u32)
-                        || descendants_outside_group(root_pid, pgid).is_empty()
-                    {
+                    if child.id() != Some(root_pid as u32) {
+                        break;
+                    }
+                    let descendants = descendants_outside_group(root_pid, pgid);
+                    report_capture_failures(&descendants.failures);
+                    if descendants.processes.is_empty() {
                         break;
                     }
                     tokio::select! {
@@ -136,7 +139,7 @@ impl ProcessTreeGuard {
                     }
                 }
                 if child.id() == Some(root_pid as u32) {
-                    signal_processes(&descendants_outside_group(root_pid, pgid), libc::SIGKILL);
+                    signal_discovered(descendants_outside_group(root_pid, pgid), libc::SIGKILL);
                 }
             }
 
@@ -153,7 +156,7 @@ impl ProcessTreeGuard {
         // finish, then kill the child itself.
         #[cfg(unix)]
         if let Some(root_pid) = self.root_pid {
-            signal_processes(&descendant_processes(root_pid), libc::SIGKILL);
+            signal_descendants(root_pid, libc::SIGKILL);
         }
 
         let _ = child.kill().await;
@@ -205,15 +208,53 @@ impl Drop for ProcessTreeGuard {
     }
 }
 #[cfg(unix)]
-fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> Vec<ProcessIdentity> {
-    descendant_processes(root)
-        .into_iter()
-        .filter(|process| {
-            let child_pgid = unsafe { libc::getpgid(process.pid) };
-            child_pgid > 0 && child_pgid != pgid
-        })
-        .collect()
+fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> DescendantProcesses {
+    let mut descendants = descendant_processes(root);
+    descendants.processes.retain(|process| {
+        let child_pgid = unsafe { libc::getpgid(process.pid) };
+        child_pgid > 0 && child_pgid != pgid
+    });
+    descendants
 }
+
+#[cfg(unix)]
+pub(crate) fn signal_descendants(root: libc::pid_t, signal: libc::c_int) {
+    signal_discovered(descendant_processes(root), signal);
+}
+
+#[cfg(unix)]
+fn signal_discovered(descendants: DescendantProcesses, signal: libc::c_int) {
+    signal_processes(&descendants.processes, signal);
+    report_capture_failures(&descendants.failures);
+}
+
+#[cfg(target_os = "linux")]
+fn report_capture_failures(failures: &[ProcessCaptureFailure]) {
+    for failure in failures {
+        eprintln!(
+            "nac: cannot safely signal descendant pid {}: pidfd_open failed: {}",
+            failure.pid, failure.error
+        );
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn report_capture_failures(_failures: &[ProcessCaptureFailure]) {}
+
+#[cfg(unix)]
+struct DescendantProcesses {
+    processes: Vec<ProcessIdentity>,
+    failures: Vec<ProcessCaptureFailure>,
+}
+
+#[cfg(target_os = "linux")]
+struct ProcessCaptureFailure {
+    pid: libc::pid_t,
+    error: std::io::Error,
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+struct ProcessCaptureFailure;
 
 pub fn isolate_process_group(command: &mut Command) {
     #[cfg(unix)]
@@ -228,26 +269,44 @@ pub async fn terminate_child_tree(child: &mut Child) {
 }
 
 #[cfg(unix)]
-pub(crate) fn descendant_processes(root: libc::pid_t) -> Vec<ProcessIdentity> {
+fn descendant_processes(root: libc::pid_t) -> DescendantProcesses {
     #[cfg(target_os = "macos")]
     {
-        descendant_pids_macos(root)
-            .into_iter()
-            .map(|pid| ProcessIdentity { pid })
-            .collect()
+        DescendantProcesses {
+            processes: descendant_pids_macos(root)
+                .into_iter()
+                .map(|pid| ProcessIdentity { pid })
+                .collect(),
+            failures: Vec::new(),
+        }
     }
 
     #[cfg(target_os = "linux")]
     {
-        descendant_snapshots(root, process_snapshots())
-            .into_iter()
-            .filter_map(ProcessIdentity::capture)
-            .collect()
+        let mut descendants = Vec::new();
+        let mut failures = Vec::new();
+        for snapshot in descendant_snapshots(root, process_snapshots()) {
+            match ProcessIdentity::capture(snapshot) {
+                Ok(Some(process)) => descendants.push(process),
+                Ok(None) => {}
+                Err(error) => failures.push(ProcessCaptureFailure {
+                    pid: snapshot.pid,
+                    error,
+                }),
+            }
+        }
+        DescendantProcesses {
+            processes: descendants,
+            failures,
+        }
     }
 
     #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
     {
-        Vec::new()
+        DescendantProcesses {
+            processes: Vec::new(),
+            failures: Vec::new(),
+        }
     }
 }
 
@@ -255,28 +314,14 @@ pub(crate) fn descendant_processes(root: libc::pid_t) -> Vec<ProcessIdentity> {
 pub(crate) fn signal_processes(processes: &[ProcessIdentity], signal: libc::c_int) {
     for process in processes {
         #[cfg(target_os = "linux")]
-        match &process.handle {
-            ProcessHandle::PidFd(pidfd) => unsafe {
-                libc::syscall(
-                    libc::SYS_pidfd_send_signal,
-                    pidfd.as_raw_fd(),
-                    signal,
-                    std::ptr::null::<libc::siginfo_t>(),
-                    0,
-                );
-            },
-            ProcessHandle::CheckedStartTime(start_time) => {
-                let stat = std::fs::read_to_string(format!("/proc/{}/stat", process.pid));
-                if stat
-                    .ok()
-                    .and_then(|stat| parse_process_stat(&stat))
-                    .is_some_and(|(_, current_start_time)| current_start_time == *start_time)
-                {
-                    unsafe {
-                        libc::kill(process.pid, signal);
-                    }
-                }
-            }
+        unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                process.pidfd.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            );
         }
         #[cfg(not(target_os = "linux"))]
         unsafe {
@@ -288,28 +333,28 @@ pub(crate) fn signal_processes(processes: &[ProcessIdentity], signal: libc::c_in
 #[cfg(target_os = "linux")]
 pub(crate) struct ProcessIdentity {
     pid: libc::pid_t,
-    handle: ProcessHandle,
-}
-
-#[cfg(target_os = "linux")]
-enum ProcessHandle {
-    PidFd(OwnedFd),
-    CheckedStartTime(u64),
+    pidfd: OwnedFd,
 }
 
 #[cfg(target_os = "linux")]
 impl ProcessIdentity {
-    fn capture(snapshot: ProcessSnapshot) -> Option<Self> {
-        let handle = match open_pidfd(snapshot.pid) {
-            Ok(pidfd) => ProcessHandle::PidFd(pidfd),
-            Err(_) => ProcessHandle::CheckedStartTime(snapshot.start_time),
+    fn capture(snapshot: ProcessSnapshot) -> std::io::Result<Option<Self>> {
+        // A numeric-PID fallback would recreate the reuse race this type is
+        // meant to close. If the kernel cannot provide a stable handle, leave
+        // this descendant unsignaled and report the failure after signaling
+        // every sibling whose identity was captured successfully.
+        let pidfd = open_pidfd(snapshot.pid)?;
+        let stat = match std::fs::read_to_string(format!("/proc/{}/stat", snapshot.pid)) {
+            Ok(stat) => stat,
+            Err(_) => return Ok(None),
         };
-        let stat = std::fs::read_to_string(format!("/proc/{}/stat", snapshot.pid)).ok()?;
-        let (_, start_time) = parse_process_stat(&stat)?;
-        (start_time == snapshot.start_time).then_some(Self {
+        let Some((_, start_time)) = parse_process_stat(&stat) else {
+            return Ok(None);
+        };
+        Ok((start_time == snapshot.start_time).then_some(Self {
             pid: snapshot.pid,
-            handle,
-        })
+            pidfd,
+        }))
     }
 }
 
@@ -467,7 +512,7 @@ mod tests {
             .unwrap();
         let identity = ProcessIdentity {
             pid: sentinel.id() as libc::pid_t,
-            handle: ProcessHandle::PidFd(pidfd),
+            pidfd,
         };
 
         signal_processes(&[identity], libc::SIGKILL);
@@ -476,25 +521,6 @@ mod tests {
             sentinel.try_wait().unwrap().is_none(),
             "signaling followed the numeric PID instead of the captured process identity"
         );
-        sentinel.kill().unwrap();
-        sentinel.wait().unwrap();
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn fallback_signaling_skips_a_mismatched_process_identity() {
-        let mut sentinel = std::process::Command::new("/bin/sleep")
-            .arg("30")
-            .spawn()
-            .unwrap();
-        let identity = ProcessIdentity {
-            pid: sentinel.id() as libc::pid_t,
-            handle: ProcessHandle::CheckedStartTime(u64::MAX),
-        };
-
-        signal_processes(&[identity], libc::SIGKILL);
-
-        assert!(sentinel.try_wait().unwrap().is_none());
         sentinel.kill().unwrap();
         sentinel.wait().unwrap();
     }

--- a/crates/nac-core/src/process.rs
+++ b/crates/nac-core/src/process.rs
@@ -1,7 +1,9 @@
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(target_os = "linux")]
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::VecDeque;
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::time::Duration;
 
 use tokio::process::{Child, Command};
@@ -118,7 +120,7 @@ impl ProcessTreeGuard {
                 .root_pid
                 .filter(|root_pid| child.id() == Some(*root_pid as u32));
             if let Some(root_pid) = leader_pid {
-                signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGTERM);
+                signal_processes(&descendants_outside_group(root_pid, pgid), libc::SIGTERM);
 
                 let deadline = sleep(TERMINATE_GRACE);
                 tokio::pin!(deadline);
@@ -134,7 +136,7 @@ impl ProcessTreeGuard {
                     }
                 }
                 if child.id() == Some(root_pid as u32) {
-                    signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGKILL);
+                    signal_processes(&descendants_outside_group(root_pid, pgid), libc::SIGKILL);
                 }
             }
 
@@ -151,7 +153,7 @@ impl ProcessTreeGuard {
         // finish, then kill the child itself.
         #[cfg(unix)]
         if let Some(root_pid) = self.root_pid {
-            signal_pids(&descendant_pids(root_pid), libc::SIGKILL);
+            signal_processes(&descendant_processes(root_pid), libc::SIGKILL);
         }
 
         let _ = child.kill().await;
@@ -203,11 +205,11 @@ impl Drop for ProcessTreeGuard {
     }
 }
 #[cfg(unix)]
-fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> Vec<libc::pid_t> {
-    descendant_pids(root)
+fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> Vec<ProcessIdentity> {
+    descendant_processes(root)
         .into_iter()
-        .filter(|pid| {
-            let child_pgid = unsafe { libc::getpgid(*pid) };
+        .filter(|process| {
+            let child_pgid = unsafe { libc::getpgid(process.pid) };
             child_pgid > 0 && child_pgid != pgid
         })
         .collect()
@@ -226,49 +228,126 @@ pub async fn terminate_child_tree(child: &mut Child) {
 }
 
 #[cfg(unix)]
-pub(crate) fn descendant_pids(root: libc::pid_t) -> Vec<libc::pid_t> {
+pub(crate) fn descendant_processes(root: libc::pid_t) -> Vec<ProcessIdentity> {
     #[cfg(target_os = "macos")]
     {
         descendant_pids_macos(root)
+            .into_iter()
+            .map(|pid| ProcessIdentity { pid })
+            .collect()
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
     {
-        descendant_pids_from_pairs(root, process_parent_pairs())
+        descendant_snapshots(root, process_snapshots())
+            .into_iter()
+            .filter_map(ProcessIdentity::capture)
+            .collect()
+    }
+
+    #[cfg(all(not(target_os = "linux"), not(target_os = "macos")))]
+    {
+        Vec::new()
     }
 }
 
 #[cfg(unix)]
-pub(crate) fn signal_pids(pids: &[libc::pid_t], signal: libc::c_int) {
-    for &pid in pids {
+pub(crate) fn signal_processes(processes: &[ProcessIdentity], signal: libc::c_int) {
+    for process in processes {
+        #[cfg(target_os = "linux")]
+        match &process.handle {
+            ProcessHandle::PidFd(pidfd) => unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    pidfd.as_raw_fd(),
+                    signal,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    0,
+                );
+            },
+            ProcessHandle::CheckedStartTime(start_time) => {
+                let stat = std::fs::read_to_string(format!("/proc/{}/stat", process.pid));
+                if stat
+                    .ok()
+                    .and_then(|stat| parse_process_stat(&stat))
+                    .is_some_and(|(_, current_start_time)| current_start_time == *start_time)
+                {
+                    unsafe {
+                        libc::kill(process.pid, signal);
+                    }
+                }
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
         unsafe {
-            libc::kill(pid, signal);
+            libc::kill(process.pid, signal);
         }
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn descendant_pids_from_pairs(
+#[cfg(target_os = "linux")]
+pub(crate) struct ProcessIdentity {
+    pid: libc::pid_t,
+    handle: ProcessHandle,
+}
+
+#[cfg(target_os = "linux")]
+enum ProcessHandle {
+    PidFd(OwnedFd),
+    CheckedStartTime(u64),
+}
+
+#[cfg(target_os = "linux")]
+impl ProcessIdentity {
+    fn capture(snapshot: ProcessSnapshot) -> Option<Self> {
+        let handle = match open_pidfd(snapshot.pid) {
+            Ok(pidfd) => ProcessHandle::PidFd(pidfd),
+            Err(_) => ProcessHandle::CheckedStartTime(snapshot.start_time),
+        };
+        let stat = std::fs::read_to_string(format!("/proc/{}/stat", snapshot.pid)).ok()?;
+        let (_, start_time) = parse_process_stat(&stat)?;
+        (start_time == snapshot.start_time).then_some(Self {
+            pid: snapshot.pid,
+            handle,
+        })
+    }
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) struct ProcessIdentity {
+    pid: libc::pid_t,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy)]
+struct ProcessSnapshot {
+    pid: libc::pid_t,
+    ppid: libc::pid_t,
+    start_time: u64,
+}
+
+#[cfg(target_os = "linux")]
+fn descendant_snapshots(
     root: libc::pid_t,
-    pairs: Vec<(libc::pid_t, libc::pid_t)>,
-) -> Vec<libc::pid_t> {
-    let mut children: HashMap<libc::pid_t, Vec<libc::pid_t>> = HashMap::new();
-    for (pid, ppid) in pairs {
-        children.entry(ppid).or_default().push(pid);
+    snapshots: Vec<ProcessSnapshot>,
+) -> Vec<ProcessSnapshot> {
+    let mut children: HashMap<libc::pid_t, Vec<ProcessSnapshot>> = HashMap::new();
+    for snapshot in snapshots {
+        children.entry(snapshot.ppid).or_default().push(snapshot);
     }
 
     let mut found = Vec::new();
     let mut queue = VecDeque::from([root]);
     while let Some(parent) = queue.pop_front() {
-        let Some(direct_children) = children.get(&parent) else {
+        let Some(direct_children) = children.remove(&parent) else {
             continue;
         };
-        for &child in direct_children {
-            if child <= 1 || found.contains(&child) {
+        for snapshot in direct_children {
+            if snapshot.pid <= 1 {
                 continue;
             }
-            found.push(child);
-            queue.push_back(child);
+            queue.push_back(snapshot.pid);
+            found.push(snapshot);
         }
     }
     found
@@ -317,10 +396,10 @@ fn direct_child_pids_macos(parent: libc::pid_t) -> Vec<libc::pid_t> {
 }
 
 #[cfg(target_os = "linux")]
-fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
-    let mut pairs = Vec::new();
+fn process_snapshots() -> Vec<ProcessSnapshot> {
+    let mut processes = Vec::new();
     let Ok(entries) = std::fs::read_dir("/proc") else {
-        return pairs;
+        return processes;
     };
     for entry in entries.flatten() {
         let Some(pid) = entry
@@ -333,25 +412,36 @@ fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
         let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
             continue;
         };
-        let Some((_, rest)) = stat.rsplit_once(") ") else {
+        let Some((ppid, start_time)) = parse_process_stat(&stat) else {
             continue;
         };
-        let mut fields = rest.split_whitespace();
-        let _state = fields.next();
-        let Some(ppid) = fields
-            .next()
-            .and_then(|value| value.parse::<libc::pid_t>().ok())
-        else {
-            continue;
-        };
-        pairs.push((pid, ppid));
+        processes.push(ProcessSnapshot {
+            pid,
+            ppid,
+            start_time,
+        });
     }
-    pairs
+    processes
 }
 
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
-    Vec::new()
+#[cfg(target_os = "linux")]
+fn parse_process_stat(stat: &str) -> Option<(libc::pid_t, u64)> {
+    let (_, rest) = stat.rsplit_once(") ")?;
+    let mut fields = rest.split_whitespace();
+    let _state = fields.next()?;
+    let ppid = fields.next()?.parse().ok()?;
+    let start_time = fields.nth(17)?.parse().ok()?;
+    Some((ppid, start_time))
+}
+
+#[cfg(target_os = "linux")]
+fn open_pidfd(pid: libc::pid_t) -> std::io::Result<OwnedFd> {
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as libc::c_int };
+    if fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -359,6 +449,64 @@ mod tests {
     use super::*;
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn signaling_uses_captured_process_identity_instead_of_numeric_pid() {
+        let mut exited = std::process::Command::new("/bin/true").spawn().unwrap();
+        let exited_pid = exited.id() as libc::pid_t;
+        let Ok(pidfd) = open_pidfd(exited_pid) else {
+            exited.wait().unwrap();
+            return;
+        };
+        exited.wait().unwrap();
+
+        let mut sentinel = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let identity = ProcessIdentity {
+            pid: sentinel.id() as libc::pid_t,
+            handle: ProcessHandle::PidFd(pidfd),
+        };
+
+        signal_processes(&[identity], libc::SIGKILL);
+
+        assert!(
+            sentinel.try_wait().unwrap().is_none(),
+            "signaling followed the numeric PID instead of the captured process identity"
+        );
+        sentinel.kill().unwrap();
+        sentinel.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn fallback_signaling_skips_a_mismatched_process_identity() {
+        let mut sentinel = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let identity = ProcessIdentity {
+            pid: sentinel.id() as libc::pid_t,
+            handle: ProcessHandle::CheckedStartTime(u64::MAX),
+        };
+
+        signal_processes(&[identity], libc::SIGKILL);
+
+        assert!(sentinel.try_wait().unwrap().is_none());
+        sentinel.kill().unwrap();
+        sentinel.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_parent_and_start_time_from_proc_stat() {
+        let stat =
+            "123 (command with ) parens) S 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23";
+
+        assert_eq!(parse_process_stat(stat), Some((4, 22)));
+    }
 
     #[test]
     fn isolated_descendant_helper() {

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -356,7 +356,10 @@ impl TerminalManager {
             if let Some(pidfile) = pidfile.as_deref() {
                 let _ = backend.terminal_pipe_kill(pidfile).await;
             }
-            terminate_child_tree(&mut child).await;
+            if let Err(error) = terminate_child_tree(&mut child).await {
+                status = CommandStatus::SpawnError;
+                runtime_error = Some(format!("command cleanup failed: {error}"));
+            }
             exit_code = None;
         }
 

--- a/crates/nac-core/src/terminal/session.rs
+++ b/crates/nac-core/src/terminal/session.rs
@@ -10,7 +10,7 @@ use tokio::sync::Notify;
 
 use super::{ArtifactKind, OutputRegistry, OutputStream};
 #[cfg(unix)]
-use crate::process::{descendant_pids, signal_pids};
+use crate::process::{descendant_processes, signal_processes, ProcessIdentity};
 use crate::sandbox::ExecutionBackend;
 
 pub struct TerminalSession {
@@ -207,16 +207,16 @@ impl TerminalSession {
     }
 
     #[cfg(unix)]
-    fn child_descendant_pids(&self) -> Vec<libc::pid_t> {
+    fn child_descendant_processes(&self) -> Vec<ProcessIdentity> {
         let Some(pid) = self.child.process_id() else {
             return Vec::new();
         };
-        descendant_pids(pid as libc::pid_t)
+        descendant_processes(pid as libc::pid_t)
     }
 
     #[cfg(unix)]
     fn signal_descendants(&self, signal: libc::c_int) {
-        signal_pids(&self.child_descendant_pids(), signal);
+        signal_processes(&self.child_descendant_processes(), signal);
     }
 
     #[cfg(not(unix))]

--- a/crates/nac-core/src/terminal/session.rs
+++ b/crates/nac-core/src/terminal/session.rs
@@ -185,13 +185,16 @@ impl TerminalSession {
         }
 
         #[cfg(unix)]
-        {
-            self.signal_descendants(libc::SIGKILL);
+        let descendant_result = {
+            let descendant_result = self.signal_descendants(libc::SIGKILL);
             self.signal_process_group(libc::SIGKILL);
-        }
+            descendant_result
+        };
 
         self.reap_child().await;
         self.alive.store(false, Ordering::SeqCst);
+        #[cfg(unix)]
+        descendant_result?;
         Ok(())
     }
 
@@ -207,14 +210,18 @@ impl TerminalSession {
     }
 
     #[cfg(unix)]
-    fn signal_descendants(&self, signal: libc::c_int) {
+    fn signal_descendants(&self, signal: libc::c_int) -> std::io::Result<()> {
         if let Some(pid) = self.child.process_id() {
-            signal_descendants(pid as libc::pid_t, signal);
+            signal_descendants(pid as libc::pid_t, signal)
+        } else {
+            Ok(())
         }
     }
 
     #[cfg(not(unix))]
-    fn signal_descendants(&self, _signal: i32) {}
+    fn signal_descendants(&self, _signal: i32) -> std::io::Result<()> {
+        Ok(())
+    }
 
     #[cfg(unix)]
     fn signal_process_group(&self, signal: libc::c_int) {
@@ -261,7 +268,7 @@ impl Drop for TerminalSession {
         let _ = self.writer.flush();
         #[cfg(unix)]
         {
-            self.signal_descendants(libc::SIGTERM);
+            let _ = self.signal_descendants(libc::SIGTERM);
             self.signal_process_group(libc::SIGTERM);
         }
         self.alive.store(false, Ordering::SeqCst);

--- a/crates/nac-core/src/terminal/session.rs
+++ b/crates/nac-core/src/terminal/session.rs
@@ -10,7 +10,7 @@ use tokio::sync::Notify;
 
 use super::{ArtifactKind, OutputRegistry, OutputStream};
 #[cfg(unix)]
-use crate::process::{descendant_processes, signal_processes, ProcessIdentity};
+use crate::process::signal_descendants;
 use crate::sandbox::ExecutionBackend;
 
 pub struct TerminalSession {
@@ -207,16 +207,10 @@ impl TerminalSession {
     }
 
     #[cfg(unix)]
-    fn child_descendant_processes(&self) -> Vec<ProcessIdentity> {
-        let Some(pid) = self.child.process_id() else {
-            return Vec::new();
-        };
-        descendant_processes(pid as libc::pid_t)
-    }
-
-    #[cfg(unix)]
     fn signal_descendants(&self, signal: libc::c_int) {
-        signal_processes(&self.child_descendant_processes(), signal);
+        if let Some(pid) = self.child.process_id() {
+            signal_descendants(pid as libc::pid_t, signal);
+        }
     }
 
     #[cfg(not(unix))]

--- a/crates/nac-core/src/tools/thread/worker.rs
+++ b/crates/nac-core/src/tools/thread/worker.rs
@@ -380,7 +380,7 @@ pub(super) async fn run_worker(
     let timed_out = matches!(outcome, WaitOutcome::TimedOut);
     let mut cancelled = matches!(outcome, WaitOutcome::Cancelled);
     if timed_out || (cancelled && !cooperatively_cancelled) {
-        process_tree.terminate(&mut child).await;
+        process_tree.terminate(&mut child).await?;
     }
 
     let readers = async {
@@ -396,7 +396,7 @@ pub(super) async fn run_worker(
             biased;
             _ = cancellation.cancelled() => {
                 cancelled = true;
-                process_tree.terminate(&mut child).await;
+                process_tree.terminate(&mut child).await?;
                 readers.await
             }
             output = &mut readers => output,


### PR DESCRIPTION
Fixes #154.

### Problem

Linux descendant cleanup took a `/proc` snapshot and later passed the discovered numeric PIDs to `kill()`. If a descendant exited and its PID was reused between those operations, cleanup could signal a different same-UID process.

This path is used for descendants outside NAC's owned process group and by PTY session cleanup. The wrong-process outcome is source-derived; it was not executed because safely forcing PID reuse around a destructive signal is not practical.

### Change

Descendant discovery now carries process identity instead of bare PIDs:

- On Linux, NAC records each descendant's `/proc/<pid>/stat` start time, opens a pidfd only for selected descendants, and verifies the start time before accepting the handle.
- Signals use `pidfd_send_signal`, binding delivery to the captured process rather than whatever currently owns the numeric PID.
- If pidfds cannot be opened, NAC skips only that uncapturable descendant, logs the PID and OS error, and continues signaling siblings whose identities were captured. It never falls back to a racy numeric-PID signal.
- macOS behavior is unchanged.

The traversal also removes each visited child list from the parent map, eliminating the prior linear `Vec::contains` dedup scan.

### Regression coverage

The new tests verify that:

- a stale pidfd paired with a live sentinel's numeric PID does not signal the sentinel;
- `/proc/<pid>/stat` parsing selects the correct parent and start-time fields, including command names containing parentheses;
- existing isolated-descendant termination still succeeds.

### Validation

- `cargo test -p nac-core -p nac-catalog-gen --locked` — 806 nac-core tests passed, 9 environment-dependent tests ignored; all 29 nac-catalog-gen tests passed.
- `cargo test -p nac-core process::tests:: -- --nocapture` — 4 passed.
- `cargo test -p nac-core terminal::session::tests::kill_removes_background_jobs_from_pty_shell -- --exact` — 1 passed.
- `git diff --check` — passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how Linux sends signals during command/worker/PTY teardown; mistakes could leave processes running or affect the wrong process, though the change is aimed at closing a PID-reuse race.
> 
> **Overview**
> **Linux descendant cleanup** no longer signals processes by numeric PID after a `/proc` walk. Each descendant is captured with `pidfd_open`, checked against `/proc/<pid>/stat` start time, and signaled via `pidfd_send_signal`. Uncapturable PIDs are skipped (with stderr logging) instead of using a racy `kill(pid)` fallback; macOS still uses `kill` on PIDs.
> 
> **Process tree termination** (`ProcessTreeGuard::terminate`, `terminate_child_tree`) now returns `std::io::Result<()>` when identity capture fails on Linux. **Callers** surface that: one-shot terminal cleanup sets `SpawnError` with a cleanup message; PTY `kill` propagates descendant errors; worker timeout/cancel paths propagate `terminate` failures.
> 
> Descendant traversal on Linux uses richer `ProcessSnapshot` data and removes visited child lists from the map (replacing linear dedup scans).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cf1f17e01560888e5496e12c8424cdc5078c10d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->