### PR TITLE
Fix identity-safe Linux process-tree cleanup

### DIFF
--- a/crates/nac-core/src/process.rs
+++ b/crates/nac-core/src/process.rs
@@ -1,7 +1,9 @@
-#[cfg(all(unix, not(target_os = "macos")))]
-use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::VecDeque;
+#[cfg(target_os = "linux")]
+use std::collections::{HashMap, HashSet};
+#[cfg(target_os = "linux")]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::time::Duration;
 
 use tokio::process::{Child, Command};
@@ -9,10 +11,23 @@ use tokio::time::sleep;
 
 const TERMINATE_GRACE: Duration = Duration::from_millis(500);
 const EXIT_POLL_INTERVAL: Duration = Duration::from_millis(25);
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) static PIDFD_OPEN_FAILURE_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
+#[cfg(all(test, target_os = "linux"))]
+static PIDFD_OPEN_FAILURE_PID: std::sync::atomic::AtomicI32 = std::sync::atomic::AtomicI32::new(0);
+
+#[cfg(all(test, target_os = "linux"))]
+pub(crate) fn set_pidfd_open_failure_for_test(pid: libc::pid_t) {
+    PIDFD_OPEN_FAILURE_PID.store(pid, std::sync::atomic::Ordering::SeqCst);
+}
 
 pub struct ProcessTreeGuard {
     #[cfg(unix)]
     root_pid: Option<libc::pid_t>,
+    #[cfg(target_os = "linux")]
+    root_start_time: Option<u64>,
     #[cfg(unix)]
     pgid: Option<libc::pid_t>,
     #[cfg(unix)]
@@ -23,9 +38,13 @@ impl ProcessTreeGuard {
     pub fn for_child(child: &Child) -> Self {
         #[cfg(unix)]
         let root_pid = child.id().map(|pid| pid as libc::pid_t);
+        #[cfg(target_os = "linux")]
+        let root_start_time = root_pid.and_then(process_start_time);
         Self {
             #[cfg(unix)]
             root_pid,
+            #[cfg(target_os = "linux")]
+            root_start_time,
             // Worker pipe commands skip process-group isolation, so the
             // child is not necessarily a group leader; only allow killpg
             // when it actually is one, otherwise fall back to killing the
@@ -62,10 +81,14 @@ impl ProcessTreeGuard {
                 }
             };
             let root_pid = child.id().map(|pid| pid as libc::pid_t);
+            #[cfg(target_os = "linux")]
+            let root_start_time = root_pid.and_then(process_start_time);
             Ok((
                 child,
                 Self {
                     root_pid,
+                    #[cfg(target_os = "linux")]
+                    root_start_time,
                     pgid: Some(pgid),
                     group_leader: Some(group_leader),
                 },
@@ -84,6 +107,10 @@ impl ProcessTreeGuard {
         #[cfg(unix)]
         {
             self.root_pid = None;
+            #[cfg(target_os = "linux")]
+            {
+                self.root_start_time = None;
+            }
             self.pgid = None;
             self.group_leader = None;
         }
@@ -93,6 +120,10 @@ impl ProcessTreeGuard {
         #[cfg(unix)]
         {
             self.root_pid = None;
+            #[cfg(target_os = "linux")]
+            {
+                self.root_start_time = None;
+            }
         }
     }
 
@@ -111,30 +142,74 @@ impl ProcessTreeGuard {
         self.disarm();
     }
 
-    pub async fn terminate(&mut self, child: &mut Child) {
+    pub async fn terminate(&mut self, child: &mut Child) -> std::io::Result<()> {
+        #[cfg(target_os = "linux")]
+        let mut cleanup_result = Ok(());
+        #[cfg(not(target_os = "linux"))]
+        let cleanup_result = Ok(());
         #[cfg(unix)]
         if let Some(pgid) = self.pgid {
             let leader_pid = self
                 .root_pid
                 .filter(|root_pid| child.id() == Some(*root_pid as u32));
             if let Some(root_pid) = leader_pid {
-                signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGTERM);
+                #[cfg(target_os = "linux")]
+                {
+                    let mut descendants = capture_descendants(
+                        root_pid,
+                        self.root_start_time,
+                        Some(pgid),
+                        "initial descendant scan",
+                    );
+                    descendants.signal_best_effort(libc::SIGTERM);
 
-                let deadline = sleep(TERMINATE_GRACE);
-                tokio::pin!(deadline);
-                loop {
-                    if child.id() != Some(root_pid as u32)
-                        || descendants_outside_group(root_pid, pgid).is_empty()
+                    let deadline = sleep(TERMINATE_GRACE);
+                    tokio::pin!(deadline);
+                    loop {
+                        if child.id() != Some(root_pid as u32) || descendants.all_exited() {
+                            break;
+                        }
+                        tokio::select! {
+                            _ = &mut deadline => break,
+                            _ = sleep(EXIT_POLL_INTERVAL) => {}
+                        }
+                    }
+
+                    if child.id() == Some(root_pid as u32)
+                        && self.root_start_time.is_some_and(|start_time| {
+                            process_identity_matches(root_pid, start_time)
+                        })
                     {
-                        break;
+                        descendants.extend(capture_descendants(
+                            root_pid,
+                            self.root_start_time,
+                            Some(pgid),
+                            "final descendant scan",
+                        ));
                     }
-                    tokio::select! {
-                        _ = &mut deadline => break,
-                        _ = sleep(EXIT_POLL_INTERVAL) => {}
-                    }
+                    cleanup_result = descendants.signal_all(libc::SIGKILL);
                 }
-                if child.id() == Some(root_pid as u32) {
-                    signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGKILL);
+
+                #[cfg(all(unix, not(target_os = "linux")))]
+                {
+                    signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGTERM);
+
+                    let deadline = sleep(TERMINATE_GRACE);
+                    tokio::pin!(deadline);
+                    loop {
+                        if child.id() != Some(root_pid as u32)
+                            || descendants_outside_group(root_pid, pgid).is_empty()
+                        {
+                            break;
+                        }
+                        tokio::select! {
+                            _ = &mut deadline => break,
+                            _ = sleep(EXIT_POLL_INTERVAL) => {}
+                        }
+                    }
+                    if child.id() == Some(root_pid as u32) {
+                        signal_pids(&descendants_outside_group(root_pid, pgid), libc::SIGKILL);
+                    }
                 }
             }
 
@@ -143,13 +218,19 @@ impl ProcessTreeGuard {
                 let _ = child.wait().await;
             }
             self.disarm();
-            return;
+            return cleanup_result;
         }
 
         // The child is not a process-group leader, so killpg cannot reach
         // it; kill any known descendants directly so pipe readers can
         // finish, then kill the child itself.
-        #[cfg(unix)]
+        #[cfg(target_os = "linux")]
+        if let Some(root_pid) = self.root_pid {
+            cleanup_result =
+                capture_descendants(root_pid, self.root_start_time, None, "descendant scan")
+                    .signal_all(libc::SIGKILL);
+        }
+        #[cfg(all(unix, not(target_os = "linux")))]
         if let Some(root_pid) = self.root_pid {
             signal_pids(&descendant_pids(root_pid), libc::SIGKILL);
         }
@@ -157,6 +238,7 @@ impl ProcessTreeGuard {
         let _ = child.kill().await;
         let _ = child.wait().await;
         self.disarm();
+        cleanup_result
     }
 
     #[cfg(unix)]
@@ -202,7 +284,7 @@ impl Drop for ProcessTreeGuard {
         }
     }
 }
-#[cfg(unix)]
+#[cfg(all(unix, not(target_os = "linux")))]
 fn descendants_outside_group(root: libc::pid_t, pgid: libc::pid_t) -> Vec<libc::pid_t> {
     descendant_pids(root)
         .into_iter()
@@ -220,13 +302,28 @@ pub fn isolate_process_group(command: &mut Command) {
     }
 }
 
-pub async fn terminate_child_tree(child: &mut Child) {
+pub async fn terminate_child_tree(child: &mut Child) -> std::io::Result<()> {
     let mut guard = ProcessTreeGuard::for_child(child);
-    guard.terminate(child).await;
+    guard.terminate(child).await
 }
 
-#[cfg(unix)]
-pub(crate) fn descendant_pids(root: libc::pid_t) -> Vec<libc::pid_t> {
+#[cfg(target_os = "linux")]
+pub(crate) fn signal_descendants(
+    root: libc::pid_t,
+    root_start_time: u64,
+    signal: libc::c_int,
+) -> std::io::Result<()> {
+    capture_descendants(root, Some(root_start_time), None, "descendant scan").signal_all(signal)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+pub(crate) fn signal_descendants(root: libc::pid_t, signal: libc::c_int) -> std::io::Result<()> {
+    signal_pids(&descendant_pids(root), signal);
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn descendant_pids(root: libc::pid_t) -> Vec<libc::pid_t> {
     #[cfg(target_os = "macos")]
     {
         descendant_pids_macos(root)
@@ -234,12 +331,12 @@ pub(crate) fn descendant_pids(root: libc::pid_t) -> Vec<libc::pid_t> {
 
     #[cfg(not(target_os = "macos"))]
     {
-        descendant_pids_from_pairs(root, process_parent_pairs())
+        Vec::new()
     }
 }
 
-#[cfg(unix)]
-pub(crate) fn signal_pids(pids: &[libc::pid_t], signal: libc::c_int) {
+#[cfg(all(unix, not(target_os = "linux")))]
+fn signal_pids(pids: &[libc::pid_t], signal: libc::c_int) {
     for &pid in pids {
         unsafe {
             libc::kill(pid, signal);
@@ -247,14 +344,286 @@ pub(crate) fn signal_pids(pids: &[libc::pid_t], signal: libc::c_int) {
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
-fn descendant_pids_from_pairs(
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ProcessMetadata {
+    pid: libc::pid_t,
+    ppid: libc::pid_t,
+    pgrp: libc::pid_t,
+    start_time: u64,
+}
+
+#[cfg(target_os = "linux")]
+struct ProcessIdentity {
+    metadata: ProcessMetadata,
+    pidfd: OwnedFd,
+}
+
+#[cfg(target_os = "linux")]
+impl ProcessIdentity {
+    fn capture(expected: ProcessMetadata) -> std::io::Result<Option<Self>> {
+        let pidfd = match open_pidfd(expected.pid) {
+            Ok(pidfd) => pidfd,
+            Err(error) if error.raw_os_error() == Some(libc::ESRCH) => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let stat = match std::fs::read_to_string(format!("/proc/{}/stat", expected.pid)) {
+            Ok(stat) => stat,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let Some((ppid, pgrp, start_time)) = parse_process_stat(&stat) else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("invalid /proc/{}/stat", expected.pid),
+            ));
+        };
+        if start_time != expected.start_time {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            metadata: ProcessMetadata {
+                pid: expected.pid,
+                ppid,
+                pgrp,
+                start_time,
+            },
+            pidfd,
+        }))
+    }
+
+    fn send_signal(&self, signal: libc::c_int) -> std::io::Result<()> {
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.pidfd.as_raw_fd(),
+                signal,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if result < 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct CleanupFailures {
+    count: usize,
+    first: Option<std::io::Error>,
+}
+
+#[cfg(target_os = "linux")]
+impl CleanupFailures {
+    fn record(&mut self, pid: libc::pid_t, operation: &str, error: std::io::Error) {
+        self.count += 1;
+        if self.first.is_none() {
+            self.first = Some(std::io::Error::new(
+                error.kind(),
+                format!("{operation} for pid {pid}: {error}"),
+            ));
+        }
+    }
+
+    fn extend(&mut self, mut other: Self) {
+        self.count += other.count;
+        if self.first.is_none() {
+            self.first = other.first.take();
+        }
+    }
+
+    fn into_result(self) -> std::io::Result<()> {
+        let Some(first) = self.first else {
+            return Ok(());
+        };
+        Err(std::io::Error::new(
+            first.kind(),
+            format!(
+                "incomplete descendant cleanup: {} operation(s) failed; first: {}",
+                self.count, first
+            ),
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Default)]
+struct CapturedDescendants {
+    processes: Vec<ProcessIdentity>,
+    failures: CleanupFailures,
+}
+#[cfg(target_os = "linux")]
+impl CapturedDescendants {
+    fn extend(&mut self, other: Self) {
+        for process in other.processes {
+            let duplicate = self.processes.iter().any(|existing| {
+                existing.metadata.pid == process.metadata.pid
+                    && existing.metadata.start_time == process.metadata.start_time
+            });
+            if !duplicate {
+                self.processes.push(process);
+            }
+        }
+        self.failures.extend(other.failures);
+    }
+
+    fn signal_best_effort(&mut self, signal: libc::c_int) {
+        self.processes
+            .retain(|process| match process.send_signal(signal) {
+                Ok(()) => true,
+                Err(error) if error.raw_os_error() == Some(libc::ESRCH) => false,
+                Err(_) => true,
+            });
+    }
+
+    fn all_exited(&mut self) -> bool {
+        self.processes
+            .retain(|process| match process.send_signal(0) {
+                Ok(()) => true,
+                Err(error) if error.raw_os_error() == Some(libc::ESRCH) => false,
+                Err(_) => true,
+            });
+        self.processes.is_empty() && self.failures.count == 0
+    }
+
+    fn signal_all(mut self, signal: libc::c_int) -> std::io::Result<()> {
+        for process in self.processes {
+            if let Err(error) = process.send_signal(signal) {
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    self.failures
+                        .record(process.metadata.pid, "pidfd_send_signal", error);
+                }
+            }
+        }
+        self.failures.into_result()
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn capture_descendants(
     root: libc::pid_t,
-    pairs: Vec<(libc::pid_t, libc::pid_t)>,
-) -> Vec<libc::pid_t> {
-    let mut children: HashMap<libc::pid_t, Vec<libc::pid_t>> = HashMap::new();
-    for (pid, ppid) in pairs {
-        children.entry(ppid).or_default().push(pid);
+    root_start_time: Option<u64>,
+    excluded_pgrp: Option<libc::pid_t>,
+    operation: &str,
+) -> CapturedDescendants {
+    let Some(root_start_time) = root_start_time else {
+        let mut failures = CleanupFailures::default();
+        failures.record(
+            root,
+            operation,
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "root process identity was unavailable",
+            ),
+        );
+        return CapturedDescendants {
+            processes: Vec::new(),
+            failures,
+        };
+    };
+    let processes = match process_metadata() {
+        Ok(processes) => processes,
+        Err(error) => {
+            let mut failures = CleanupFailures::default();
+            failures.record(root, operation, error);
+            return CapturedDescendants {
+                processes: Vec::new(),
+                failures,
+            };
+        }
+    };
+    if !processes
+        .iter()
+        .any(|process| process.pid == root && process.start_time == root_start_time)
+    {
+        let mut failures = CleanupFailures::default();
+        failures.record(
+            root,
+            operation,
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "root process identity changed before descendant discovery",
+            ),
+        );
+        return CapturedDescendants {
+            processes: Vec::new(),
+            failures,
+        };
+    }
+    let candidates = descendant_metadata(root, processes);
+
+    let mut captured = Vec::new();
+    let mut failures = CleanupFailures::default();
+    for candidate in candidates {
+        match ProcessIdentity::capture(candidate) {
+            Ok(Some(process)) => captured.push(process),
+            Ok(None) => {}
+            Err(error) => failures.record(candidate.pid, "pidfd_open/capture", error),
+        }
+    }
+    if !process_identity_matches(root, root_start_time) {
+        failures.record(
+            root,
+            operation,
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "root process identity changed during descendant discovery",
+            ),
+        );
+        captured.clear();
+    } else {
+        retain_authoritative_descendants(root, excluded_pgrp, &mut captured, &mut failures);
+    }
+
+    let processes = captured;
+    CapturedDescendants {
+        processes,
+        failures,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn retain_authoritative_descendants(
+    root: libc::pid_t,
+    excluded_pgrp: Option<libc::pid_t>,
+    captured: &mut Vec<ProcessIdentity>,
+    failures: &mut CleanupFailures,
+) {
+    let authoritative = descendant_metadata(
+        root,
+        captured.iter().map(|process| process.metadata).collect(),
+    )
+    .into_iter()
+    .map(|process| (process.pid, process.start_time))
+    .collect::<HashSet<_>>();
+    captured.retain(|process| {
+        if excluded_pgrp == Some(process.metadata.pgrp) {
+            return false;
+        }
+        if authoritative.contains(&(process.metadata.pid, process.metadata.start_time)) {
+            return true;
+        }
+        failures.record(
+            process.metadata.pid,
+            "pidfd_open/capture",
+            std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "captured process no longer has authoritative descendant ancestry",
+            ),
+        );
+        false
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn descendant_metadata(root: libc::pid_t, processes: Vec<ProcessMetadata>) -> Vec<ProcessMetadata> {
+    let mut children: HashMap<libc::pid_t, Vec<ProcessMetadata>> = HashMap::new();
+    for process in processes {
+        children.entry(process.ppid).or_default().push(process);
     }
 
     let mut found = Vec::new();
@@ -264,11 +633,15 @@ fn descendant_pids_from_pairs(
             continue;
         };
         for &child in direct_children {
-            if child <= 1 || found.contains(&child) {
+            if child.pid <= 1
+                || found
+                    .iter()
+                    .any(|found: &ProcessMetadata| found.pid == child.pid)
+            {
                 continue;
             }
             found.push(child);
-            queue.push_back(child);
+            queue.push_back(child.pid);
         }
     }
     found
@@ -317,12 +690,20 @@ fn direct_child_pids_macos(parent: libc::pid_t) -> Vec<libc::pid_t> {
 }
 
 #[cfg(target_os = "linux")]
-fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
-    let mut pairs = Vec::new();
-    let Ok(entries) = std::fs::read_dir("/proc") else {
-        return pairs;
-    };
-    for entry in entries.flatten() {
+pub(crate) fn process_start_time(pid: libc::pid_t) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_process_stat(&stat).map(|(_, _, start_time)| start_time)
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn process_identity_matches(pid: libc::pid_t, start_time: u64) -> bool {
+    process_start_time(pid) == Some(start_time)
+}
+
+#[cfg(target_os = "linux")]
+fn process_metadata() -> std::io::Result<Vec<ProcessMetadata>> {
+    let mut processes = Vec::new();
+    for entry in std::fs::read_dir("/proc")?.flatten() {
         let Some(pid) = entry
             .file_name()
             .to_str()
@@ -333,25 +714,42 @@ fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
         let Ok(stat) = std::fs::read_to_string(entry.path().join("stat")) else {
             continue;
         };
-        let Some((_, rest)) = stat.rsplit_once(") ") else {
+        let Some((ppid, pgrp, start_time)) = parse_process_stat(&stat) else {
             continue;
         };
-        let mut fields = rest.split_whitespace();
-        let _state = fields.next();
-        let Some(ppid) = fields
-            .next()
-            .and_then(|value| value.parse::<libc::pid_t>().ok())
-        else {
-            continue;
-        };
-        pairs.push((pid, ppid));
+        processes.push(ProcessMetadata {
+            pid,
+            ppid,
+            pgrp,
+            start_time,
+        });
     }
-    pairs
+    Ok(processes)
 }
 
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
-fn process_parent_pairs() -> Vec<(libc::pid_t, libc::pid_t)> {
-    Vec::new()
+#[cfg(target_os = "linux")]
+fn parse_process_stat(stat: &str) -> Option<(libc::pid_t, libc::pid_t, u64)> {
+    let (_, rest) = stat.rsplit_once(") ")?;
+    let mut fields = rest.split_whitespace();
+    let _state = fields.next()?;
+    let ppid = fields.next()?.parse().ok()?;
+    let pgrp = fields.next()?.parse().ok()?;
+    let start_time = fields.nth(16)?.parse().ok()?;
+    Some((ppid, pgrp, start_time))
+}
+
+#[cfg(target_os = "linux")]
+fn open_pidfd(pid: libc::pid_t) -> std::io::Result<OwnedFd> {
+    #[cfg(test)]
+    if PIDFD_OPEN_FAILURE_PID.load(std::sync::atomic::Ordering::SeqCst) == pid {
+        return Err(std::io::Error::from_raw_os_error(libc::EPERM));
+    }
+    let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) as libc::c_int };
+    if fd < 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -359,6 +757,222 @@ mod tests {
     use super::*;
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
+
+    #[cfg(target_os = "linux")]
+    fn test_identity(pid: libc::pid_t, ppid: libc::pid_t, pidfd: OwnedFd) -> ProcessIdentity {
+        ProcessIdentity {
+            metadata: ProcessMetadata {
+                pid,
+                ppid,
+                pgrp: pid,
+                start_time: 1,
+            },
+            pidfd,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn capture_test_identity(pid: libc::pid_t) -> ProcessIdentity {
+        let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).unwrap();
+        let (ppid, pgrp, start_time) = parse_process_stat(&stat).unwrap();
+        ProcessIdentity::capture(ProcessMetadata {
+            pid,
+            ppid,
+            pgrp,
+            start_time,
+        })
+        .unwrap()
+        .unwrap()
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parses_parent_group_and_start_time_from_proc_stat() {
+        let stat =
+            "123 (command with ) parens) S 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23";
+
+        assert_eq!(parse_process_stat(stat), Some((4, 5, 22)));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mismatched_start_time_is_not_captured() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let stat = std::fs::read_to_string(format!("/proc/{}/stat", child.id())).unwrap();
+        let (ppid, pgrp, start_time) = parse_process_stat(&stat).unwrap();
+
+        let identity = ProcessIdentity::capture(ProcessMetadata {
+            pid: child.id() as libc::pid_t,
+            ppid,
+            pgrp,
+            start_time: start_time.saturating_add(1),
+        })
+        .unwrap();
+
+        assert!(identity.is_none());
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mismatched_root_identity_rejects_descendant_discovery() {
+        let mut root = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let pid = root.id() as libc::pid_t;
+        let wrong_start_time = process_start_time(pid).unwrap().saturating_add(1);
+
+        let result = capture_descendants(pid, Some(wrong_start_time), None, "test descendant scan")
+            .signal_all(libc::SIGKILL);
+
+        assert!(result.is_err());
+        assert!(root.try_wait().unwrap().is_none());
+        root.kill().unwrap();
+        root.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn matching_pidfd_is_signaled() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let identity = capture_test_identity(child.id() as libc::pid_t);
+
+        identity.send_signal(libc::SIGKILL).unwrap();
+
+        assert!(!child.wait().unwrap().success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn captured_pidfd_survives_parent_change_through_later_scan() {
+        let mut child = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let identity = capture_test_identity(child.id() as libc::pid_t);
+        let mut descendants = CapturedDescendants {
+            processes: vec![identity],
+            failures: CleanupFailures::default(),
+        };
+        descendants.processes[0].metadata.ppid = 1;
+
+        descendants.extend(CapturedDescendants {
+            processes: Vec::new(),
+            failures: CleanupFailures::default(),
+        });
+        descendants.signal_all(libc::SIGKILL).unwrap();
+
+        assert!(!child.wait().unwrap().success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn stale_pidfd_cannot_signal_reused_numeric_pid() {
+        let mut exited = std::process::Command::new("/bin/true").spawn().unwrap();
+        let mut identity = capture_test_identity(exited.id() as libc::pid_t);
+        exited.wait().unwrap();
+
+        let mut sentinel = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        identity.metadata.pid = sentinel.id() as libc::pid_t;
+
+        let error = identity.send_signal(libc::SIGKILL).unwrap_err();
+        assert_eq!(error.raw_os_error(), Some(libc::ESRCH));
+        assert!(sentinel.try_wait().unwrap().is_none());
+        sentinel.kill().unwrap();
+        sentinel.wait().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn signal_errors_do_not_stop_later_identities() {
+        let invalid_fd: OwnedFd = std::fs::File::open("/dev/null").unwrap().into();
+        let invalid = test_identity(101, 1, invalid_fd);
+
+        let mut exited = std::process::Command::new("/bin/true").spawn().unwrap();
+        let stale = capture_test_identity(exited.id() as libc::pid_t);
+        exited.wait().unwrap();
+
+        let mut live = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let live_identity = capture_test_identity(live.id() as libc::pid_t);
+        let descendants = CapturedDescendants {
+            processes: vec![invalid, stale, live_identity],
+            failures: CleanupFailures::default(),
+        };
+
+        let error = descendants.signal_all(libc::SIGKILL).unwrap_err();
+
+        assert!(error.to_string().contains("pidfd_send_signal"));
+        assert!(!live.wait().unwrap().success());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn snapshot_ancestry_rejects_unrelated_candidates() {
+        let root = 50;
+        let child = ProcessMetadata {
+            pid: 51,
+            ppid: root,
+            pgrp: 50,
+            start_time: 1,
+        };
+        let grandchild = ProcessMetadata {
+            pid: 52,
+            ppid: 51,
+            pgrp: 50,
+            start_time: 2,
+        };
+        let unrelated = ProcessMetadata {
+            pid: 53,
+            ppid: 1,
+            pgrp: 53,
+            start_time: 3,
+        };
+
+        let descendants = descendant_metadata(root, vec![unrelated, grandchild, child]);
+        let pids = descendants
+            .iter()
+            .map(|process| process.pid)
+            .collect::<Vec<_>>();
+
+        assert_eq!(pids, vec![51, 52]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn post_capture_ancestry_rejects_unrelated_identity() {
+        let child_fd: OwnedFd = std::fs::File::open("/dev/null").unwrap().into();
+        let unrelated_fd: OwnedFd = std::fs::File::open("/dev/null").unwrap().into();
+        let mut captured = vec![
+            test_identity(51, 50, child_fd),
+            test_identity(52, 1, unrelated_fd),
+        ];
+        let mut failures = CleanupFailures::default();
+
+        retain_authoritative_descendants(50, None, &mut captured, &mut failures);
+
+        assert_eq!(
+            captured
+                .iter()
+                .map(|process| process.metadata.pid)
+                .collect::<Vec<_>>(),
+            vec![51]
+        );
+        assert_eq!(failures.count, 1);
+    }
 
     #[test]
     fn isolated_descendant_helper() {
@@ -414,7 +1028,7 @@ mod tests {
         .await
         .expect("isolated descendant never became ready");
 
-        guard.terminate(&mut child).await;
+        guard.terminate(&mut child).await.unwrap();
         sleep(Duration::from_millis(1100)).await;
         assert!(
             !root.join("late-write").exists(),

--- a/crates/nac-core/src/terminal/manager.rs
+++ b/crates/nac-core/src/terminal/manager.rs
@@ -23,6 +23,7 @@ use super::{
 const PIPE_CHUNK_BYTES: usize = 16 * 1024;
 const PIPE_CHANNEL_CHUNKS: usize = 16;
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const READER_DRAIN_GRACE: Duration = Duration::from_millis(100);
 
 const NONINTERACTIVE_PROMPT_ENV: &[(&str, &str)] = &[
     ("GIT_TERMINAL_PROMPT", "0"),
@@ -78,7 +79,12 @@ impl TerminalManager {
             sessions.remove(&name)
         };
         if let Some(mut old) = old {
-            let _ = old.kill().await;
+            if let Err(error) = old.kill().await {
+                eprintln!(
+                    "nac: terminal session '{}' cleanup incomplete during replacement: {error:#}",
+                    old.name
+                );
+            }
         }
 
         let evicted: Vec<TerminalSession> = {
@@ -100,7 +106,12 @@ impl TerminalManager {
             evicted
         };
         for mut session in evicted {
-            let _ = session.kill().await;
+            if let Err(error) = session.kill().await {
+                eprintln!(
+                    "nac: terminal session '{}' cleanup incomplete during eviction: {error:#}",
+                    session.name
+                );
+            }
         }
 
         let session = TerminalSession::spawn(
@@ -291,8 +302,19 @@ impl TerminalManager {
         let stderr = child.stderr.take().expect("piped stderr is present");
         let output_id = self.output_registry.create(ArtifactKind::Command);
         let (sender, mut receiver) = mpsc::channel(PIPE_CHANNEL_CHUNKS);
-        let stdout_reader = tokio::spawn(read_chunks(stdout, OutputStream::Stdout, sender.clone()));
-        let stderr_reader = tokio::spawn(read_chunks(stderr, OutputStream::Stderr, sender));
+        let reader_shutdown = ThreadCancellation::default();
+        let stdout_reader = tokio::spawn(read_chunks(
+            stdout,
+            OutputStream::Stdout,
+            sender.clone(),
+            reader_shutdown.clone(),
+        ));
+        let stderr_reader = tokio::spawn(read_chunks(
+            stderr,
+            OutputStream::Stderr,
+            sender,
+            reader_shutdown.clone(),
+        ));
 
         let deadline = start + Duration::from_millis(yield_ms);
         let mut status = CommandStatus::Completed;
@@ -352,40 +374,83 @@ impl TerminalManager {
             }
         }
 
+        let mut force_reader_shutdown = false;
         if !process_exited {
             if let Some(pidfile) = pidfile.as_deref() {
                 let _ = backend.terminal_pipe_kill(pidfile).await;
             }
-            terminate_child_tree(&mut child).await;
+            match terminate_child_tree(&mut child).await {
+                Ok(()) => force_reader_shutdown = true,
+                Err(error) => {
+                    reader_shutdown.cancel();
+                    let cleanup_error = format!("command cleanup incomplete: {error}");
+                    runtime_error = Some(match runtime_error.take() {
+                        Some(existing) => format!("{existing}\n{cleanup_error}"),
+                        None => cleanup_error,
+                    });
+                }
+            }
             exit_code = None;
         }
 
-        let mut append_failed = false;
-        while let Some(chunk) = receiver.recv().await {
-            if append_failed {
-                continue;
+        let preserve_status = !process_exited;
+        let record_output_error =
+            |message: String, status: &mut CommandStatus, runtime_error: &mut Option<String>| {
+                if preserve_status {
+                    *runtime_error = Some(match runtime_error.take() {
+                        Some(existing) => format!("{existing}\n{message}"),
+                        None => message,
+                    });
+                } else {
+                    *status = CommandStatus::SpawnError;
+                    *runtime_error = Some(message);
+                }
+            };
+
+        let reader_shutdown_timer = async {
+            if force_reader_shutdown {
+                sleep(READER_DRAIN_GRACE).await;
+            } else {
+                std::future::pending::<()>().await;
             }
-            if let Err(error) = self
-                .output_registry
-                .append(&output_id, chunk.stream, chunk.bytes)
-            {
-                status = CommandStatus::SpawnError;
-                runtime_error = Some(error.to_string());
-                append_failed = true;
+        };
+        tokio::pin!(reader_shutdown_timer);
+        let mut reader_shutdown_pending = force_reader_shutdown;
+        let mut append_failed = false;
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut reader_shutdown_timer, if reader_shutdown_pending => {
+                    reader_shutdown.cancel();
+                    reader_shutdown_pending = false;
+                }
+                chunk = receiver.recv() => {
+                    let Some(chunk) = chunk else {
+                        break;
+                    };
+                    if append_failed {
+                        continue;
+                    }
+                    if let Err(error) = self.output_registry.append(
+                        &output_id,
+                        chunk.stream,
+                        chunk.bytes,
+                    ) {
+                        record_output_error(error.to_string(), &mut status, &mut runtime_error);
+                        append_failed = true;
+                    }
+                }
             }
         }
 
         for reader in [stdout_reader, stderr_reader] {
-            match reader.await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    status = CommandStatus::SpawnError;
-                    runtime_error = Some(format!("failed to read command output: {error}"));
-                }
-                Err(error) => {
-                    status = CommandStatus::SpawnError;
-                    runtime_error = Some(format!("command output reader failed: {error}"));
-                }
+            let message = match reader.await {
+                Ok(Ok(())) => None,
+                Ok(Err(error)) => Some(format!("failed to read command output: {error}")),
+                Err(error) => Some(format!("command output reader failed: {error}")),
+            };
+            if let Some(message) = message {
+                record_output_error(message, &mut status, &mut runtime_error);
             }
         }
 
@@ -447,7 +512,12 @@ impl TerminalManager {
             .map(|(_, session)| session)
             .collect();
         for mut session in sessions {
-            let _ = session.kill().await;
+            if let Err(error) = session.kill().await {
+                eprintln!(
+                    "nac: terminal session '{}' cleanup incomplete during removal: {error:#}",
+                    session.name
+                );
+            }
         }
         self.output_registry.clear();
     }
@@ -527,18 +597,26 @@ async fn read_chunks<R>(
     mut reader: R,
     stream: OutputStream,
     sender: mpsc::Sender<StreamChunk>,
+    shutdown: ThreadCancellation,
 ) -> std::io::Result<()>
 where
     R: AsyncRead + Unpin,
 {
     loop {
         let mut bytes = vec![0u8; PIPE_CHUNK_BYTES];
-        let read = reader.read(&mut bytes).await?;
+        let read = tokio::select! {
+            _ = shutdown.cancelled() => return Ok(()),
+            read = reader.read(&mut bytes) => read?,
+        };
         if read == 0 {
             return Ok(());
         }
         bytes.truncate(read);
-        if sender.send(StreamChunk { stream, bytes }).await.is_err() {
+        let sent = tokio::select! {
+            _ = shutdown.cancelled() => return Ok(()),
+            sent = sender.send(StreamChunk { stream, bytes }) => sent,
+        };
+        if sent.is_err() {
             return Ok(());
         }
     }
@@ -546,6 +624,33 @@ where
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn pipe_reader_shutdown_preserves_queued_output_and_closes_channel() {
+        use tokio::io::AsyncWriteExt;
+
+        let (mut writer, reader) = tokio::io::duplex(64);
+        let (sender, mut receiver) = mpsc::channel(1);
+        let shutdown = ThreadCancellation::default();
+        let handle = tokio::spawn(read_chunks(
+            reader,
+            OutputStream::Stdout,
+            sender,
+            shutdown.clone(),
+        ));
+
+        writer.write_all(b"before shutdown").await.unwrap();
+        let chunk = receiver.recv().await.unwrap();
+        assert_eq!(chunk.bytes, b"before shutdown");
+
+        shutdown.cancel();
+        tokio::time::timeout(Duration::from_secs(1), handle)
+            .await
+            .expect("reader did not stop")
+            .unwrap()
+            .unwrap();
+        assert!(receiver.recv().await.is_none());
+    }
     use super::*;
     use crate::paths::PathContext;
     use crate::sandbox::{
@@ -609,6 +714,94 @@ mod tests {
 
         assert_eq!(output.status, CommandStatus::TimedOut);
         assert_eq!(output.exit_code, None);
+    }
+
+    #[cfg(target_os = "linux")]
+    async fn run_one_shot_with_pidfd_failure(cancel: bool) -> CommandOutput {
+        let _test_lock = crate::process::PIDFD_OPEN_FAILURE_LOCK.lock().await;
+        let manager = TerminalManager::new();
+        let root = std::env::temp_dir().join(format!("nac-pidfd-failure-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let pidfile = root.join("descendant-pid");
+        let command = format!(
+            "setsid sh -c 'printf $$ > {pidfile}; printf child-output; \
+             printf child-error >&2; trap \"\" TERM; sleep 30' & \
+             printf parent-output; printf parent-error >&2; sleep 30",
+            pidfile = pidfile.display()
+        );
+        let cancellation = ThreadCancellation::default();
+        let task_cancellation = cancellation.clone();
+        let task_manager = manager.clone();
+        let task_backend = backend();
+        let timeout_ms = if cancel { 5_000 } else { 200 };
+        let task = tokio::spawn(async move {
+            task_manager
+                .exec_one_shot(
+                    &command,
+                    None,
+                    120,
+                    40,
+                    timeout_ms,
+                    8_000,
+                    &task_backend,
+                    cancel.then_some(&task_cancellation),
+                )
+                .await
+        });
+
+        let descendant_pid = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(pid) = std::fs::read_to_string(&pidfile) {
+                    break pid.parse::<libc::pid_t>().unwrap();
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("isolated descendant did not publish its pid");
+        struct PidfdFailureReset;
+        impl Drop for PidfdFailureReset {
+            fn drop(&mut self) {
+                crate::process::set_pidfd_open_failure_for_test(0);
+            }
+        }
+        let _failure_reset = PidfdFailureReset;
+        crate::process::set_pidfd_open_failure_for_test(descendant_pid);
+        if cancel {
+            cancellation.cancel();
+        }
+
+        let output = tokio::time::timeout(Duration::from_secs(3), task)
+            .await
+            .expect("one-shot cleanup remained blocked on inherited pipes")
+            .unwrap();
+
+        assert_eq!(output.exit_code, None);
+        assert!(output.stdout_preview.contains("parent-output"));
+        assert!(output.stdout_preview.contains("child-output"));
+        assert!(output.stderr_preview.contains("parent-error"));
+        assert!(output.stderr_preview.contains("child-error"));
+        assert!(output.stderr_preview.contains("command cleanup incomplete"));
+
+        unsafe {
+            libc::kill(descendant_pid, libc::SIGKILL);
+        }
+        let _ = std::fs::remove_dir_all(root);
+        output
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn one_shot_pidfd_failure_is_bounded_and_preserves_timeout_output() {
+        let output = run_one_shot_with_pidfd_failure(false).await;
+        assert_eq!(output.status, CommandStatus::TimedOut);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn one_shot_pidfd_failure_is_bounded_and_preserves_cancellation_output() {
+        let output = run_one_shot_with_pidfd_failure(true).await;
+        assert_eq!(output.status, CommandStatus::Cancelled);
     }
 
     #[cfg(unix)]

--- a/crates/nac-core/src/terminal/session.rs
+++ b/crates/nac-core/src/terminal/session.rs
@@ -4,13 +4,17 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "linux")]
+use anyhow::anyhow;
 use anyhow::{Context, Result};
 use portable_pty::{NativePtySystem, PtySize, PtySystem};
 use tokio::sync::Notify;
 
 use super::{ArtifactKind, OutputRegistry, OutputStream};
-#[cfg(unix)]
-use crate::process::{descendant_pids, signal_pids};
+#[cfg(all(unix, not(target_os = "linux")))]
+use crate::process::signal_descendants;
+#[cfg(target_os = "linux")]
+use crate::process::{process_identity_matches, process_start_time, signal_descendants};
 use crate::sandbox::ExecutionBackend;
 
 pub struct TerminalSession {
@@ -20,6 +24,8 @@ pub struct TerminalSession {
     preview_cursor: u64,
     output_notify: Arc<Notify>,
     child: Box<dyn portable_pty::Child + Send + Sync>,
+    #[cfg(target_os = "linux")]
+    root_start_time: u64,
     _pty_pair: portable_pty::PtyPair,
     _reader_thread: std::thread::JoinHandle<()>,
     pub created_at: Instant,
@@ -65,6 +71,19 @@ impl TerminalSession {
             .slave
             .spawn_command(cmd)
             .context("Failed to spawn bash in PTY")?;
+        #[cfg(target_os = "linux")]
+        let mut child = child;
+        #[cfg(target_os = "linux")]
+        let root_start_time = {
+            let start_time = child
+                .process_id()
+                .and_then(|pid| process_start_time(pid as libc::pid_t));
+            let Some(start_time) = start_time else {
+                let _ = child.kill();
+                return Err(anyhow!("Failed to capture PTY root process identity"));
+            };
+            start_time
+        };
 
         let reader = pty_pair
             .master
@@ -112,6 +131,8 @@ impl TerminalSession {
             preview_cursor: 0,
             output_notify: notify,
             child,
+            #[cfg(target_os = "linux")]
+            root_start_time,
             _pty_pair: pty_pair,
             _reader_thread: reader_thread,
             created_at: Instant::now(),
@@ -184,14 +205,20 @@ impl TerminalSession {
             let _ = backend.terminal_pipe_kill(pidfile).await;
         }
 
+        self.refresh_status();
         #[cfg(unix)]
-        {
-            self.signal_descendants(libc::SIGKILL);
+        let descendant_result = if self.exit_code.is_none() {
+            let descendant_result = self.signal_descendants(libc::SIGKILL);
             self.signal_process_group(libc::SIGKILL);
-        }
+            descendant_result
+        } else {
+            Ok(())
+        };
 
         self.reap_child().await;
         self.alive.store(false, Ordering::SeqCst);
+        #[cfg(unix)]
+        descendant_result?;
         Ok(())
     }
 
@@ -206,23 +233,46 @@ impl TerminalSession {
         self.exit_code
     }
 
-    #[cfg(unix)]
-    fn child_descendant_pids(&self) -> Vec<libc::pid_t> {
-        let Some(pid) = self.child.process_id() else {
-            return Vec::new();
-        };
-        descendant_pids(pid as libc::pid_t)
+    #[cfg(target_os = "linux")]
+    fn signal_descendants(&self, signal: libc::c_int) -> std::io::Result<()> {
+        if let Some(pid) = self.child.process_id() {
+            signal_descendants(pid as libc::pid_t, self.root_start_time, signal)
+        } else {
+            Ok(())
+        }
     }
 
-    #[cfg(unix)]
-    fn signal_descendants(&self, signal: libc::c_int) {
-        signal_pids(&self.child_descendant_pids(), signal);
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn signal_descendants(&self, signal: libc::c_int) -> std::io::Result<()> {
+        if let Some(pid) = self.child.process_id() {
+            signal_descendants(pid as libc::pid_t, signal)
+        } else {
+            Ok(())
+        }
     }
 
     #[cfg(not(unix))]
-    fn signal_descendants(&self, _signal: i32) {}
+    fn signal_descendants(&self, _signal: i32) -> std::io::Result<()> {
+        Ok(())
+    }
 
-    #[cfg(unix)]
+    #[cfg(target_os = "linux")]
+    fn signal_process_group(&self, signal: libc::c_int) {
+        let Some(pid) = self.child.process_id().map(|pid| pid as libc::pid_t) else {
+            return;
+        };
+        if !process_identity_matches(pid, self.root_start_time) {
+            return;
+        }
+        unsafe {
+            let pgid = libc::getpgid(pid);
+            if pgid > 0 {
+                libc::kill(-pgid, signal);
+            }
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
     fn signal_process_group(&self, signal: libc::c_int) {
         if let Some(pid) = self.child.process_id() {
             unsafe {
@@ -265,9 +315,10 @@ impl TerminalSession {
 impl Drop for TerminalSession {
     fn drop(&mut self) {
         let _ = self.writer.flush();
+        self.refresh_status();
         #[cfg(unix)]
-        {
-            self.signal_descendants(libc::SIGTERM);
+        if self.exit_code.is_none() {
+            let _ = self.signal_descendants(libc::SIGTERM);
             self.signal_process_group(libc::SIGTERM);
         }
         self.alive.store(false, Ordering::SeqCst);
@@ -302,8 +353,18 @@ pub(crate) fn terminal_env_owned() -> Vec<(String, String)> {
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
-    fn process_exists(pid: u32) -> bool {
+    #[cfg(target_os = "linux")]
+    fn process_running(pid: u32) -> bool {
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            return false;
+        };
+        stat.rsplit_once(") ")
+            .and_then(|(_, fields)| fields.split_whitespace().next())
+            != Some("Z")
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    fn process_running(pid: u32) -> bool {
         unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
     }
 
@@ -362,7 +423,7 @@ mod tests {
         }
         let child_pid = child_pid.unwrap_or_else(|| panic!("child pid not found in: {output:?}"));
         assert!(
-            process_exists(child_pid),
+            process_running(child_pid),
             "background child exited too early"
         );
 
@@ -370,7 +431,7 @@ mod tests {
 
         let mut still_running = false;
         for _ in 0..40 {
-            still_running = process_exists(child_pid);
+            still_running = process_running(child_pid);
             if !still_running {
                 break;
             }

--- a/crates/nac-core/src/tools/thread/mod.rs
+++ b/crates/nac-core/src/tools/thread/mod.rs
@@ -374,20 +374,29 @@ fn classify_dispatch_failure(
     timeout_secs: u64,
 ) -> Option<DispatchFailure> {
     if run.cancelled {
+        let mut message = format!("Thread '{thread_name}' was cancelled.");
+        if let Some(cleanup_error) = &run.cleanup_error {
+            message.push('\n');
+            message.push_str(cleanup_error);
+        }
         return Some(DispatchFailure {
             status: store::EpisodeStatus::Cancelled,
-            message: format!("Thread '{thread_name}' was cancelled."),
+            message,
         });
     }
 
     if run.timed_out {
-        let message = match run.timeout_reason.as_deref() {
+        let mut message = match run.timeout_reason.as_deref() {
             Some(reason) => format!(
                 "Thread '{}' timed out after {}s.\n{}",
                 thread_name, timeout_secs, reason
             ),
             None => format!("Thread '{}' timed out after {}s", thread_name, timeout_secs),
         };
+        if let Some(cleanup_error) = &run.cleanup_error {
+            message.push('\n');
+            message.push_str(cleanup_error);
+        }
         return Some(DispatchFailure {
             status: store::EpisodeStatus::TimedOut,
             message,
@@ -771,6 +780,35 @@ mod tests {
     use crate::tools::test_runtime;
     use serde_json::json;
     use std::sync::Arc;
+
+    #[test]
+    fn cleanup_diagnostic_preserves_timeout_and_cancellation_classification() {
+        let mut run = WorkerRun {
+            stdout: "partial stdout".to_string(),
+            stderr: "partial stderr".to_string(),
+            exit_code: -1,
+            timed_out: true,
+            cancelled: false,
+            timeout_reason: None,
+            usage: None,
+            model_error: None,
+            cleanup_error: Some("worker cleanup incomplete: pidfd_open denied".to_string()),
+        };
+
+        let timed_out = classify_dispatch_failure(&run, "worker-a", 30).unwrap();
+        assert_eq!(timed_out.status, store::EpisodeStatus::TimedOut);
+        assert!(timed_out.message.contains("timed out after 30s"));
+        assert!(timed_out.message.contains("worker cleanup incomplete"));
+        assert!(!timed_out.message.contains("Failed to spawn"));
+
+        run.timed_out = false;
+        run.cancelled = true;
+        let cancelled = classify_dispatch_failure(&run, "worker-a", 30).unwrap();
+        assert_eq!(cancelled.status, store::EpisodeStatus::Cancelled);
+        assert!(cancelled.message.contains("was cancelled"));
+        assert!(cancelled.message.contains("worker cleanup incomplete"));
+        assert!(!cancelled.message.contains("Failed to spawn"));
+    }
 
     fn skill_record(
         name: &str,

--- a/crates/nac-core/src/tools/thread/worker.rs
+++ b/crates/nac-core/src/tools/thread/worker.rs
@@ -15,6 +15,7 @@ use crate::tools::{ThreadCancellation, ToolRuntime};
 const CANCEL_ACK_GRACE: Duration = Duration::from_millis(250);
 // SSH cleanup can spend five seconds in the kill request; Podman can spend two.
 const COOPERATIVE_CLEANUP_GRACE: Duration = Duration::from_secs(7);
+const READER_DRAIN_GRACE: Duration = Duration::from_millis(100);
 
 pub(super) struct WorkerRun {
     pub(super) stdout: String,
@@ -25,6 +26,7 @@ pub(super) struct WorkerRun {
     pub(super) timeout_reason: Option<String>,
     pub(super) usage: Option<TokenUsage>,
     pub(super) model_error: Option<String>,
+    pub(super) cleanup_error: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -258,14 +260,23 @@ pub(super) async fn run_worker(
     let thread_name_for_logs = invocation.thread_name.to_string();
     let timeout_trace_for_logs = timeout_trace.clone();
     let (cancel_ack_tx, mut cancel_ack_rx) = watch::channel(false);
+    let reader_shutdown = ThreadCancellation::default();
     let stderr_cancellation = cancellation.clone();
+    let stderr_shutdown = reader_shutdown.clone();
     let stderr_handle = tokio::spawn(async move {
         let reader = BufReader::new(stderr);
         let mut lines = reader.lines();
         let mut output = String::new();
         let mut worker_usage = TokenUsage::default();
         let mut model_error = None;
-        while let Some(line) = next_pipe_line(&mut lines).await {
+        loop {
+            let line = tokio::select! {
+                _ = stderr_shutdown.cancelled() => break,
+                line = next_pipe_line(&mut lines) => line,
+            };
+            let Some(line) = line else {
+                break;
+            };
             if stderr_cancellation.is_cancelled() {
                 break;
             }
@@ -315,12 +326,20 @@ pub(super) async fn run_worker(
     });
 
     let stdout_cancellation = cancellation.clone();
+    let stdout_shutdown = reader_shutdown.clone();
     let stdout = child.stdout.take().unwrap();
     let stdout_handle = tokio::spawn(async move {
         let reader = BufReader::new(stdout);
         let mut lines = reader.lines();
         let mut output = String::new();
-        while let Some(line) = next_pipe_line(&mut lines).await {
+        loop {
+            let line = tokio::select! {
+                _ = stdout_shutdown.cancelled() => break,
+                line = next_pipe_line(&mut lines) => line,
+            };
+            let Some(line) = line else {
+                break;
+            };
             if stdout_cancellation.is_cancelled() {
                 break;
             }
@@ -379,8 +398,16 @@ pub(super) async fn run_worker(
 
     let timed_out = matches!(outcome, WaitOutcome::TimedOut);
     let mut cancelled = matches!(outcome, WaitOutcome::Cancelled);
+    let mut cleanup_error = None;
+    let mut force_reader_shutdown = false;
     if timed_out || (cancelled && !cooperatively_cancelled) {
-        process_tree.terminate(&mut child).await;
+        match process_tree.terminate(&mut child).await {
+            Ok(()) => force_reader_shutdown = true,
+            Err(error) => {
+                reader_shutdown.cancel();
+                cleanup_error = Some(format!("worker cleanup incomplete: {error}"));
+            }
+        }
     }
 
     let readers = async {
@@ -389,18 +416,35 @@ pub(super) async fn run_worker(
         (stderr, worker_usage, model_error, stdout)
     };
     tokio::pin!(readers);
-    let (stderr, worker_usage, model_error, stdout) = if timed_out || cancelled {
-        readers.await
-    } else {
+    let mut reader_output = None;
+    if !timed_out && !cancelled {
         tokio::select! {
             biased;
             _ = cancellation.cancelled() => {
                 cancelled = true;
-                process_tree.terminate(&mut child).await;
+                match process_tree.terminate(&mut child).await {
+                    Ok(()) => force_reader_shutdown = true,
+                    Err(error) => {
+                        reader_shutdown.cancel();
+                        cleanup_error = Some(format!("worker cleanup incomplete: {error}"));
+                    }
+                }
+            }
+            output = &mut readers => reader_output = Some(output),
+        }
+    }
+    let (stderr, worker_usage, model_error, stdout) = if let Some(output) = reader_output {
+        output
+    } else if force_reader_shutdown {
+        match timeout(READER_DRAIN_GRACE, &mut readers).await {
+            Ok(output) => output,
+            Err(_) => {
+                reader_shutdown.cancel();
                 readers.await
             }
-            output = &mut readers => output,
         }
+    } else {
+        readers.await
     };
 
     if !timed_out && !cancelled {
@@ -425,6 +469,7 @@ pub(super) async fn run_worker(
         timeout_reason,
         usage: worker_usage,
         model_error,
+        cleanup_error,
     })
 }
 
@@ -560,6 +605,117 @@ wait
         assert!(!root.join("a.late").exists());
         assert!(!root.join("b.late").exists());
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn pidfd_failure_does_not_block_worker_timeout_or_cancellation() {
+        let _test_lock = crate::process::PIDFD_OPEN_FAILURE_LOCK.lock().await;
+        let expected_usage = TokenUsage {
+            input_tokens: 7,
+            output_tokens: 3,
+            ..TokenUsage::default()
+        };
+        let usage_event = serde_json::to_string(&AgentEvent::AssistantMessage {
+            thread_name: Some("worker".to_string()),
+            content: "partial".to_string(),
+            usage: Some(expected_usage.clone()),
+        })
+        .unwrap();
+        for cancel in [false, true] {
+            let root =
+                std::env::temp_dir().join(format!("nac_worker_pidfd_{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(&root).unwrap();
+            let executable = root.join("worker.sh");
+            let script = format!(
+                "#!/bin/sh\n\
+                 setsid sh -c 'printf $$ > \"{root}/descendant.pid\"; \
+                 printf \"child-output\\n\"; trap \"\" TERM; sleep 30' &\n\
+                 printf 'worker-output\\n'\n\
+                 printf 'worker-stderr\\n' >&2\n\
+                 printf '%s\\n' '{prefix}{usage_event}' >&2\n\
+                 sleep 0.1\n\
+                 printf ready > \"{root}/ready\"\n\
+                 trap '' TERM\n\
+                 wait\n",
+                prefix = crate::events::STDERR_EVENT_PREFIX,
+                root = root.display()
+            );
+            std::fs::write(&executable, script).unwrap();
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700)).unwrap();
+
+            let mut runtime = test_runtime();
+            runtime.workspace_cwd = root.clone();
+            runtime.config_cwd = root.clone();
+            runtime.worker_executable = Some(executable);
+            let cancellation = ThreadCancellation::default();
+            let worker_cancellation = cancellation.clone();
+            let no_sources = Vec::<String>::new();
+            let no_skills = Vec::<String>::new();
+            let client = ModelClient::new_for_test();
+            let worker = run_worker(
+                &runtime,
+                &client,
+                WorkerInvocation {
+                    session_id: "session",
+                    thread_name: "worker",
+                    dispatch_id: "dispatch",
+                    action: "worker",
+                    source_threads: &no_sources,
+                    scheduled_skills: &no_skills,
+                    timeout_secs: if cancel { 30 } else { 1 },
+                },
+                worker_cancellation,
+            );
+            struct PidfdFailureReset;
+            impl Drop for PidfdFailureReset {
+                fn drop(&mut self) {
+                    crate::process::set_pidfd_open_failure_for_test(0);
+                }
+            }
+            let _failure_reset = PidfdFailureReset;
+            let stop_when_ready = async {
+                let descendant_pid = tokio::time::timeout(Duration::from_secs(2), async {
+                    loop {
+                        if root.join("ready").exists() {
+                            let pid = std::fs::read_to_string(root.join("descendant.pid")).unwrap();
+                            break pid.parse::<libc::pid_t>().unwrap();
+                        }
+                        sleep(Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+                .expect("isolated worker descendant did not publish its pid");
+                crate::process::set_pidfd_open_failure_for_test(descendant_pid);
+                if cancel {
+                    cancellation.cancel();
+                }
+                descendant_pid
+            };
+
+            let (run, descendant_pid) = tokio::time::timeout(Duration::from_secs(5), async {
+                tokio::join!(worker, stop_when_ready)
+            })
+            .await
+            .expect("worker cleanup remained blocked on inherited pipes");
+            let run = run.unwrap();
+
+            assert_eq!(run.cancelled, cancel);
+            assert_eq!(run.timed_out, !cancel);
+            assert!(run.stdout.contains("worker-output"));
+            assert!(run.stdout.contains("child-output"));
+            assert!(run.stderr.contains("worker-stderr"));
+            assert_eq!(run.usage.as_ref(), Some(&expected_usage));
+            assert!(run
+                .cleanup_error
+                .as_deref()
+                .is_some_and(|error| error.contains("pidfd_open/capture")));
+
+            unsafe {
+                libc::kill(descendant_pid, libc::SIGKILL);
+            }
+            let _ = std::fs::remove_dir_all(root);
+        }
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Bind Linux descendant signaling to verified `pidfd` handles instead of reusable numeric PIDs.
- Validate the supervised root before and after discovery, verify post-open descendant ancestry, and retain accepted handles across TERM/KILL scans.
- Continue signaling captured siblings after individual failures, report incomplete cleanup, and never fall back to `kill(pid, ...)` for Linux descendants.
- Bound one-shot and worker pipe-reader teardown without replacing `TimedOut` or `Cancelled` lifecycle status; preserve queued stdout, stderr, usage, and cleanup diagnostics.
- Protect PTY cleanup with the root process start time and surface replacement, eviction, and remove-all cleanup failures.

Closes #154.
Supersedes #156 with a rebuilt implementation and failure-path coverage.

## Safety and compatibility

- Linux requires a kernel with `pidfd_open`/`pidfd_send_signal` support (Linux 5.3+ for the combined path). If pidfd capture or signaling is unavailable, NAC skips that unsafe direct signal and reports incomplete cleanup; it does not use a numeric-PID fallback.
- A newly opened handle is accepted only when refreshed metadata still establishes ancestry to the unchanged supervised root. A process that reparents before safe capture is treated as ambiguous and skipped.
- Already accepted pidfds remain authoritative if a descendant reparents later.
- Process snapshots are not atomic. A process that forks or reparents after the final discovery pass can still escape cleanup; closing that containment gap requires kernel-enforced ownership rather than another `/proc` scan.
- macOS, other non-Linux platforms, and remote backend wrapper behavior are unchanged.

## Validation

- `cargo test -p nac-core --locked` — 805 passed, 9 ignored on macOS.
- `cargo check -p nac-core --tests --locked` — passed on macOS and Debian Bookworm Linux.
- Linux Podman regressions passed:
  - 11 process identity, ancestry, pidfd signaling, and isolated-descendant tests.
  - one-shot timeout and cancellation with injected `pidfd_open` failure.
  - worker timeout and cancellation with injected failure, bounded return, retained stdout/stderr/usage, and cleanup diagnostics.
  - PTY background-job teardown.
- Built `nac-web` in Debian Bookworm and served it inside Podman; `/health`, `/openapi.json`, and `/models` responded successfully.
- `rustfmt --check` passes for all changed Rust files. Workspace-wide `cargo fmt --all --check` still reports unrelated formatting drift already present on `main`; those files are intentionally outside this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to Linux process termination and PTY/worker teardown—security-sensitive areas where PID reuse bugs could leave orphans or signal wrong processes; macOS/non-Linux behavior is preserved.
> 
> **Overview**
> **Linux process-tree teardown** no longer signals descendants by bare PID. The guard records the root’s `/proc` start time, discovers descendants from richer metadata, opens **`pidfd`** handles, verifies identity (including after reparenting), and signals via **`pidfd_send_signal`**. Incomplete cleanup surfaces as **`std::io::Result`** from `terminate` / `terminate_child_tree` / `signal_descendants` instead of silent best-effort `kill`. Non-Linux Unix paths are unchanged.
> 
> **Terminal and worker shutdown** propagate those errors without changing **`TimedOut`** / **`Cancelled`** status: cleanup diagnostics are appended to stderr or dispatch messages, and **`WorkerRun.cleanup_error`** is folded into timeout/cancel text. One-shot and worker **pipe readers** accept **`ThreadCancellation`**, with a short drain grace after successful kill so teardown stays bounded when pidfd capture fails.
> 
> **PTY sessions** on Linux store root start time at spawn, gate process-group kills on identity match, and log incomplete cleanup on replace/evict/remove-all.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a710d50ca2f968dd5771def3d8b3a07cd0877b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->