### PR TITLE
feat(catalog): drop minimax, trinity-mini, and trinity-large-preview from arcee register

### DIFF
--- a/crates/nac-core/src/model/catalog/arcee_overlay.rs
+++ b/crates/nac-core/src/model/catalog/arcee_overlay.rs
@@ -348,7 +348,7 @@ fn map_arcee_model(model: &ArceeApiModel) -> ArceeOverlayEntry {
 
     // Third-party models always produce reasoning_content (confirmed via API
     // testing); the `supported_features` field is null for some of them
-    // (minimax-m3, kimi-k3, deepseek-v4-flash-latest), so the features check
+    // (kimi-k3, deepseek-v4-flash-latest), so the features check
     // alone is unreliable. Any model with a third-party effort map reasons.
     let reasoning = third_party_map.is_some()
         || model

--- a/crates/nac-core/src/model/catalog/seed.rs
+++ b/crates/nac-core/src/model/catalog/seed.rs
@@ -23,7 +23,7 @@
 
 use super::{
     api_kind_for, Compat, CompletionsThinkingFormat, ModelCatalog, ModelCostRates, ModelMetadata,
-    ModelSource, ProviderCatalog, ThinkingLevelMap, FALLBACK_MAX_TOKENS, PROVIDER_DEFAULT_MODEL_ID,
+    ModelSource, ProviderCatalog, ThinkingLevelMap, PROVIDER_DEFAULT_MODEL_ID,
 };
 use crate::model::{BackendKind, ReasoningEffort};
 use std::collections::BTreeMap;
@@ -242,8 +242,7 @@ fn codex_seed_models() -> Vec<ModelMetadata> {
 /// `supported_reasoning_efforts` is always null, so the API-derived map is
 /// always empty; these tiers are what the arcee API actually honors for each
 /// model family (confirmed via API testing, PR #128): deepseek/glm take
-/// none/high/max, kimi low/high/max (thinking is always enabled), minimax
-/// none/max (a thinking toggle, not graduated efforts).
+/// none/high/max, kimi low/high/max (thinking is always enabled).
 const THIRD_PARTY_NONE_HIGH_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
     (ReasoningEffort::None, "none"),
     (ReasoningEffort::High, "high"),
@@ -252,10 +251,6 @@ const THIRD_PARTY_NONE_HIGH_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
 const THIRD_PARTY_LOW_HIGH_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
     (ReasoningEffort::Low, "low"),
     (ReasoningEffort::High, "high"),
-    (ReasoningEffort::Max, "max"),
-];
-const THIRD_PARTY_NONE_MAX_LEVELS: &[(ReasoningEffort, &str)] = &[
-    (ReasoningEffort::None, "none"),
     (ReasoningEffort::Max, "max"),
 ];
 
@@ -312,13 +307,6 @@ pub(super) const ARCEE_THIRD_PARTY_SEED_MODELS: &[ThirdPartySeedModel] = &[
         max_tokens: 131_072,
         efforts: THIRD_PARTY_LOW_HIGH_MAX_LEVELS,
     },
-    ThirdPartySeedModel {
-        id: "minimaxai/minimax-m3",
-        display_name: "MiniMax-M3",
-        context_window: 512_000,
-        max_tokens: 250_000,
-        efforts: THIRD_PARTY_NONE_MAX_LEVELS,
-    },
 ];
 
 /// Effort map for a known arcee third-party model, looked up from
