### PR TITLE
fix(auth): do not start web server after login (nac)

### DIFF
--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -648,10 +648,10 @@ async fn run_managed_worker(cli: ManagedWorkerCli) -> Result<()> {
 async fn run_codex_auth_cli(cli: CodexAuthCli) -> Result<()> {
     match cli.command {
         Some(command) => {
-            let start_dashboard = matches!(command, CodexAuthCommand::Login);
+            let is_login = matches!(command, CodexAuthCommand::Login);
             run_codex_auth_action(codex_auth_action(command)).await?;
-            if start_dashboard {
-                start_dashboard_after_login().await?;
+            if is_login {
+                println!("Login complete. Run `nac-web` to start the dashboard.");
             }
             Ok(())
         }
@@ -675,10 +675,10 @@ fn codex_auth_action(command: CodexAuthCommand) -> CodexAuthAction {
 async fn run_arcee_auth_cli(cli: ArceeAuthCli) -> Result<()> {
     match cli.command {
         Some(command) => {
-            let start_dashboard = matches!(command, ArceeAuthCommand::Login);
+            let is_login = matches!(command, ArceeAuthCommand::Login);
             run_arcee_auth_action(arcee_auth_action(command)).await?;
-            if start_dashboard {
-                start_dashboard_after_login().await?;
+            if is_login {
+                println!("Login complete. Run `nac-web` to start the dashboard.");
             }
             Ok(())
         }
@@ -689,20 +689,6 @@ async fn run_arcee_auth_cli(cli: ArceeAuthCli) -> Result<()> {
             Ok(())
         }
     }
-}
-
-/// After a successful browser login, continue into the same flow as a plain
-/// `nac-web`: confirm the project folder and open the dashboard. Non-interactive
-/// shells only print the next command so CI / scripts are not blocked.
-async fn start_dashboard_after_login() -> Result<()> {
-    println!();
-    if !nac_core::browser::should_open_browser() {
-        println!("Next: run `nac-web` from your project directory to open the dashboard.");
-        return Ok(());
-    }
-    println!("Login complete. Starting the dashboard…");
-    println!();
-    run_server(ServerCli::parse_from(["nac-web"])).await
 }
 
 fn arcee_auth_action(command: ArceeAuthCommand) -> ArceeAuthAction {


### PR DESCRIPTION
## Description

**What.** `nac-web arcee-auth login` and `nac-web codex-auth login` now only persist credentials, print a success message, and exit 0 — they no longer start the web server.

**Why.** Issue #159: the auth login commands were unconditionally starting the dashboard after a successful login, which bound an HTTP port, opened a browser, and blocked the process. Login should be a side-effect-free credential step; starting the dashboard is the job of `nac-web` (the serve path).

- Removed the `start_dashboard_after_login()` call from both `run_codex_auth_cli` and `run_arcee_auth_cli`.
- Removed the now-unused `start_dashboard_after_login` function and its doc comment.
- Login now prints `Login complete. Run `nac-web` to start the dashboard.` and exits 0.

## Usage

```bash
nac-web arcee-auth login
# credentials persisted, success message printed, process exits 0
# (previously: HTTP server bound, browser opened, process blocked)

nac-web codex-auth login
# same behavior

nac-web
# start the dashboard explicitly when you want it
```

## Changelog

- `nac-web arcee-auth login` / `nac-web codex-auth login` no longer start the web server; they persist credentials, print a success message, and exit 0.

## Validation

- `cargo check --workspace --locked` — PASS
- `cargo clippy -p nac-server --locked --all-targets` — PASS
- `cargo test -p nac-server --locked` — 12/12 PASS (including `codex_auth_command_parses_subcommands` and `arcee_auth_command_parses_subcommands`)

## Bug Evidence

Before this PR, `nac-web arcee-auth login` / `nac-web codex-auth login` called `start_dashboard_after_login()` → `run_server(...)`, which bound an HTTP port, opened a browser, and blocked the process.

Root cause: both auth CLI handlers unconditionally started the dashboard on `Login`.

Fix: removed the dashboard-start blocks from both handlers and removed the `start_dashboard_after_login` function. Login now only persists credentials, prints `Login complete. Run `nac-web` to start the dashboard.`, and exits 0.

Validation: `cargo check --workspace --locked` PASS, `cargo clippy -p nac-server --locked --all-targets` PASS, `cargo test -p nac-server --locked` 12/12 PASS.

Closes #159

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only behavior change for auth login; no changes to credential storage APIs or server bind/auth logic.
> 
> **Overview**
> **Codex and Arcee `login` subcommands no longer chain into the web server.** After credentials are saved, both handlers print `Login complete. Run \`nac-web\` to start the dashboard.` and return instead of invoking the former post-login flow.
> 
> The **`start_dashboard_after_login` helper is removed** entirely. That path had optionally called `run_server` (bind HTTP, project-dir prompts, browser open) when a TTY allowed it, which left login blocking on a long-running server process.
> 
> **`status` / `logout` behavior is unchanged**; only successful `login` drops the dashboard auto-start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebded0ea15998f0440158e00411d608ebb0b378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->