### PR TITLE
fix(models): show actionable light-model errors

### DIFF
--- a/crates/nac-core/src/light_model.rs
+++ b/crates/nac-core/src/light_model.rs
@@ -51,6 +51,9 @@ pub(crate) fn resolve_light_client(
         session_headers.clone(),
     )
     .and_then(ModelClient::from_effective_settings)
+    // Embed the full cause chain in the context message while keeping the
+    // original error as the source for downcasting. Callers must render this
+    // error with `{}` (`to_string`); `{:#}` would print the cause twice.
     .map_err(|error| {
         let message = format!("invalid light model settings: {error:#}");
         error.context(message)

--- a/crates/nac-core/src/light_model.rs
+++ b/crates/nac-core/src/light_model.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::model::{
@@ -51,7 +51,10 @@ pub(crate) fn resolve_light_client(
         session_headers.clone(),
     )
     .and_then(ModelClient::from_effective_settings)
-    .context("invalid light model settings")
+    .map_err(|error| {
+        let message = format!("invalid light model settings: {error:#}");
+        error.context(message)
+    })
 }
 
 /// Validate a light-model configuration through the same resolution path
@@ -114,5 +117,37 @@ mod tests {
         assert!(error.contains("invalid light model settings"));
 
         restore_env("OPENAI_API_KEY", original_openai);
+    }
+
+    #[test]
+    fn missing_light_model_api_key_names_the_required_credential() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let original_arcee = std::env::var_os("ARCEE_API_KEY");
+        unsafe {
+            std::env::remove_var("ARCEE_API_KEY");
+        }
+
+        let light = LightModelSettings {
+            model: "deepseek/deepseek-v4-flash-latest".to_string(),
+            backend: Some(BackendKind::ArceeApi),
+            base_url: Some("https://api.arcee.ai/api/v1".to_string()),
+            api_key_env: None,
+            reasoning_effort: None,
+        };
+        let error = resolve_light_client(&light, &BTreeMap::new())
+            .map(|_| ())
+            .unwrap_err();
+        let message = error.to_string();
+
+        assert!(
+            error
+                .downcast_ref::<crate::model::ModelConfigurationError>()
+                .is_some()
+        );
+        assert!(message.contains("invalid light model settings"), "{message}");
+        assert!(message.contains("api_key_env"), "{message}");
+        assert!(message.contains("ARCEE_API_KEY"), "{message}");
+
+        restore_env("ARCEE_API_KEY", original_arcee);
     }
 }

--- a/crates/nac-core/src/light_model.rs
+++ b/crates/nac-core/src/light_model.rs
@@ -31,8 +31,9 @@ pub struct LightModelSettings {
 ///
 /// The variant carries the configuration-error semantics, so the shared
 /// runtime path matches on the type instead of type-sniffing an
-/// `anyhow::Error` chain. The inner error keeps its full cause chain under a
-/// plain context; the HTTP boundary renders that chain once with `{:#}`.
+/// `anyhow::Error` chain. `Display` renders only the top-level context and
+/// `source` returns the inner error, so the HTTP boundary renders the full
+/// cause chain exactly once with `{:#}`.
 #[derive(Debug)]
 pub enum LightModelError {
     /// The light-model settings are invalid and the user can repair them.
@@ -57,18 +58,19 @@ impl LightModelError {
 
 impl std::fmt::Display for LightModelError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Only the top-level context; the inner error is the `source`, so
+        // `{:#}` walks the cause chain exactly once.
         match self {
-            Self::InvalidSettings(error) | Self::Other(error) => write!(formatter, "{error}"),
+            Self::InvalidSettings(_) => formatter.write_str("invalid light model settings"),
+            Self::Other(_) => formatter.write_str("failed to resolve the light model"),
         }
     }
 }
 
 impl std::error::Error for LightModelError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        // `Display` already renders the inner error's top context, so the
-        // source is the rest of the chain.
         match self {
-            Self::InvalidSettings(error) | Self::Other(error) => error.chain().nth(1),
+            Self::InvalidSettings(error) | Self::Other(error) => Some(error.as_ref()),
         }
     }
 }