@@ -345,16 +333,15 @@ pub(super) fn third_party_seed_limits(model_id: &str) -> Option<(u64, u64)> {
 /// Arcee known models (shared by arcee-auth and arcee-api): the Trinity
 /// lineup from Arcee's own docs (docs.arcee.ai/get-started/models-overview
 /// and /pricing). `trinity-large-thinking` is the documented hosted API id
-/// (also the README's example); the other two ids follow the same
-/// lowercase-hyphen convention from the pricing page's model names. Context
+/// (also the README's example). Context
 /// windows use Arcee's stated hosted value (128k; the Large models support
 /// more when self-hosted — patch via models.json where a deployment allows
 /// it). Max output is undocumented except trinity-large-thinking's 80k
-/// (Vercel AI Gateway's arcee-ai integration); the others keep the
-/// conservative fallback. Cache pricing is undocumented (zero = unknown).
+/// (Vercel AI Gateway's arcee-ai integration). Cache pricing is undocumented
+/// (zero = unknown).
 /// Effort maps stay empty for the Trinity models: trinity-large-thinking
-/// always reasons (no effort knob), and the non-thinking variants accept no
-/// reasoning control. The Arcee third-party models (deepseek-v4-pro, glm-5.2,
+/// always reasons (no effort knob). The Arcee third-party models
+/// (deepseek-v4-pro, glm-5.2,
 /// etc.) are seeded too — from [`ARCEE_THIRD_PARTY_SEED_MODELS`], which the
 /// arcee overlay also reads — so the frontend's default pick resolves real
 /// limits even before the live overlay loads; without a seed entry they fall
@@ -400,29 +387,13 @@ fn arcee_seed_models(provider: BackendKind) -> Vec<ModelMetadata> {
             ),
         )
     };
-    let mut models = vec![
-        model(
-            "trinity-large-thinking",
-            "Trinity-Large-Thinking",
-            80_000,
-            rates(0.25, 0.80, 0.0, 0.0),
-            true,
-        ),
-        model(
-            "trinity-mini",
-            "Trinity-Mini",
-            FALLBACK_MAX_TOKENS,
-            rates(0.045, 0.15, 0.0, 0.0),
-            false,
-        ),
-        model(
-            "trinity-large-preview",
-            "Trinity-Large-Preview",
-            FALLBACK_MAX_TOKENS,
-            rates(0.45, 0.15, 0.0, 0.0),
-            false,
-        ),
-    ];
+    let mut models = vec![model(
+        "trinity-large-thinking",
+        "Trinity-Large-Thinking",
+        80_000,
+        rates(0.25, 0.80, 0.0, 0.0),
+        true,
+    )];
     models.extend(ARCEE_THIRD_PARTY_SEED_MODELS.iter().map(third_party));
     models
 }

--- a/crates/nac-core/src/model/catalog/tests.rs
+++ b/crates/nac-core/src/model/catalog/tests.rs
@@ -447,25 +447,14 @@ fn hand_seeded_arcee_and_codex_entries_carry_documented_values() {
         }
     }
 
-    let arcee_cases = [
-        (
-            "trinity-large-thinking",
-            "Trinity-Large-Thinking",
-            80_000,
-            0.25,
-            0.80,
-            true,
-        ),
-        ("trinity-mini", "Trinity-Mini", 16_384, 0.045, 0.15, false),
-        (
-            "trinity-large-preview",
-            "Trinity-Large-Preview",
-            16_384,
-            0.45,
-            0.15,
-            false,
-        ),
-    ];
+    let arcee_cases = [(
+        "trinity-large-thinking",
+        "Trinity-Large-Thinking",
+        80_000,
+        0.25,
+        0.80,
+        true,
+    )];
     for backend in [BackendKind::ArceeAuth, BackendKind::ArceeApi] {
         for (id, display_name, max_tokens, input, output, reasoning) in &arcee_cases {
             let metadata = resolve(backend, id);
@@ -538,7 +527,7 @@ fn arcee_third_party_models_are_seeded_with_real_limits() {
         }
     }
     // Spot-check the family differences: deepseek tops out at max, kimi has
-    // no `none` (thinking is always enabled), minimax is a none/max toggle.
+    // no `none` (thinking is always enabled).
     let flash = resolve(BackendKind::ArceeAuth, "deepseek/deepseek-v4-flash-latest");
     assert_eq!(
         flash.thinking_level_map.wire_value(ReasoningEffort::Max),
@@ -546,11 +535,6 @@ fn arcee_third_party_models_are_seeded_with_real_limits() {
     );
     let kimi = resolve(BackendKind::ArceeAuth, "moonshotai/kimi-k3");
     assert_eq!(kimi.thinking_level_map.wire_value(ReasoningEffort::None), None);
-    let minimax = resolve(BackendKind::ArceeAuth, "minimaxai/minimax-m3");
-    assert_eq!(
-        minimax.thinking_level_map.wire_value(ReasoningEffort::High),
-        None
-    );
 }
 
 #[test]
@@ -680,7 +664,7 @@ fn generated_entries_satisfy_catalog_invariants() {
     // Snapshot pin: 79 agent-compatible generated models plus 21 hand-seeded
     // entries (2 deprecated deepseek models removed). Drift fails loudly here
     // at regen/seed-edit time, forcing a deliberate review.
-    assert_eq!(entry_count, 100, "catalog model count drifted");
+    assert_eq!(entry_count, 94, "catalog model count drifted");
 }
 
 /// The S4 guard: every generated catalog entry — not just the S0 spot-check
@@ -1176,7 +1160,7 @@ fn api_listing_lists_only_real_entries_with_defaults_in_default_limits() {
         total += provider.models.len();
     }
     // Same snapshot pin as `generated_entries_satisfy_catalog_invariants`.
-    assert_eq!(total, 100, "catalog model count drifted");
+    assert_eq!(total, 94, "catalog model count drifted");
 
     // The hand-seeded providers serve their maintained entries (the picker's
     // model lists) while their `_default` limits stay conservative fallbacks
@@ -1203,7 +1187,7 @@ fn api_listing_lists_only_real_entries_with_defaults_in_default_limits() {
             .iter()
             .find(|provider| provider.id == backend)
             .unwrap();
-        assert_eq!(provider.models.len(), 8, "{backend}");
+        assert_eq!(provider.models.len(), 5, "{backend}");
         assert!(
             provider
                 .models


### PR DESCRIPTION
## Description

**What.** Removes `minimaxai/minimax-m3`, `trinity-mini`, and `trinity-large-preview` from the seeded arcee model register shared by the arcee-auth and arcee-api backends.

**Why.** These models should no longer be offered through the arcee API register; `trinity-large-thinking` and the remaining third-party models (deepseek, glm, kimi) stay registered.

- Drops the `minimaxai/minimax-m3` row from `ARCEE_THIRD_PARTY_SEED_MODELS` in `crates/nac-core/src/model/catalog/seed.rs`, along with the now-unused `THIRD_PARTY_NONE_MAX_LEVELS` effort tier (minimax was its only consumer).
- Drops the `trinity-mini` and `trinity-large-preview` entries from `arcee_seed_models`; `trinity-large-thinking` is kept.
- Updates stale doc comments referencing the removed models (`seed.rs`, `arcee_overlay.rs`).
- Updates catalog tests: removes the deleted-model cases and re-pins the catalog model counts (100 → 94 total, 8 → 5 per arcee backend).

## Usage

No user-facing usage change. The removed models no longer appear in the arcee-auth / arcee-api model listings; `trinity-large-thinking` remains available.

## Changelog

- Removes MiniMax-M3, Trinity-Mini, and Trinity-Large-Preview from the arcee model register.

## Validation

Ran `cargo test -p nac-core`: 803 passed, 0 failed, 9 ignored. This includes the updated catalog seed, overlay, and api-listing tests. `cargo fmt --check` and `cargo clippy -p nac-core` report only pre-existing findings in files untouched by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow catalog seed and test updates only; no auth, overlay fetch, or request-path logic changes.
> 
> **Overview**
> Removes **MiniMax-M3**, **Trinity-Mini**, and **Trinity-Large-Preview** from the hand-seeded Arcee model register used by both `arcee-auth` and `arcee-api`. **`trinity-large-thinking`** and the four remaining third-party seeds (DeepSeek, GLM, Kimi) stay.
> 
> In `seed.rs`, drops the `minimaxai/minimax-m3` row from `ARCEE_THIRD_PARTY_SEED_MODELS` and deletes the unused `THIRD_PARTY_NONE_MAX_LEVELS` effort tier; trims `arcee_seed_models` to a single Trinity entry. Doc comments in `seed.rs` and `arcee_overlay.rs` are updated to match.
> 
> Catalog tests drop assertions for the removed models and re-pin counts (**100 → 94** total models, **8 → 5** models per Arcee backend in API listings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c011fce1f91df31290b89726aca443fdc0df0825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->