@@ -99,11 +101,10 @@ pub(crate) fn resolve_light_client(
     .and_then(ModelClient::from_effective_settings)
     .map_err(|error| {
         // Classify at the source, while the typed configuration error is
-        // still visible, and keep the cause chain intact under a plain
-        // context. Callers render the chain with `{:#}` at the boundary.
-        let invalid_settings = error.downcast_ref::<ModelConfigurationError>().is_some();
-        let error = error.context("invalid light model settings");
-        if invalid_settings {
+        // still visible. The variant's `Display` carries the top-level
+        // context and the inner error stays the `source`, so callers render
+        // the chain once with `{:#}` at the boundary.
+        if error.downcast_ref::<ModelConfigurationError>().is_some() {
             LightModelError::InvalidSettings(error)
         } else {
             LightModelError::Other(error)
@@ -207,5 +208,25 @@ mod tests {
         assert!(rendered.contains("ARCEE_API_KEY"), "{rendered}");
 
         restore_env("ARCEE_API_KEY", original_arcee);
+    }
+
+    #[test]
+    fn alternate_rendering_walks_the_chain_exactly_once() {
+        let inner = || anyhow::anyhow!("leaf diagnostic").context("middle context");
+
+        let rendered = format!(
+            "{:#}",
+            anyhow::Error::from(LightModelError::InvalidSettings(inner()))
+        );
+        assert_eq!(
+            rendered,
+            "invalid light model settings: middle context: leaf diagnostic"
+        );
+
+        let rendered = format!("{:#}", anyhow::Error::from(LightModelError::Other(inner())));
+        assert_eq!(
+            rendered,
+            "failed to resolve the light model: middle context: leaf diagnostic"
+        );
     }
 }

--- a/crates/nac-core/src/light_model.rs
+++ b/crates/nac-core/src/light_model.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::{
     managed_backend_base_url, provider_for_model, BackendKind, EffectiveModelSettings, ModelClient,
-    ReasoningEffort,
+    ModelConfigurationError, ReasoningEffort,
 };
 
 /// The optional light worker model of a session. `Some` on a session enables
@@ -27,13 +27,59 @@ pub struct LightModelSettings {
     pub reasoning_effort: Option<ReasoningEffort>,
 }
 
+/// Error resolving a session's light model.
+///
+/// The variant carries the configuration-error semantics, so the shared
+/// runtime path matches on the type instead of type-sniffing an
+/// `anyhow::Error` chain. The inner error keeps its full cause chain under a
+/// plain context; the HTTP boundary renders that chain once with `{:#}`.
+#[derive(Debug)]
+pub enum LightModelError {
+    /// The light-model settings are invalid and the user can repair them.
+    InvalidSettings(anyhow::Error),
+    /// Resolution failed for a reason other than the settings themselves.
+    Other(anyhow::Error),
+}
+
+impl LightModelError {
+    /// Whether the failure is a caller-fixable settings problem.
+    pub fn is_invalid_settings(&self) -> bool {
+        matches!(self, Self::InvalidSettings(_))
+    }
+
+    /// The inner error, with its cause chain intact.
+    pub fn into_inner(self) -> anyhow::Error {
+        match self {
+            Self::InvalidSettings(error) | Self::Other(error) => error,
+        }
+    }
+}
+
+impl std::fmt::Display for LightModelError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidSettings(error) | Self::Other(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for LightModelError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // `Display` already renders the inner error's top context, so the
+        // source is the rest of the chain.
+        match self {
+            Self::InvalidSettings(error) | Self::Other(error) => error.chain().nth(1),
+        }
+    }
+}
+
 /// Resolve the light model at launch or resume, so invalid settings fail
 /// before the first dispatch. The client carries the session's extra
 /// headers, matching how single-mode workers inherit them.
 pub(crate) fn resolve_light_client(
     light: &LightModelSettings,
     session_headers: &BTreeMap<String, String>,
-) -> Result<ModelClient> {
+) -> std::result::Result<ModelClient, LightModelError> {
     let backend = light
         .backend
         .or_else(|| provider_for_model(light.model.as_str()));
@@ -51,12 +97,17 @@ pub(crate) fn resolve_light_client(
         session_headers.clone(),
     )
     .and_then(ModelClient::from_effective_settings)
-    // Embed the full cause chain in the context message while keeping the
-    // original error as the source for downcasting. Callers must render this
-    // error with `{}` (`to_string`); `{:#}` would print the cause twice.
     .map_err(|error| {
-        let message = format!("invalid light model settings: {error:#}");
-        error.context(message)
+        // Classify at the source, while the typed configuration error is
+        // still visible, and keep the cause chain intact under a plain
+        // context. Callers render the chain with `{:#}` at the boundary.
+        let invalid_settings = error.downcast_ref::<ModelConfigurationError>().is_some();
+        let error = error.context("invalid light model settings");
+        if invalid_settings {
+            LightModelError::InvalidSettings(error)
+        } else {
+            LightModelError::Other(error)
+        }
     })
 }
 
@@ -66,7 +117,9 @@ pub fn validate(
     light: &LightModelSettings,
     session_headers: &BTreeMap<String, String>,
 ) -> Result<()> {
-    resolve_light_client(light, session_headers).map(|_| ())
+    resolve_light_client(light, session_headers)
+        .map(|_| ())
+        .map_err(anyhow::Error::from)
 }
 
 #[cfg(test)]
@@ -140,16 +193,18 @@ mod tests {
         let error = resolve_light_client(&light, &BTreeMap::new())
             .map(|_| ())
             .unwrap_err();
-        let message = error.to_string();
 
+        // The variant carries the configuration semantics; the chain stays
+        // intact inside the error and the boundary renders it once with
+        // `{:#}`.
+        assert!(error.is_invalid_settings());
+        let rendered = format!("{:#}", anyhow::Error::from(error));
         assert!(
-            error
-                .downcast_ref::<crate::model::ModelConfigurationError>()
-                .is_some()
+            rendered.contains("invalid light model settings"),
+            "{rendered}"
         );
-        assert!(message.contains("invalid light model settings"), "{message}");
-        assert!(message.contains("api_key_env"), "{message}");
-        assert!(message.contains("ARCEE_API_KEY"), "{message}");
+        assert!(rendered.contains("api_key_env"), "{rendered}");
+        assert!(rendered.contains("ARCEE_API_KEY"), "{rendered}");
 
         restore_env("ARCEE_API_KEY", original_arcee);
     }

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -1350,7 +1350,9 @@ async fn build_resume_config_from_snapshot(
             LightModelError::InvalidSettings(inner) => inner.context(
                 "stored session light-model settings are invalid; settings repair required",
             ),
-            LightModelError::Other(inner) => inner,
+            // Keep the typed wrapper so its top-level context still names
+            // the light model as the failing component.
+            error @ LightModelError::Other(_) => anyhow::Error::from(error),
         })?
         .map(std::sync::Arc::new);
     let sandbox = if ssh.is_some() {

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use crate::agent::{Agent, AgentConfig, AgentMode};
 use crate::agents_md::AgentsMdBundle;
 use crate::events::EventSink;
-use crate::light_model::{resolve_light_client, LightModelSettings};
+use crate::light_model::{resolve_light_client, LightModelError, LightModelSettings};
 use crate::mcp::{McpRegistry, McpRootPolicy, McpTransportPolicy};
 use crate::model::{
     managed_backend_base_url, resolve_model_metadata, BackendKind, EffectiveModelSettings,
@@ -1343,15 +1343,14 @@ async fn build_resume_config_from_snapshot(
         .as_ref()
         .map(|light| resolve_light_client(light, &snapshot.extra_headers))
         .transpose()
-        .map_err(|error| {
-            if error.downcast_ref::<ModelConfigurationError>().is_some() {
-                let message = format!(
-                    "stored session light-model settings are invalid; settings repair required: {error}"
-                );
-                error.context(message)
-            } else {
-                error
-            }
+        .map_err(|error| match error {
+            // The resolver classifies the failure at the source; add the
+            // repair context without type-sniffing the chain. The boundary
+            // renders the full chain once with `{:#}`.
+            LightModelError::InvalidSettings(inner) => inner.context(
+                "stored session light-model settings are invalid; settings repair required",
+            ),
+            LightModelError::Other(inner) => inner,
         })?
         .map(std::sync::Arc::new);
     let sandbox = if ssh.is_some() {

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -1344,10 +1344,14 @@ async fn build_resume_config_from_snapshot(
         .map(|light| resolve_light_client(light, &snapshot.extra_headers))
         .transpose()
         .map_err(|error| {
-            anyhow::anyhow!(
-                "stored session light-model settings are invalid; settings repair required: {:#}",
+            if error.downcast_ref::<ModelConfigurationError>().is_some() {
+                let message = format!(
+                    "stored session light-model settings are invalid; settings repair required: {error}"
+                );
+                error.context(message)
+            } else {
                 error
-            )
+            }
         })?
         .map(std::sync::Arc::new);
     let sandbox = if ssh.is_some() {

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2121,7 +2121,7 @@ impl SessionManager {
         // Fail a broken light model here, not at the session's next launch.
         if let Some(light) = prospective.light_model.as_ref() {
             nac_core::light_model::validate(light, &extra_headers)
-                .map_err(|error| request_configuration_error(format!("{error:#}")))?;
+                .map_err(|error| request_configuration_error(error.to_string()))?;
         }
         validate_model_configuration(
             backend,
@@ -2886,7 +2886,7 @@ async fn create_model_config_handler(
             if let Some(name) = credential_name.as_deref() {
                 let _ = remove_api_key(name);
             }
-            return Err(request_configuration_error(format!("{error:#}")).into());
+            return Err(request_configuration_error(error.to_string()).into());
         }
     }
     let record = model_configurations::insert_model_configuration(
@@ -3072,7 +3072,7 @@ async fn update_model_config_handler(
             if let Some((name, _)) = replacement_credential.as_ref() {
                 let _ = remove_api_key(name);
             }
-            return Err(request_configuration_error(format!("{error:#}")).into());
+            return Err(request_configuration_error(error.to_string()).into());
         }
     }
     match model_configurations::update_model_configuration(
@@ -8328,6 +8328,52 @@ model = "gpt-5.2"
             response.message
         );
         assert!(manager.list_sessions(false).await.unwrap().is_empty());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn update_reports_the_missing_light_model_credential_exactly_once() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
+        let root = temp_root("update_missing_light_credential");
+        let nac_home = root.join("nac-home");
+        write_arcee_auth(&nac_home, "https://api.arcee.ai");
+        let _env = ScopedModelEnv::isolated(&nac_home, None);
+        seed_editable_session(&root, "session");
+        let manager = test_manager(&root);
+
+        let error = manager
+            .update_session_config(
+                "session",
+                UpdateConfigRequest {
+                    light_model: RequestField::Value(LightModelSettings {
+                        model: "deepseek/deepseek-v4-flash-latest".to_string(),
+                        backend: Some(BackendKind::ArceeApi),
+                        base_url: Some("https://api.arcee.ai/api/v1".to_string()),
+                        api_key_env: None,
+                        reasoning_effort: None,
+                    }),
+                    ..UpdateConfigRequest::default()
+                },
+            )
+            .await
+            .expect_err("an API-key light model without a key must fail the update");
+        let response = ApiError::from(error);
+
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert!(
+            response.message.contains("invalid light model settings"),
+            "{}",
+            response.message
+        );
+        // The resolver's message already embeds the cause chain; rendering it
+        // with `{:#}` would repeat the cause.
+        assert_eq!(
+            response.message.matches("ARCEE_API_KEY").count(),
+            1,
+            "{}",
+            response.message
+        );
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -8284,6 +8284,55 @@ model = "gpt-5.2"
     }
 
     #[tokio::test]
+    async fn create_reports_the_missing_light_model_credential() {
+        let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
+        let root = temp_root("create_missing_light_credential");
+        let nac_home = root.join("nac-home");
+        let _env = ScopedModelEnv::isolated(&nac_home, None);
+        write_arcee_auth(&nac_home, "https://api.arcee.ai");
+        let manager = test_manager(&root);
+
+        let error = manager
+            .create_session(CreateSessionRequest {
+                model: RequestField::Value("moonshotai/kimi-k3".to_string()),
+                base_url: RequestField::Value("https://api.arcee.ai/api/v1".to_string()),
+                backend: RequestField::Value("arcee-auth".to_string()),
+                api_key_env: RequestField::Null,
+                light_model: RequestField::Value(LightModelSettings {
+                    model: "deepseek/deepseek-v4-flash-latest".to_string(),
+                    backend: Some(BackendKind::ArceeApi),
+                    base_url: Some("https://api.arcee.ai/api/v1".to_string()),
+                    api_key_env: None,
+                    reasoning_effort: None,
+                }),
+                ..CreateSessionRequest::default()
+            })
+            .await
+            .expect_err("an API-key light model without a key must fail creation");
+        let response = ApiError::from(error);
+
+        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert!(
+            response.message.contains("invalid light model settings"),
+            "{}",
+            response.message
+        );
+        assert!(
+            response.message.contains("api_key_env"),
+            "{}",
+            response.message
+        );
+        assert!(
+            response.message.contains("ARCEE_API_KEY"),
+            "{}",
+            response.message
+        );
+        assert!(manager.list_sessions(false).await.unwrap().is_empty());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn codex_create_preflights_endpoint_and_managed_credentials_before_persistence() {
         let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
 

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -53,7 +53,7 @@ use nac_core::{
     events::{
         AssistantStreamDelta, AssistantStreamDeltaReceiver, SessionEventEnvelope, SessionReplayGap,
     },
-    light_model::LightModelSettings,
+    light_model::{LightModelError, LightModelSettings},
     model::{
         list_managed_provider_models, list_provider_models, list_stored_api_keys,
         managed_backend_base_url, provider_default_base_url, provider_for_model,
@@ -1381,7 +1381,18 @@ impl SessionManager {
             },
             &config,
         )
-        .await?;
+        .await
+        .map_err(|error| {
+            // A broken light model fails here, at launch resolution. Route it
+            // through the configuration-error boundary so the response names
+            // the actionable cause.
+            match error.downcast_ref::<LightModelError>() {
+                Some(light_error) if light_error.is_invalid_settings() => {
+                    request_configuration_error_from(error)
+                }
+                _ => error,
+            }
+        })?;
         let parts = SessionService::from_orchestrator_run_config(run_config);
         let service = parts.service;
         let snapshot = service.frontend_snapshot().await?;
@@ -2121,7 +2132,7 @@ impl SessionManager {
         // Fail a broken light model here, not at the session's next launch.
         if let Some(light) = prospective.light_model.as_ref() {
             nac_core::light_model::validate(light, &extra_headers)
-                .map_err(|error| request_configuration_error(error.to_string()))?;
+                .map_err(request_configuration_error_from)?;
         }
         validate_model_configuration(
             backend,
@@ -2886,7 +2897,7 @@ async fn create_model_config_handler(
             if let Some(name) = credential_name.as_deref() {
                 let _ = remove_api_key(name);
             }
-            return Err(request_configuration_error(error.to_string()).into());
+            return Err(request_configuration_error_from(error).into());
         }
     }
     let record = model_configurations::insert_model_configuration(
@@ -3072,7 +3083,7 @@ async fn update_model_config_handler(
             if let Some((name, _)) = replacement_credential.as_ref() {
                 let _ = remove_api_key(name);
             }
-            return Err(request_configuration_error(error.to_string()).into());
+            return Err(request_configuration_error_from(error).into());
         }
     }
     match model_configurations::update_model_configuration(
@@ -4130,6 +4141,14 @@ fn validate_steering_instruction(
 
 fn request_configuration_error(message: impl Into<String>) -> anyhow::Error {
     anyhow!(RequestConfigurationError(message.into()))
+}
+
+/// Render a failing configuration error at the HTTP boundary. This is the
+/// single place the full `{:#}` cause chain is rendered; inner layers keep
+/// their chains intact under plain `.context(...)` messages, so the cause
+/// appears exactly once.
+fn request_configuration_error_from(error: anyhow::Error) -> anyhow::Error {
+    request_configuration_error(format!("{error:#}"))
 }
 
 fn nonblank_request_string(value: String, field: &str) -> Result<String> {
@@ -8333,7 +8352,7 @@ model = "gpt-5.2"
     }
 
     #[tokio::test]
-    async fn update_reports_the_missing_light_model_credential_exactly_once() {
+    async fn update_reports_the_missing_light_model_credential() {
         let _lock = SERVER_MODEL_ENV_LOCK.lock().unwrap();
         let root = temp_root("update_missing_light_credential");
         let nac_home = root.join("nac-home");
@@ -8361,16 +8380,23 @@ model = "gpt-5.2"
         let response = ApiError::from(error);
 
         assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        // Assert the rendered boundary output: the resolver keeps the cause
+        // chain intact and the boundary renders it once with `{:#}`, so the
+        // response pairs the context with the actionable cause.
         assert!(
-            response.message.contains("invalid light model settings"),
+            response
+                .message
+                .starts_with("invalid light model settings: "),
             "{}",
             response.message
         );
-        // The resolver's message already embeds the cause chain; rendering it
-        // with `{:#}` would repeat the cause.
-        assert_eq!(
-            response.message.matches("ARCEE_API_KEY").count(),
-            1,
+        assert!(
+            response.message.contains("api_key_env"),
+            "{}",
+            response.message
+        );
+        assert!(
+            response.message.contains("ARCEE_API_KEY"),
             "{}",
             response.message
         );


### PR DESCRIPTION
## Description

**What.** Preserve the actionable cause when NAC rejects invalid light-model settings.

**Why.** Session creation previously returned only `invalid light model settings`, which hid the credential or provider configuration the user needed to fix.

The light-model resolver now includes its already-redacted validation chain in the user-facing message while retaining the original typed error for status classification and diagnostics. Authentication behavior, model selection, persistence, and HTTP status codes are unchanged.

## Usage

When a dual-model session selects an Arcee API-key light model without an available key, the existing HTTP 400 now identifies the missing selector and names `ARCEE_API_KEY` instead of showing only a generic light-model error.

## Bug Evidence

Before this change, a managed Arcee primary model paired with an `arcee-api` light model and no API key returned:

```text
invalid light model settings
```

The root cause was attached as an `anyhow` source but the API response rendered only the outer context. The resolver now promotes that cause into the outer message while preserving the underlying `ModelConfigurationError`.

Regression coverage verifies the response remains HTTP 400, includes `api_key_env` and `ARCEE_API_KEY`, retains the typed configuration error, and does not persist a failed session.

## Changelog

- Show actionable validation details for invalid light-model configurations.

## Validation

Ran `cargo test -p nac-core -p nac-server --locked`: 804 core tests, 99 server-library tests, and 12 server-binary tests passed with no failures. Re-ran the focused core and server regressions after review fixes; both passed without warnings. `git diff --check` passed.

The repository-wide `cargo clippy --all-targets -- -D warnings` remains red on pre-existing warnings in untouched files; this change introduces no new compiler warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error formatting and classification only; auth, model selection, persistence, and status codes are unchanged per the PR scope.
> 
> **Overview**
> Invalid light-model settings no longer surface only a generic **invalid light model settings** message. The resolver now returns a typed **`LightModelError`** (caller-fixable **`InvalidSettings`** vs **`Other`**) and classifies **`ModelConfigurationError`** at resolution time instead of sniffing **`anyhow`** chains.
> 
> **`Display`** / **`source`** are split so the HTTP layer can render the full cause once with **`{:#}`** via **`request_configuration_error_from`**, while resume and launch add repair context by matching on the variant. Session create, config update, and model-configuration create/update route light-model validation through that boundary so responses include details such as missing **`api_key_env`** and **`ARCEE_API_KEY`**. HTTP status and persistence behavior are unchanged; failed creates still do not persist sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b992d18ad1b18c7a6f3735dedf689335e65242c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->