### PR TITLE
fix(security): redact credentials from provider error events and logs (nac)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
  "openssh-sftp-client",
  "portable-pty",
  "rand 0.9.4",
+ "regex",
  "reqwest",
  "rmcp",
  "rusqlite",

--- a/crates/nac-core/Cargo.toml
+++ b/crates/nac-core/Cargo.toml
@@ -32,6 +32,7 @@ diffy = { version = "0.5.0", default-features = false }
 fs2 = "0.4"
 sha2 = "0.10"
 rand = "0.9"
+regex = "1"
 base64 = "0.22"
 cap-std = "4"
 globset = { version = "0.4", default-features = false }

--- a/crates/nac-core/src/events.rs
+++ b/crates/nac-core/src/events.rs
@@ -10,6 +10,7 @@ use tokio::sync::{broadcast, mpsc::UnboundedSender};
 use uuid::Uuid;
 
 use crate::agent::key_arg_preview;
+use crate::model::redact_credentials;
 
 pub const STDERR_EVENT_PREFIX: &str = "__NAC_EVENT__";
 pub const SESSION_EVENT_BUS_CAPACITY: usize = 1024;
@@ -235,14 +236,16 @@ pub enum AgentEvent {
         thread_name: Option<String>,
         message: String,
     },
-    /// A model call the provider itself refused, reported verbatim.
+    /// A model call the provider itself refused, reported with credentials
+    /// redacted.
     ///
     /// Ordinary errors are reduced to a constant before they leave the process,
     /// because their text can carry paths and tool output. What a provider says
     /// about its own API — no credits, bad key, rate limit, context too long —
     /// carries none of that and is the one thing the user has to see to act, so
-    /// it travels intact. Live-only, like the other events whose absence keeps
-    /// the persisted stream readable by older builds.
+    /// it travels intact apart from credential material, which is masked before
+    /// the event leaves the process. Live-only, like the other events whose
+    /// absence keeps the persisted stream readable by older builds.
     ModelError {
         thread_name: Option<String>,
         message: String,
@@ -878,7 +881,10 @@ pub(crate) fn sanitize_external_agent_event(event: AgentEvent) -> Option<AgentEv
         } => AgentEvent::ModelError {
             thread_name,
             // Provider bodies can be long; the actionable part is at the front.
-            message: bounded_provider_message(&message),
+            // Credential shapes are masked first as defense in depth: the exact
+            // secret is not known here, but header-shaped credential lines and
+            // bearer tokens are still caught if they reached the event.
+            message: bounded_provider_message(&redact_credentials(&message, &[])),
         },
         event @ (AgentEvent::TokenUsageUpdated { .. }
         | AgentEvent::AssistantMessage { .. }
@@ -2322,5 +2328,24 @@ mod tests {
         assert_eq!(boundary.sequence_id, 0);
         assert_eq!(emitted.sequence_id, 1);
         assert_eq!(boundary.epoch_id, emitted.epoch_id);
+    }
+
+    #[test]
+    fn model_error_sanitization_redacts_credential_shapes_and_bounds_length() {
+        let event = AgentEvent::ModelError {
+            thread_name: Some("impl".to_string()),
+            message: "HTTP 400 from https://api.test: Authorization: Bearer sk-canary-event-12345; x-api-key: sk-canary-event-12345; no credits".to_string(),
+        };
+        let sanitized = sanitize_external_agent_event(event).unwrap();
+        let AgentEvent::ModelError { message, .. } = sanitized else {
+            panic!("expected ModelError");
+        };
+        assert!(
+            !message.contains("sk-canary-event-12345"),
+            "credential leaked through sanitization: {message}"
+        );
+        assert!(message.contains("[REDACTED]"), "{message}");
+        assert!(message.contains("no credits"), "{message}");
+        assert!(message.contains("HTTP 400"), "{message}");
     }
 }

--- a/crates/nac-core/src/events.rs
+++ b/crates/nac-core/src/events.rs
@@ -2348,4 +2348,69 @@ mod tests {
         assert!(message.contains("no credits"), "{message}");
         assert!(message.contains("HTTP 400"), "{message}");
     }
+
+    const MODEL_ERROR_CANARY: &str = "sk-canary-sink-12345";
+    const MODEL_ERROR_STDERR_HELPER_ENV: &str = "NAC_MODEL_ERROR_STDERR_HELPER";
+
+    fn credential_bearing_model_error() -> AgentEvent {
+        AgentEvent::ModelError {
+            thread_name: Some("impl".to_string()),
+            message: format!("HTTP 400: Authorization: Bearer {MODEL_ERROR_CANARY}; no credits"),
+        }
+    }
+
+    #[tokio::test]
+    async fn model_error_sink_redacts_session_event_replay() {
+        let bus = SessionEventBus::new(Some("session-redaction".to_string()));
+        EventSink::bus(bus.clone()).emit(credential_bearing_model_error());
+
+        let events = bus.recent_events(None, 10);
+        assert_eq!(events.len(), 1);
+        let SessionEvent::Agent {
+            event: AgentEvent::ModelError { message, .. },
+        } = &events[0].event
+        else {
+            panic!("expected replayed ModelError");
+        };
+        assert!(!message.contains(MODEL_ERROR_CANARY), "{message}");
+        assert!(message.contains("[REDACTED]"), "{message}");
+        assert!(message.contains("no credits"), "{message}");
+    }
+
+    #[test]
+    fn model_error_stderr_process_helper() {
+        if std::env::var_os(MODEL_ERROR_STDERR_HELPER_ENV).is_some() {
+            EventSink::stderr_prefixed().emit(credential_bearing_model_error());
+        }
+    }
+
+    #[test]
+    fn model_error_sink_redacts_prefixed_stderr() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "events::tests::model_error_stderr_process_helper",
+                "--nocapture",
+            ])
+            .env(MODEL_ERROR_STDERR_HELPER_ENV, "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "stderr helper failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let stderr = String::from_utf8(output.stderr).unwrap();
+        assert!(!stderr.contains(MODEL_ERROR_CANARY), "{stderr}");
+        let event = stderr
+            .lines()
+            .find_map(decode_stderr_event)
+            .expect("prefixed ModelError on stderr");
+        let AgentEvent::ModelError { message, .. } = event else {
+            panic!("expected stderr ModelError");
+        };
+        assert!(message.contains("[REDACTED]"), "{message}");
+        assert!(message.contains("no credits"), "{message}");
+    }
 }

--- a/crates/nac-core/src/model/arcee.rs
+++ b/crates/nac-core/src/model/arcee.rs
@@ -747,6 +747,7 @@ async fn request_token_refresh(
             status,
             redirect_location.as_deref(),
             &body,
+            &[refresh_token],
         ));
     }
 
@@ -768,7 +769,7 @@ async fn request_token_refresh(
         _ => Err(anyhow!(
             "Arcee token refresh failed with HTTP {}: {}",
             status.as_u16(),
-            truncate(&body)
+            truncate(&redact_credentials(&body, &[refresh_token]))
         )),
     }
 }
@@ -887,13 +888,14 @@ async fn request_device_code(client: &Client, service: &ArceeAuthService) -> Res
             status,
             redirect_location.as_deref(),
             &body,
+            &[],
         ));
     }
     if !status.is_success() {
         return Err(anyhow!(
             "Arcee device-code request failed with HTTP {}: {}",
             status.as_u16(),
-            truncate(&body)
+            truncate(&redact_credentials(&body, &[]))
         ));
     }
 
@@ -978,6 +980,7 @@ where
                 status,
                 redirect_location.as_deref(),
                 &body,
+                &[device.device_code.as_str()],
             ));
         }
 
@@ -1009,7 +1012,7 @@ where
                 return Err(anyhow!(
                     "Arcee device authorization failed with HTTP {}: {}",
                     status.as_u16(),
-                    truncate(&body)
+                    truncate(&redact_credentials(&body, &[device.device_code.as_str()]))
                 ))
             }
         }
@@ -1066,15 +1069,21 @@ fn arcee_redirect_error(
     status: reqwest::StatusCode,
     location: Option<&str>,
     body: &str,
+    secrets: &[&str],
 ) -> anyhow::Error {
     let location = location
-        .map(|value| format!(" Location: {}.", truncate(value)))
+        .map(|value| {
+            format!(
+                " Location: {}.",
+                truncate(&redact_credentials(value, secrets))
+            )
+        })
         .unwrap_or_default();
     anyhow!(
         "Arcee {action} received HTTP {} redirect from {url}; automatic redirects are disabled and the request was not replayed.{} Body: {}",
         status.as_u16(),
         location,
-        truncate(body)
+        truncate(&redact_credentials(body, secrets))
     )
 }
 

--- a/crates/nac-core/src/model/arcee.rs
+++ b/crates/nac-core/src/model/arcee.rs
@@ -1007,7 +1007,13 @@ where
                     "Arcee device code expired; run `nac arcee-auth login` again"
                 ))
             }
-            Some(other) => return Err(anyhow!("Arcee device authorization failed: {other}")),
+            Some(other) => {
+                let message = redact_credentials(
+                    other,
+                    &[device.device_code.as_str(), device.user_code.as_str()],
+                );
+                return Err(anyhow!("Arcee device authorization failed: {message}"));
+            }
             None => {
                 return Err(anyhow!(
                     "Arcee device authorization failed with HTTP {}: {}",
@@ -1480,6 +1486,40 @@ mod tests {
             assert_eq!(requests.len(), 1);
             assert_device_request(&requests[0], "/app/v1/device/token");
         }
+    }
+
+    #[tokio::test]
+    async fn token_poll_redacts_device_code_from_structured_error() {
+        let secret = "sensitive-device-code";
+        let server = ScriptedServer::start(vec![ScriptedResponse::json(
+            "400 Bad Request",
+            format!(r#"{{"error":"{secret}"}}"#),
+        )]);
+        let device = DeviceCode {
+            device_code: secret.to_string(),
+            user_code: "ERROR".to_string(),
+            verification_uri_complete: "https://accounts.arcee.ai/device".to_string(),
+            interval_secs: 1,
+            expires_in_secs: 60,
+        };
+
+        let error = poll_device_code_with(
+            &no_redirect_client().unwrap(),
+            &ArceeAuthService::for_test(&server.base_url),
+            &device,
+            || 0,
+            |_| ready(()),
+        )
+        .await
+        .expect_err("terminal poll response should fail")
+        .to_string();
+        server.finish();
+
+        assert!(
+            !error.contains(secret),
+            "error leaked the echoed device credential: {error}"
+        );
+        assert!(error.contains(crate::model::redact::REDACTED), "{error}");
     }
 
     #[test]

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -1004,7 +1004,8 @@ async fn post_codex_json_with_retry_delay(
             // Codex often omits Content-Type on streamed responses. `Accept`
             // and `stream: true` make a missing header an SSE response here.
             let result = if content_type.is_none() || is_event_stream(content_type.as_deref()) {
-                stream_codex_responses(response, url, status, on_delta).await
+                stream_codex_responses(response, url, status, on_delta, &[auth.access.as_str()])
+                    .await
             } else {
                 let response_body = read_codex_body(response, url, status).await?;
                 parse_codex_success_body(
@@ -1086,8 +1087,9 @@ async fn stream_codex_responses(
     url: &str,
     status: StatusCode,
     on_delta: DeltaSink<'_>,
+    secrets: &[&str],
 ) -> std::result::Result<Value, CodexRequestError> {
-    read_sse_response(url, response, ResponsesStreamFold::new(on_delta))
+    read_sse_response(url, response, ResponsesStreamFold::new(on_delta), secrets)
         .await
         .map_err(|error| CodexRequestError {
             status: Some(status),

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -488,7 +488,7 @@ async fn request_device_code(client: &Client) -> Result<DeviceCode> {
         return Err(anyhow!(
             "Codex device-code request failed with HTTP {}: {}",
             status.as_u16(),
-            truncate(&body)
+            truncate(&redact_credentials(&body, &[]))
         ));
     }
 
@@ -701,7 +701,10 @@ async fn poll_device_code(client: &Client, device: &DeviceCode) -> Result<Author
             return Err(anyhow!(
                 "Codex device authorization failed with HTTP {}: {}",
                 status.as_u16(),
-                truncate(&body)
+                truncate(&redact_credentials(
+                    &body,
+                    &[device.device_auth_id.as_str(), device.user_code.as_str()]
+                ))
             ));
         }
 
@@ -737,7 +740,12 @@ async fn exchange_authorization_code(
         .await
         .context("failed to exchange Codex authorization code")?;
 
-    parse_token_response(response, "Codex token exchange").await
+    parse_token_response(
+        response,
+        "Codex token exchange",
+        &[code.code.as_str(), code.verifier.as_str()],
+    )
+    .await
 }
 
 async fn refresh_access_token(client: &Client, refresh_token: &str) -> Result<TokenResponse> {
@@ -753,10 +761,14 @@ async fn refresh_access_token(client: &Client, refresh_token: &str) -> Result<To
         .await
         .context("failed to refresh Codex access token")?;
 
-    parse_token_response(response, "Codex token refresh").await
+    parse_token_response(response, "Codex token refresh", &[refresh_token]).await
 }
 
-async fn parse_token_response(response: reqwest::Response, label: &str) -> Result<TokenResponse> {
+async fn parse_token_response(
+    response: reqwest::Response,
+    label: &str,
+    secrets: &[&str],
+) -> Result<TokenResponse> {
     let status = response.status();
     let body = response
         .text()
@@ -766,7 +778,7 @@ async fn parse_token_response(response: reqwest::Response, label: &str) -> Resul
         return Err(anyhow!(
             "{label} failed with HTTP {}: {}",
             status.as_u16(),
-            truncate(&body)
+            truncate(&redact_credentials(&body, secrets))
         ));
     }
     serde_json::from_str(&body).with_context(|| format!("failed to parse {label} response"))
@@ -995,7 +1007,13 @@ async fn post_codex_json_with_retry_delay(
                 stream_codex_responses(response, url, status, on_delta).await
             } else {
                 let response_body = read_codex_body(response, url, status).await?;
-                parse_codex_success_body(url, status, content_type.as_deref(), &response_body)
+                parse_codex_success_body(
+                    url,
+                    status,
+                    content_type.as_deref(),
+                    &response_body,
+                    &[auth.access.as_str()],
+                )
             };
             match result {
                 Ok(value) => return Ok(value),
@@ -1014,10 +1032,13 @@ async fn post_codex_json_with_retry_delay(
 
         let error = CodexRequestError {
             status: Some(status),
-            message: format!(
-                "HTTP {} from {url}: {}",
-                status.as_u16(),
-                truncate(&response_body)
+            message: redact_credentials(
+                &format!(
+                    "HTTP {} from {url}: {}",
+                    status.as_u16(),
+                    truncate(&redact_credentials(&response_body, &[auth.access.as_str()]))
+                ),
+                &[auth.access.as_str()],
             ),
             retryable_stream: false,
             observable_delta: false,
@@ -1081,6 +1102,7 @@ fn parse_codex_success_body(
     status: StatusCode,
     content_type: Option<&str>,
     response_body: &str,
+    secrets: &[&str],
 ) -> std::result::Result<Value, CodexRequestError> {
     if content_type
         .map(|value| value.contains("text/event-stream"))
@@ -1089,9 +1111,12 @@ fn parse_codex_success_body(
     {
         return parse_codex_sse_response(response_body).map_err(|error| CodexRequestError {
             status: Some(status),
-            message: format!(
-                "Failed to parse SSE response from {url}: {error}\nBody: {}",
-                truncate(response_body)
+            message: redact_credentials(
+                &format!(
+                    "Failed to parse SSE response from {url}: {error}\nBody: {}",
+                    truncate(&redact_credentials(response_body, secrets))
+                ),
+                secrets,
             ),
             retryable_stream: error.is_retryable(),
             observable_delta: false,
@@ -1100,9 +1125,12 @@ fn parse_codex_success_body(
 
     serde_json::from_str::<Value>(response_body).map_err(|error| CodexRequestError {
         status: Some(status),
-        message: format!(
-            "Failed to parse response from {url}: {error}\nBody: {}",
-            truncate(response_body)
+        message: redact_credentials(
+            &format!(
+                "Failed to parse response from {url}: {error}\nBody: {}",
+                truncate(&redact_credentials(response_body, secrets))
+            ),
+            secrets,
         ),
         retryable_stream: false,
         observable_delta: false,
@@ -2144,6 +2172,7 @@ mod tests {
             StatusCode::OK,
             Some("application/json"),
             body,
+            &[],
         )
         .unwrap_err();
 

--- a/crates/nac-core/src/model/chatgpt_codex.rs
+++ b/crates/nac-core/src/model/chatgpt_codex.rs
@@ -1033,13 +1033,14 @@ async fn post_codex_json_with_retry_delay(
 
         let error = CodexRequestError {
             status: Some(status),
-            message: redact_credentials(
-                &format!(
-                    "HTTP {} from {url}: {}",
-                    status.as_u16(),
-                    truncate(&redact_credentials(&response_body, &[auth.access.as_str()]))
-                ),
-                &[auth.access.as_str()],
+            message: format!(
+                "HTTP {} from {}: {}",
+                status.as_u16(),
+                redact_credentials(url, &[]),
+                truncate(&redact_credentials(
+                    &response_body,
+                    &[auth.access.as_str()],
+                ))
             ),
             retryable_stream: false,
             observable_delta: false,
@@ -1068,7 +1069,10 @@ async fn read_codex_body(
 ) -> std::result::Result<String, CodexRequestError> {
     response.text().await.map_err(|error| CodexRequestError {
         status: Some(status),
-        message: format!("Failed to read response body from {url}: {error}"),
+        message: format!(
+            "Failed to read response body from {}: {error}",
+            redact_credentials(url, &[])
+        ),
         retryable_stream: false,
         observable_delta: false,
     })
@@ -1111,28 +1115,27 @@ fn parse_codex_success_body(
         .unwrap_or(false)
         || response_body.lines().any(|line| line.starts_with("data:"))
     {
-        return parse_codex_sse_response(response_body).map_err(|error| CodexRequestError {
-            status: Some(status),
-            message: redact_credentials(
-                &format!(
-                    "Failed to parse SSE response from {url}: {error}\nBody: {}",
+        return parse_codex_sse_response(response_body).map_err(|error| {
+            let message = redact_credentials(&error.to_string(), secrets);
+            CodexRequestError {
+                status: Some(status),
+                message: format!(
+                    "Failed to parse SSE response from {}: {message}\nBody: {}",
+                    redact_credentials(url, &[]),
                     truncate(&redact_credentials(response_body, secrets))
                 ),
-                secrets,
-            ),
-            retryable_stream: error.is_retryable(),
-            observable_delta: false,
+                retryable_stream: error.is_retryable(),
+                observable_delta: false,
+            }
         });
     }
 
     serde_json::from_str::<Value>(response_body).map_err(|error| CodexRequestError {
         status: Some(status),
-        message: redact_credentials(
-            &format!(
-                "Failed to parse response from {url}: {error}\nBody: {}",
-                truncate(&redact_credentials(response_body, secrets))
-            ),
-            secrets,
+        message: format!(
+            "Failed to parse response from {}: {error}\nBody: {}",
+            redact_credentials(url, &[]),
+            truncate(&redact_credentials(response_body, secrets))
         ),
         retryable_stream: false,
         observable_delta: false,

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -2,7 +2,7 @@ use super::anthropic_stream::AnthropicStreamFold;
 use super::chat_stream::ChatStreamFold;
 use super::pseudo_tool_calls::finalize_chat_tool_recovery;
 use super::responses_stream::ResponsesStreamFold;
-use super::sse::{read_sse_response, with_source_chain, StreamFold};
+use super::sse::{read_sse_response_with_extra_headers, with_source_chain, StreamFold};
 use super::*;
 use anyhow::Context;
 
@@ -733,14 +733,18 @@ impl ModelClient {
         let body_text = read_response_body(response).await?;
         serde_json::from_str::<Value>(&body_text).map_err(|e| ModelHttpError {
             status: Some(status.as_u16()),
-            message: redact_credentials(
-                &format!(
-                    "Failed to parse response from {}: {}\nBody: {}",
-                    url,
-                    e,
-                    truncate_utf8(&redact_credentials(&body_text, secrets), 500)
-                ),
-                secrets,
+            message: format!(
+                "Failed to parse response from {}: {}\nBody: {}",
+                redact_credentials(url, &[]),
+                e,
+                truncate_utf8(
+                    &redact_credentials_with_extra_headers(
+                        &body_text,
+                        secrets,
+                        &self.extra_headers,
+                    ),
+                    500,
+                )
             ),
         })
     }
@@ -784,7 +788,7 @@ impl ModelClient {
                         status: None,
                         message: format!(
                             "HTTP request failed for {}: {}",
-                            url,
+                            redact_credentials(url, &[]),
                             with_source_chain(&e)
                         ),
                     };
@@ -807,41 +811,57 @@ impl ModelClient {
             }
 
             let body = read_response_body(response).await?;
+            let safe_url = redact_credentials(url, &[]);
 
             if status.is_redirection() {
                 let location = redirect_location.as_deref().map(|value| {
                     format!(
                         " Location: {}.",
-                        truncate_utf8(&redact_credentials(value, secrets), 500)
+                        truncate_utf8(
+                            &redact_credentials_with_extra_headers(
+                                value,
+                                secrets,
+                                &self.extra_headers,
+                            ),
+                            500,
+                        )
                     )
                 });
                 let location = location.unwrap_or_default();
                 return Err(ModelHttpError {
                     status: Some(status.as_u16()),
-                    message: redact_credentials(
-                        &format!(
-                            "Model request for backend '{}' received HTTP {} redirect from {}; automatic redirects are disabled and the request was not replayed.{} Body: {}",
-                            self.backend,
-                            status.as_u16(),
-                            url,
-                            location,
-                            truncate_utf8(&redact_json_body(&body, secrets), 500)
-                        ),
-                        secrets,
+                    message: format!(
+                        "Model request for backend '{}' received HTTP {} redirect from {}; automatic redirects are disabled and the request was not replayed.{} Body: {}",
+                        self.backend,
+                        status.as_u16(),
+                        safe_url,
+                        location,
+                        truncate_utf8(
+                            &redact_json_body_with_extra_headers(
+                                &body,
+                                secrets,
+                                &self.extra_headers,
+                            ),
+                            500,
+                        )
                     ),
                 });
             }
 
             let error = ModelHttpError {
                 status: Some(status.as_u16()),
-                message: redact_credentials(
-                    &format!(
-                        "HTTP {} from {}: {}",
-                        status.as_u16(),
-                        url,
-                        truncate_utf8(&redact_json_body(&body, secrets), 500)
-                    ),
-                    secrets,
+                message: format!(
+                    "HTTP {} from {}: {}",
+                    status.as_u16(),
+                    safe_url,
+                    truncate_utf8(
+                        &redact_json_body_with_extra_headers(
+                            &body,
+                            secrets,
+                            &self.extra_headers,
+                        ),
+                        500,
+                    )
                 ),
             };
 
@@ -903,7 +923,15 @@ impl ModelClient {
             let response = self
                 .send_with_retry_headers(url, body, apply_headers, secrets)
                 .await?;
-            match read_sse_response(url, response, make_fold(), secrets).await {
+            match read_sse_response_with_extra_headers(
+                url,
+                response,
+                make_fold(),
+                secrets,
+                &self.extra_headers,
+            )
+            .await
+            {
                 Ok(value) => return Ok(value),
                 Err(error) if error.is_retryable() && !error.has_observable_delta() => {
                     last_error = Some(ModelHttpError {

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -903,7 +903,7 @@ impl ModelClient {
             let response = self
                 .send_with_retry_headers(url, body, apply_headers, secrets)
                 .await?;
-            match read_sse_response(url, response, make_fold()).await {
+            match read_sse_response(url, response, make_fold(), secrets).await {
                 Ok(value) => return Ok(value),
                 Err(error) if error.is_retryable() && !error.has_observable_delta() => {
                     last_error = Some(ModelHttpError {

--- a/crates/nac-core/src/model/client/mod.rs
+++ b/crates/nac-core/src/model/client/mod.rs
@@ -675,12 +675,16 @@ impl ModelClient {
                     body,
                     |request| request.header("Authorization", format!("Bearer {token}")),
                     || ChatStreamFold::new(Some(on_delta), reasoning_field),
+                    &[token],
                 )
                 .await;
         }
-        self.try_post_json_with_retry_headers(url, body, |request| {
-            request.header("Authorization", format!("Bearer {token}"))
-        })
+        self.try_post_json_with_retry_headers(
+            url,
+            body,
+            |request| request.header("Authorization", format!("Bearer {token}")),
+            &[token],
+        )
         .await
     }
 
@@ -707,7 +711,7 @@ impl ModelClient {
     where
         F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
     {
-        self.try_post_json_with_retry_headers(url, body, apply_headers)
+        self.try_post_json_with_retry_headers(url, body, apply_headers, &[self.api_key.as_str()])
             .await
             .map_err(|error| anyhow!(error.message))
     }
@@ -717,22 +721,26 @@ impl ModelClient {
         url: &str,
         body: &Value,
         apply_headers: F,
+        secrets: &[&str],
     ) -> std::result::Result<Value, ModelHttpError>
     where
         F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
     {
         let response = self
-            .send_with_retry_headers(url, body, apply_headers)
+            .send_with_retry_headers(url, body, apply_headers, secrets)
             .await?;
         let status = response.status();
         let body_text = read_response_body(response).await?;
         serde_json::from_str::<Value>(&body_text).map_err(|e| ModelHttpError {
             status: Some(status.as_u16()),
-            message: format!(
-                "Failed to parse response from {}: {}\nBody: {}",
-                url,
-                e,
-                truncate_utf8(&body_text, 500)
+            message: redact_credentials(
+                &format!(
+                    "Failed to parse response from {}: {}\nBody: {}",
+                    url,
+                    e,
+                    truncate_utf8(&redact_credentials(&body_text, secrets), 500)
+                ),
+                secrets,
             ),
         })
     }
@@ -745,6 +753,7 @@ impl ModelClient {
         url: &str,
         body: &Value,
         apply_headers: F,
+        secrets: &[&str],
     ) -> std::result::Result<reqwest::Response, ModelHttpError>
     where
         F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
@@ -800,30 +809,39 @@ impl ModelClient {
             let body = read_response_body(response).await?;
 
             if status.is_redirection() {
-                let location = redirect_location
-                    .as_deref()
-                    .map(|value| format!(" Location: {}.", truncate_utf8(value, 500)))
-                    .unwrap_or_default();
+                let location = redirect_location.as_deref().map(|value| {
+                    format!(
+                        " Location: {}.",
+                        truncate_utf8(&redact_credentials(value, secrets), 500)
+                    )
+                });
+                let location = location.unwrap_or_default();
                 return Err(ModelHttpError {
                     status: Some(status.as_u16()),
-                    message: format!(
-                        "Model request for backend '{}' received HTTP {} redirect from {}; automatic redirects are disabled and the request was not replayed.{} Body: {}",
-                        self.backend,
-                        status.as_u16(),
-                        url,
-                        location,
-                        truncate_utf8(&body, 500)
+                    message: redact_credentials(
+                        &format!(
+                            "Model request for backend '{}' received HTTP {} redirect from {}; automatic redirects are disabled and the request was not replayed.{} Body: {}",
+                            self.backend,
+                            status.as_u16(),
+                            url,
+                            location,
+                            truncate_utf8(&redact_json_body(&body, secrets), 500)
+                        ),
+                        secrets,
                     ),
                 });
             }
 
             let error = ModelHttpError {
                 status: Some(status.as_u16()),
-                message: format!(
-                    "HTTP {} from {}: {}",
-                    status.as_u16(),
-                    url,
-                    truncate_utf8(&body, 500)
+                message: redact_credentials(
+                    &format!(
+                        "HTTP {} from {}: {}",
+                        status.as_u16(),
+                        url,
+                        truncate_utf8(&redact_json_body(&body, secrets), 500)
+                    ),
+                    secrets,
                 ),
             };
 
@@ -856,9 +874,15 @@ impl ModelClient {
         MakeFold: Fn() -> Fold,
         Fold: StreamFold,
     {
-        self.try_post_sse_with_retry_headers(url, body, apply_headers, make_fold)
-            .await
-            .map_err(|error| anyhow!(error.message))
+        self.try_post_sse_with_retry_headers(
+            url,
+            body,
+            apply_headers,
+            make_fold,
+            &[self.api_key.as_str()],
+        )
+        .await
+        .map_err(|error| anyhow!(error.message))
     }
 
     async fn try_post_sse_with_retry_headers<F, MakeFold, Fold>(
@@ -867,6 +891,7 @@ impl ModelClient {
         body: &Value,
         apply_headers: F,
         make_fold: MakeFold,
+        secrets: &[&str],
     ) -> std::result::Result<Value, ModelHttpError>
     where
         F: Fn(reqwest::RequestBuilder) -> reqwest::RequestBuilder + Copy,
@@ -876,7 +901,7 @@ impl ModelClient {
         let mut last_error = None;
         for attempt in 0..10 {
             let response = self
-                .send_with_retry_headers(url, body, apply_headers)
+                .send_with_retry_headers(url, body, apply_headers, secrets)
                 .await?;
             match read_sse_response(url, response, make_fold()).await {
                 Ok(value) => return Ok(value),

--- a/crates/nac-core/src/model/client/tests/http_contract.rs
+++ b/crates/nac-core/src/model/client/tests/http_contract.rs
@@ -606,17 +606,21 @@ async fn arcee_multibyte_error_body_does_not_panic() {
 
 #[tokio::test]
 async fn provider_error_body_echoing_credentials_is_redacted() {
-    let secret = "sk-canary-echo-0123456789";
+    let api_secret = "sk-canary-echo-0123456789";
+    let extra_header_secret = "4";
     let body = format!(
-        "{{\"error\":{{\"message\":\"invalid request\",\"authorization\":\"Bearer {secret}\",\"x-api-key\":\"{secret}\"}}}}"
+        "{{\"error\":{{\"message\":\"invalid request api={api_secret} extra={extra_header_secret}\",\"authorization\":\"Bearer {api_secret}\"}}}}"
     );
     let server = ScriptedServer::start(vec![ScriptedResponse::json("400 Bad Request", body)]);
     let mut client = test_model_client(
         BackendKind::OpenAiResponses,
         server.base_url.clone(),
-        std::collections::BTreeMap::new(),
+        std::collections::BTreeMap::from([(
+            "x-provider-secret".to_string(),
+            extra_header_secret.to_string(),
+        )]),
     );
-    client.api_key = secret.to_string();
+    client.api_key = api_secret.to_string();
 
     let error = send_provider_test_request(&client, &format!("{}/v1/responses", server.base_url))
         .await
@@ -627,11 +631,22 @@ async fn provider_error_body_echoing_credentials_is_redacted() {
     assert_eq!(requests.len(), 1);
     assert_eq!(
         requests[0].headers.get("authorization").map(String::as_str),
-        Some(format!("Bearer {secret}")).as_deref()
+        Some(format!("Bearer {api_secret}")).as_deref()
+    );
+    assert_eq!(
+        requests[0]
+            .headers
+            .get("x-provider-secret")
+            .map(String::as_str),
+        Some(extra_header_secret)
     );
     assert!(
-        !error.contains(secret),
-        "error leaked the echoed credential: {error}"
+        !error.contains(api_secret),
+        "error leaked the echoed API credential: {error}"
+    );
+    assert!(
+        !error.contains("extra=4"),
+        "error leaked the echoed short extra-header credential: {error}"
     );
     assert!(
         error.contains("[REDACTED]"),

--- a/crates/nac-core/src/model/client/tests/http_contract.rs
+++ b/crates/nac-core/src/model/client/tests/http_contract.rs
@@ -604,6 +604,46 @@ async fn arcee_multibyte_error_body_does_not_panic() {
     );
 }
 
+#[tokio::test]
+async fn provider_error_body_echoing_credentials_is_redacted() {
+    let secret = "sk-canary-echo-0123456789";
+    let body = format!(
+        "{{\"error\":{{\"message\":\"invalid request\",\"authorization\":\"Bearer {secret}\",\"x-api-key\":\"{secret}\"}}}}"
+    );
+    let server = ScriptedServer::start(vec![ScriptedResponse::json("400 Bad Request", body)]);
+    let mut client = test_model_client(
+        BackendKind::OpenAiResponses,
+        server.base_url.clone(),
+        std::collections::BTreeMap::new(),
+    );
+    client.api_key = secret.to_string();
+
+    let error = send_provider_test_request(&client, &format!("{}/v1/responses", server.base_url))
+        .await
+        .expect_err("HTTP 400 should return an error")
+        .to_string();
+    let requests = server.finish();
+
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0].headers.get("authorization").map(String::as_str),
+        Some(format!("Bearer {secret}")).as_deref()
+    );
+    assert!(
+        !error.contains(secret),
+        "error leaked the echoed credential: {error}"
+    );
+    assert!(
+        error.contains("[REDACTED]"),
+        "error did not mark redaction: {error}"
+    );
+    assert!(error.contains("HTTP 400"), "unexpected error: {error}");
+    assert!(
+        error.contains("invalid request"),
+        "non-secret body content must survive: {error}"
+    );
+}
+
 // --- S6: api-axis dispatch + catalog-driven max_tokens -------------------
 
 #[tokio::test]

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -42,6 +42,7 @@ mod client;
 mod history;
 mod providers;
 mod pseudo_tool_calls;
+mod redact;
 mod requests;
 mod responses;
 mod responses_stream;
@@ -67,6 +68,7 @@ pub use providers::{
     list_managed_provider_models, list_provider_models, provider_default_base_url,
     provider_uses_api_key, ProviderModel,
 };
+pub(crate) use redact::{redact_credentials, redact_json_body};
 
 /// Resolve the API key a backend would use at run time.
 ///

--- a/crates/nac-core/src/model/mod.rs
+++ b/crates/nac-core/src/model/mod.rs
@@ -68,7 +68,9 @@ pub use providers::{
     list_managed_provider_models, list_provider_models, provider_default_base_url,
     provider_uses_api_key, ProviderModel,
 };
-pub(crate) use redact::{redact_credentials, redact_json_body};
+pub(crate) use redact::{
+    redact_credentials, redact_credentials_with_extra_headers, redact_json_body_with_extra_headers,
+};
 
 /// Resolve the API key a backend would use at run time.
 ///

--- a/crates/nac-core/src/model/redact.rs
+++ b/crates/nac-core/src/model/redact.rs
@@ -1,0 +1,296 @@
+//! Credential redaction for provider error text.
+//!
+//! Provider HTTP error bodies and stream error events are surfaced to the user
+//! and persisted into session events and server logs. A provider that echoes
+//! request headers or bodies back in an error can therefore leak API keys and
+//! bearer tokens. This module strips known secrets and recognizable credential
+//! shapes out of that text before it is embedded in an error message.
+//!
+//! Redaction is deliberately conservative: exact secret values are replaced
+//! wherever they appear, and header-shaped credential lines (`Authorization`,
+//! `x-api-key`, ...) are masked even when the exact value is not known. Ordinary
+//! error prose is left intact so the actionable part of a provider message
+//! ("no credits", "bad key", "rate limit") survives.
+
+use regex::Regex;
+use serde_json::Value;
+use std::sync::OnceLock;
+
+/// Marker substituted for any credential material found in provider text.
+pub(crate) const REDACTED: &str = "[REDACTED]";
+
+/// JSON object keys whose values are always treated as credentials, matched
+/// case-insensitively.
+const SENSITIVE_JSON_KEYS: [&str; 13] = [
+    "authorization",
+    "x-api-key",
+    "api_key",
+    "apikey",
+    "api-key",
+    "access_token",
+    "refresh_token",
+    "token",
+    "secret",
+    "password",
+    "key",
+    "cookie",
+    "set-cookie",
+];
+
+/// Secrets shorter than this are not replaced verbatim: a one- or two-character
+/// "secret" would otherwise rewrite ordinary words. Header-shape patterns still
+/// catch short credentials when they appear in a recognizable form.
+const MIN_EXACT_SECRET_LEN: usize = 4;
+
+/// `Authorization: Bearer <token>` / `Authorization: Basic <b64>`, with or
+/// without the surrounding quotes JSON would add.
+fn header_with_scheme_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"(?i)(authorization|proxy-authorization)\s*"?\s*[:=]\s*"?\s*(?:bearer|basic)\s+[^\s,;"]+"#,
+        )
+        .expect("valid credential header regex")
+    })
+}
+
+/// Any other credential header value, bare or quoted.
+fn header_value_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)(authorization|proxy-authorization|x-api-key|api-key|apikey)\s*"?\s*[:=]\s*"?\s*[^\s,;"]+"#)
+            .expect("valid credential header regex")
+    })
+}
+
+/// A `Bearer`/`Basic` token standing alone in prose, without a header name.
+fn bearer_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=:-]{4,}")
+            .expect("valid bearer token regex")
+    })
+}
+
+/// `https://user:pass@host` userinfo embedded in a URL.
+fn url_userinfo_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(https?://)[^/\s:@]+:[^/\s@]+@").expect("valid URL userinfo regex")
+    })
+}
+
+/// Redact credentials from provider-controlled text.
+///
+/// Exact secret values are replaced first (longest first, so a secret that is a
+/// prefix of another cannot leave a tail behind), then recognizable credential
+/// shapes — `Authorization`/`x-api-key` header lines, `Bearer`/`Basic` tokens,
+/// and URL userinfo — are masked even when the exact value is not known.
+pub(crate) fn redact_credentials(text: &str, secrets: &[&str]) -> String {
+    let mut redacted = text.to_string();
+    let mut known: Vec<&str> = secrets
+        .iter()
+        .copied()
+        .filter(|secret| !secret.is_empty() && secret.len() >= MIN_EXACT_SECRET_LEN)
+        .collect();
+    known.sort_by_key(|secret| std::cmp::Reverse(secret.len()));
+    for secret in known {
+        redacted = redacted.replace(secret, REDACTED);
+    }
+    redact_patterns(&redacted)
+}
+
+fn redact_patterns(text: &str) -> String {
+    let mut redacted = header_with_scheme_re()
+        .replace_all(text, "$1: [REDACTED]")
+        .into_owned();
+    redacted = header_value_re()
+        .replace_all(&redacted, "$1: [REDACTED]")
+        .into_owned();
+    redacted = bearer_token_re()
+        .replace_all(&redacted, "$1 [REDACTED]")
+        .into_owned();
+    redacted = url_userinfo_re()
+        .replace_all(&redacted, "$1[REDACTED]@")
+        .into_owned();
+    redacted
+}
+
+/// Redact credentials from a provider response body.
+///
+/// When the body parses as JSON, sensitive keys are masked and every string
+/// value is passed through [`redact_credentials`]; otherwise the whole body is
+/// treated as plain text. The result is always a `String`, so callers can
+/// truncate it afterwards without ever truncating a secret first.
+pub(crate) fn redact_json_body(body: &str, secrets: &[&str]) -> String {
+    match serde_json::from_str::<Value>(body) {
+        Ok(value) => serde_json::to_string(&redact_json_value(value, secrets))
+            .unwrap_or_else(|_| redact_credentials(body, secrets)),
+        Err(_) => redact_credentials(body, secrets),
+    }
+}
+
+fn redact_json_value(value: Value, secrets: &[&str]) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut redacted = serde_json::Map::with_capacity(map.len());
+            for (key, value) in map {
+                if SENSITIVE_JSON_KEYS
+                    .iter()
+                    .any(|sensitive| key.eq_ignore_ascii_case(sensitive))
+                {
+                    redacted.insert(key, Value::String(REDACTED.to_string()));
+                } else {
+                    redacted.insert(key, redact_json_value(value, secrets));
+                }
+            }
+            Value::Object(redacted)
+        }
+        Value::Array(items) => Value::Array(
+            items
+                .into_iter()
+                .map(|item| redact_json_value(item, secrets))
+                .collect(),
+        ),
+        Value::String(text) => Value::String(redact_credentials(&text, secrets)),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CANARY: &str = "sk-canary-0123456789";
+
+    #[test]
+    fn replaces_exact_secret_values_anywhere() {
+        let redacted = redact_credentials(
+            &format!("invalid key {CANARY} in request body {CANARY} again"),
+            &[CANARY],
+        );
+        assert!(!redacted.contains(CANARY));
+        assert_eq!(redacted.matches(REDACTED).count(), 2);
+        assert!(redacted.contains("invalid key"));
+    }
+
+    #[test]
+    fn replaces_longest_secret_first() {
+        let redacted = redact_credentials(
+            "prefix-secret and prefix-secret-suffix",
+            &["prefix-secret", "prefix-secret-suffix"],
+        );
+        assert!(!redacted.contains("prefix-secret"));
+        assert_eq!(redacted.matches(REDACTED).count(), 2);
+    }
+
+    #[test]
+    fn ignores_empty_and_short_secrets_for_verbatim_replacement() {
+        assert_eq!(redact_credentials("abc", &["abc"]), "abc");
+        assert_eq!(redact_credentials("plain", &["", "x"]), "plain");
+    }
+
+    #[test]
+    fn redacts_authorization_header_with_scheme() {
+        for text in [
+            "Authorization: Bearer sk-live-abcdef",
+            "authorization: basic dXNlcjpwYXNz",
+            r#""authorization": "Bearer sk-live-abcdef""#,
+            "Proxy-Authorization: Bearer sk-live-abcdef",
+        ] {
+            let redacted = redact_credentials(text, &[]);
+            assert!(!redacted.contains("sk-live-abcdef"), "{text} -> {redacted}");
+            assert!(!redacted.contains("dXNlcjpwYXNz"), "{text} -> {redacted}");
+            assert!(redacted.contains(REDACTED), "{text} -> {redacted}");
+        }
+    }
+
+    #[test]
+    fn redacts_bare_credential_headers() {
+        for text in [
+            "x-api-key: sk-live-abcdef",
+            "X-API-KEY: sk-live-abcdef",
+            "api-key: sk-live-abcdef",
+            "apikey: sk-live-abcdef",
+            "Authorization: sk-live-abcdef",
+        ] {
+            let redacted = redact_credentials(text, &[]);
+            assert!(!redacted.contains("sk-live-abcdef"), "{text} -> {redacted}");
+            assert!(redacted.contains(REDACTED), "{text} -> {redacted}");
+        }
+    }
+
+    #[test]
+    fn redacts_standalone_bearer_tokens_in_prose() {
+        let redacted = redact_credentials("the token Bearer sk-live-abcdef was rejected", &[]);
+        assert!(!redacted.contains("sk-live-abcdef"));
+        assert!(redacted.contains("Bearer [REDACTED]"));
+        assert!(redacted.contains("was rejected"));
+    }
+
+    #[test]
+    fn redacts_url_userinfo() {
+        let redacted =
+            redact_credentials("endpoint https://user:pass@api.example.com/v1 refused", &[]);
+        assert!(!redacted.contains("user:pass"));
+        assert!(redacted.contains("https://[REDACTED]@api.example.com"));
+        // Ports are not userinfo and must survive.
+        assert_eq!(
+            redact_credentials("http://host:8080/path", &[]),
+            "http://host:8080/path"
+        );
+    }
+
+    #[test]
+    fn preserves_ordinary_error_prose() {
+        let text = "no credits remaining; rate limit exceeded; context too long";
+        assert_eq!(redact_credentials(text, &[]), text);
+    }
+
+    #[test]
+    fn redacts_sensitive_json_keys_case_insensitively() {
+        let body = r#"{"error":{"message":"bad request","API_KEY":"sk-json-1","Authorization":"Bearer sk-json-2","access_token":"tok-json-3","refresh_token":"tok-json-4","token":"tok-json-5","secret":"s-json-6","password":"p-json-7","key":"k-json-8","cookie":"c-json-9","set-cookie":"sc-json-10","api_key":"ak-json-11","apikey":"ak-json-12","api-key":"ak-json-13","x-api-key":"xk-json-14"}}"#;
+        let redacted = redact_json_body(body, &[]);
+        assert!(!redacted.contains("sk-json-1"));
+        assert!(!redacted.contains("sk-json-2"));
+        assert!(!redacted.contains("tok-json-3"));
+        assert!(!redacted.contains("tok-json-4"));
+        assert!(!redacted.contains("tok-json-5"));
+        assert!(!redacted.contains("s-json-6"));
+        assert!(!redacted.contains("p-json-7"));
+        assert!(!redacted.contains("k-json-8"));
+        assert!(!redacted.contains("c-json-9"));
+        assert!(!redacted.contains("sc-json-10"));
+        assert!(!redacted.contains("ak-json-11"));
+        assert!(!redacted.contains("ak-json-12"));
+        assert!(!redacted.contains("ak-json-13"));
+        assert!(!redacted.contains("xk-json-14"));
+        assert!(redacted.contains("\"message\":\"bad request\""));
+        assert_eq!(redacted.matches(REDACTED).count(), 14);
+    }
+
+    #[test]
+    fn redacts_secret_values_inside_json_strings() {
+        let body = format!(r#"{{"error":"invalid key {CANARY} supplied"}}"#);
+        let redacted = redact_json_body(&body, &[CANARY]);
+        assert!(!redacted.contains(CANARY));
+        assert!(redacted.contains("invalid key [REDACTED] supplied"));
+    }
+
+    #[test]
+    fn falls_back_to_text_redaction_for_non_json_bodies() {
+        let body = format!("plain text with {CANARY} inside");
+        let redacted = redact_json_body(&body, &[CANARY]);
+        assert!(!redacted.contains(CANARY));
+        assert!(redacted.contains("plain text with [REDACTED] inside"));
+    }
+
+    #[test]
+    fn redacts_nested_arrays_and_objects() {
+        let body = r#"{"errors":[{"key":"sk-nested-1"},{"detail":{"token":"tok-nested-2"}}]}"#;
+        let redacted = redact_json_body(body, &[]);
+        assert!(!redacted.contains("sk-nested-1"));
+        assert!(!redacted.contains("tok-nested-2"));
+        assert_eq!(redacted.matches(REDACTED).count(), 2);
+    }
+}

--- a/crates/nac-core/src/model/redact.rs
+++ b/crates/nac-core/src/model/redact.rs
@@ -12,9 +12,11 @@
 //! error prose is left intact so the actionable part of a provider message
 //! ("no credits", "bad key", "rate limit") survives.
 
+use std::collections::BTreeMap;
+use std::sync::OnceLock;
+
 use regex::Regex;
 use serde_json::Value;
-use std::sync::OnceLock;
 
 /// Marker substituted for any credential material found in provider text.
 pub(crate) const REDACTED: &str = "[REDACTED]";
@@ -36,11 +38,6 @@ const SENSITIVE_JSON_KEYS: [&str; 13] = [
     "cookie",
     "set-cookie",
 ];
-
-/// Secrets shorter than this are not replaced verbatim: a one- or two-character
-/// "secret" would otherwise rewrite ordinary words. Header-shape patterns still
-/// catch short credentials when they appear in a recognizable form.
-const MIN_EXACT_SECRET_LEN: usize = 4;
 
 /// `Authorization: Bearer <token>` / `Authorization: Basic <b64>`, with or
 /// without the surrounding quotes JSON would add.
@@ -89,43 +86,87 @@ fn url_userinfo_re() -> &'static Regex {
 /// shapes — `Authorization`/`x-api-key` header lines, `Bearer`/`Basic` tokens,
 /// and URL userinfo — are masked even when the exact value is not known.
 pub(crate) fn redact_credentials(text: &str, secrets: &[&str]) -> String {
-    let mut redacted = text.to_string();
-    let mut known: Vec<&str> = secrets
-        .iter()
-        .copied()
-        .filter(|secret| !secret.is_empty() && secret.len() >= MIN_EXACT_SECRET_LEN)
-        .collect();
-    known.sort_by_key(|secret| std::cmp::Reverse(secret.len()));
-    for secret in known {
-        redacted = redacted.replace(secret, REDACTED);
-    }
-    redact_patterns(&redacted)
+    CredentialRedactor::new(secrets.iter().copied()).redact(text)
 }
 
-fn redact_patterns(text: &str) -> String {
-    let mut redacted = header_with_scheme_re()
-        .replace_all(text, "$1: [REDACTED]")
-        .into_owned();
-    redacted = header_value_re()
-        .replace_all(&redacted, "$1: [REDACTED]")
-        .into_owned();
-    redacted = bearer_token_re()
-        .replace_all(&redacted, |captures: &regex::Captures<'_>| {
-            // Ordinary prose ("bearer token", "basic authentication") is all
-            // lowercase letters; credential material carries at least one
-            // digit, uppercase letter, or symbol. Masking a prose word would
-            // hide the actionable part of a provider error.
-            let token = &captures[2];
-            if token.bytes().any(|byte| !byte.is_ascii_lowercase()) {
-                format!("{} [REDACTED]", &captures[1])
-            } else {
-                captures[0].to_string()
-            }
-        })
-        .into_owned();
-    redacted = url_userinfo_re()
-        .replace_all(&redacted, "$1[REDACTED]@")
-        .into_owned();
+/// Redact known credentials plus every configured extra-header value.
+///
+/// Extra headers may use provider-specific names that pattern matching cannot
+/// recognize, so their values must travel with the request's ordinary secrets.
+pub(crate) fn redact_credentials_with_extra_headers(
+    text: &str,
+    secrets: &[&str],
+    extra_headers: &BTreeMap<String, String>,
+) -> String {
+    CredentialRedactor::new(
+        secrets
+            .iter()
+            .copied()
+            .chain(extra_headers.values().map(String::as_str)),
+    )
+    .redact(text)
+}
+
+struct CredentialRedactor<'a> {
+    known: Vec<&'a str>,
+}
+
+impl<'a> CredentialRedactor<'a> {
+    fn new(secrets: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut known: Vec<&str> = secrets
+            .into_iter()
+            .filter(|secret| !secret.is_empty())
+            .collect();
+        known.sort_unstable_by(|left, right| {
+            right.len().cmp(&left.len()).then_with(|| left.cmp(right))
+        });
+        known.dedup();
+        Self { known }
+    }
+
+    fn redact(&self, text: &str) -> String {
+        let mut redacted = text.to_string();
+        for secret in &self.known {
+            redacted = redacted.replace(secret, REDACTED);
+        }
+        redact_patterns(redacted)
+    }
+}
+
+fn redact_patterns(mut redacted: String) -> String {
+    let pattern = header_with_scheme_re();
+    if pattern.is_match(&redacted) {
+        redacted = pattern
+            .replace_all(&redacted, "$1: [REDACTED]")
+            .into_owned();
+    }
+    let pattern = header_value_re();
+    if pattern.is_match(&redacted) {
+        redacted = pattern
+            .replace_all(&redacted, "$1: [REDACTED]")
+            .into_owned();
+    }
+    let pattern = bearer_token_re();
+    if pattern.is_match(&redacted) {
+        redacted = pattern
+            .replace_all(&redacted, |captures: &regex::Captures<'_>| {
+                // Ordinary prose ("bearer token", "basic authentication") is all
+                // lowercase letters; credential material carries at least one
+                // digit, uppercase letter, or symbol. Masking a prose word would
+                // hide the actionable part of a provider error.
+                let token = &captures[2];
+                if token.bytes().any(|byte| !byte.is_ascii_lowercase()) {
+                    format!("{} [REDACTED]", &captures[1])
+                } else {
+                    captures[0].to_string()
+                }
+            })
+            .into_owned();
+    }
+    let pattern = url_userinfo_re();
+    if pattern.is_match(&redacted) {
+        redacted = pattern.replace_all(&redacted, "$1[REDACTED]@").into_owned();
+    }
     redacted
 }
 
@@ -135,15 +176,36 @@ fn redact_patterns(text: &str) -> String {
 /// value is passed through [`redact_credentials`]; otherwise the whole body is
 /// treated as plain text. The result is always a `String`, so callers can
 /// truncate it afterwards without ever truncating a secret first.
+#[cfg(test)]
 pub(crate) fn redact_json_body(body: &str, secrets: &[&str]) -> String {
+    redact_json_body_with(body, &CredentialRedactor::new(secrets.iter().copied()))
+}
+
+pub(crate) fn redact_json_body_with_extra_headers(
+    body: &str,
+    secrets: &[&str],
+    extra_headers: &BTreeMap<String, String>,
+) -> String {
+    redact_json_body_with(
+        body,
+        &CredentialRedactor::new(
+            secrets
+                .iter()
+                .copied()
+                .chain(extra_headers.values().map(String::as_str)),
+        ),
+    )
+}
+
+fn redact_json_body_with(body: &str, redactor: &CredentialRedactor<'_>) -> String {
     match serde_json::from_str::<Value>(body) {
-        Ok(value) => serde_json::to_string(&redact_json_value(value, secrets))
-            .unwrap_or_else(|_| redact_credentials(body, secrets)),
-        Err(_) => redact_credentials(body, secrets),
+        Ok(value) => serde_json::to_string(&redact_json_value(value, redactor))
+            .unwrap_or_else(|_| redactor.redact(body)),
+        Err(_) => redactor.redact(body),
     }
 }
 
-fn redact_json_value(value: Value, secrets: &[&str]) -> Value {
+fn redact_json_value(value: Value, redactor: &CredentialRedactor<'_>) -> Value {
     match value {
         Value::Object(map) => {
             let mut redacted = serde_json::Map::with_capacity(map.len());
@@ -154,7 +216,7 @@ fn redact_json_value(value: Value, secrets: &[&str]) -> Value {
                 {
                     redacted.insert(key, Value::String(REDACTED.to_string()));
                 } else {
-                    redacted.insert(key, redact_json_value(value, secrets));
+                    redacted.insert(key, redact_json_value(value, redactor));
                 }
             }
             Value::Object(redacted)
@@ -162,10 +224,10 @@ fn redact_json_value(value: Value, secrets: &[&str]) -> Value {
         Value::Array(items) => Value::Array(
             items
                 .into_iter()
-                .map(|item| redact_json_value(item, secrets))
+                .map(|item| redact_json_value(item, redactor))
                 .collect(),
         ),
-        Value::String(text) => Value::String(redact_credentials(&text, secrets)),
+        Value::String(text) => Value::String(redactor.redact(&text)),
         other => other,
     }
 }
@@ -198,9 +260,10 @@ mod tests {
     }
 
     #[test]
-    fn ignores_empty_and_short_secrets_for_verbatim_replacement() {
-        assert_eq!(redact_credentials("abc", &["abc"]), "abc");
-        assert_eq!(redact_credentials("plain", &["", "x"]), "plain");
+    fn redacts_short_known_secrets_and_ignores_empty_values() {
+        let redacted = redact_credentials("invalid key abc", &["abc"]);
+        assert_eq!(redacted, "invalid key [REDACTED]");
+        assert_eq!(redact_credentials("plain", &[""]), "plain");
     }
 
     #[test]

--- a/crates/nac-core/src/model/redact.rs
+++ b/crates/nac-core/src/model/redact.rs
@@ -81,10 +81,12 @@ fn url_userinfo_re() -> &'static Regex {
 
 /// Redact credentials from provider-controlled text.
 ///
-/// Exact secret values are replaced first (longest first, so a secret that is a
-/// prefix of another cannot leave a tail behind), then recognizable credential
-/// shapes — `Authorization`/`x-api-key` header lines, `Bearer`/`Basic` tokens,
-/// and URL userinfo — are masked even when the exact value is not known.
+/// Known secrets of four or more bytes are replaced wherever they appear.
+/// Shorter secrets are replaced only as complete credential values so values
+/// such as `no`, `v1`, or `4` do not destroy ordinary prose, paths, or status
+/// codes. Recognizable credential shapes — `Authorization`/`x-api-key` header
+/// lines, `Bearer`/`Basic` tokens, and URL userinfo — are masked even when the
+/// exact value is not known.
 pub(crate) fn redact_credentials(text: &str, secrets: &[&str]) -> String {
     CredentialRedactor::new(secrets.iter().copied()).redact(text)
 }
@@ -98,27 +100,57 @@ pub(crate) fn redact_credentials_with_extra_headers(
     secrets: &[&str],
     extra_headers: &BTreeMap<String, String>,
 ) -> String {
-    CredentialRedactor::new(
-        secrets
-            .iter()
-            .copied()
-            .chain(extra_headers.values().map(String::as_str)),
-    )
-    .redact(text)
+    CredentialRedactor::with_extra_headers(secrets.iter().copied(), extra_headers).redact(text)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct KnownSecret<'a> {
+    value: &'a str,
+    header_name: Option<&'a str>,
 }
 
 struct CredentialRedactor<'a> {
-    known: Vec<&'a str>,
+    known: Vec<KnownSecret<'a>>,
 }
 
 impl<'a> CredentialRedactor<'a> {
     fn new(secrets: impl IntoIterator<Item = &'a str>) -> Self {
-        let mut known: Vec<&str> = secrets
+        Self::from_known(secrets.into_iter().map(|value| KnownSecret {
+            value,
+            header_name: None,
+        }))
+    }
+
+    fn with_extra_headers(
+        secrets: impl IntoIterator<Item = &'a str>,
+        extra_headers: &'a BTreeMap<String, String>,
+    ) -> Self {
+        Self::from_known(
+            secrets
+                .into_iter()
+                .map(|value| KnownSecret {
+                    value,
+                    header_name: None,
+                })
+                .chain(extra_headers.iter().map(|(name, value)| KnownSecret {
+                    value: value.as_str(),
+                    header_name: (value.len() < 4).then_some(name.as_str()),
+                })),
+        )
+    }
+
+    fn from_known(secrets: impl IntoIterator<Item = KnownSecret<'a>>) -> Self {
+        let mut known: Vec<KnownSecret<'a>> = secrets
             .into_iter()
-            .filter(|secret| !secret.is_empty())
+            .filter(|secret| !secret.value.is_empty())
             .collect();
         known.sort_unstable_by(|left, right| {
-            right.len().cmp(&left.len()).then_with(|| left.cmp(right))
+            right
+                .value
+                .len()
+                .cmp(&left.value.len())
+                .then_with(|| left.value.cmp(right.value))
+                .then_with(|| left.header_name.cmp(&right.header_name))
         });
         known.dedup();
         Self { known }
@@ -127,10 +159,134 @@ impl<'a> CredentialRedactor<'a> {
     fn redact(&self, text: &str) -> String {
         let mut redacted = text.to_string();
         for secret in &self.known {
-            redacted = redacted.replace(secret, REDACTED);
+            redacted = if secret.value.len() >= 4 {
+                if redacted.contains(secret.value) {
+                    redacted.replace(secret.value, REDACTED)
+                } else {
+                    redacted
+                }
+            } else {
+                replace_short_secret(redacted, secret.value, secret.header_name)
+            };
         }
         redact_patterns(redacted)
     }
+}
+
+fn replace_short_secret(text: String, secret: &str, header_name: Option<&str>) -> String {
+    let mut output: Option<String> = None;
+    let mut cursor = 0;
+    for (start, _) in text.match_indices(secret) {
+        let end = start + secret.len();
+        if !short_secret_is_credential_value(&text, start, end, header_name) {
+            continue;
+        }
+        let output = output.get_or_insert_with(|| String::with_capacity(text.len()));
+        output.push_str(&text[cursor..start]);
+        output.push_str(REDACTED);
+        cursor = end;
+    }
+    match output {
+        Some(mut output) => {
+            output.push_str(&text[cursor..]);
+            output
+        }
+        None => text,
+    }
+}
+
+fn short_secret_is_credential_value(
+    text: &str,
+    start: usize,
+    end: usize,
+    header_name: Option<&str>,
+) -> bool {
+    let before = &text[..start];
+    let after = &text[end..];
+    if before.trim().is_empty() && after.trim().is_empty() {
+        return true;
+    }
+    if after
+        .chars()
+        .next()
+        .is_some_and(is_short_secret_token_character)
+    {
+        return false;
+    }
+
+    let prefix = before.trim_end();
+    if prefix.ends_with('=') {
+        return true;
+    }
+    if prefix.ends_with(':')
+        && (prefix.len() != before.len()
+            || no_space_colon_has_credential_label(prefix, header_name))
+    {
+        return true;
+    }
+    let quoted = matches!(prefix.chars().last(), Some('"' | '\''));
+    let unquoted_prefix = if quoted {
+        prefix[..prefix.len() - 1].trim_end()
+    } else {
+        prefix
+    };
+    if quoted && matches!(unquoted_prefix.chars().last(), Some(':' | '=')) {
+        return true;
+    }
+    if before
+        .chars()
+        .next_back()
+        .is_some_and(is_short_secret_token_character)
+    {
+        return false;
+    }
+
+    let cue = unquoted_prefix
+        .rsplit(|character: char| {
+            !(character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+        })
+        .next()
+        .unwrap_or_default();
+    is_credential_cue(cue)
+}
+
+fn no_space_colon_has_credential_label(prefix: &str, header_name: Option<&str>) -> bool {
+    let label = prefix
+        .strip_suffix(':')
+        .and_then(|prefix| {
+            prefix
+                .rsplit(|character: char| {
+                    character.is_ascii_whitespace()
+                        || matches!(character, '"' | '\'' | '{' | '[' | '(' | ',' | ';')
+                })
+                .next()
+        })
+        .unwrap_or_default();
+    is_credential_cue(label)
+        || header_name.is_some_and(|header_name| label.eq_ignore_ascii_case(header_name))
+}
+
+fn is_short_secret_token_character(character: char) -> bool {
+    character.is_alphanumeric() || matches!(character, '-' | '_')
+}
+
+fn is_credential_cue(value: &str) -> bool {
+    [
+        "authorization",
+        "bearer",
+        "basic",
+        "credential",
+        "secret",
+        "token",
+        "key",
+        "api-key",
+        "apikey",
+        "x-api-key",
+        "password",
+        "cookie",
+    ]
+    .iter()
+    .any(|cue| value.eq_ignore_ascii_case(cue))
 }
 
 fn redact_patterns(mut redacted: String) -> String {
@@ -188,12 +344,7 @@ pub(crate) fn redact_json_body_with_extra_headers(
 ) -> String {
     redact_json_body_with(
         body,
-        &CredentialRedactor::new(
-            secrets
-                .iter()
-                .copied()
-                .chain(extra_headers.values().map(String::as_str)),
-        ),
+        &CredentialRedactor::with_extra_headers(secrets.iter().copied(), extra_headers),
     )
 }
 
@@ -266,6 +417,57 @@ mod tests {
         assert_eq!(redact_credentials("plain", &[""]), "plain");
     }
 
+    #[test]
+    fn short_known_secrets_preserve_unrelated_prose_and_paths() {
+        let text = "no credits; api key noël; failed to tokenize input; endpoint /v1/models or \
+                    http://localhost:4/v1; HTTP 400";
+        assert_eq!(redact_credentials(text, &["no", "ize", "v1", "4"]), text);
+    }
+
+    #[test]
+    fn short_known_secrets_redact_only_credential_values() {
+        for (text, secret, expected) in [
+            ("invalid key abc", "abc", "invalid key [REDACTED]"),
+            ("extra=no", "no", "extra=[REDACTED]"),
+            ("x-provider: 4", "4", "x-provider: [REDACTED]"),
+            ("Authorization:4", "4", "Authorization: [REDACTED]"),
+            (r#""echo":"4""#, "4", r#""echo":"[REDACTED]""#),
+            (" 4\n", "4", " [REDACTED]\n"),
+        ] {
+            assert_eq!(redact_credentials(text, &[secret]), expected, "{text}");
+        }
+    }
+
+    #[test]
+    fn short_extra_header_values_match_embedded_header_names() {
+        let extra_headers = BTreeMap::from([
+            ("Tenant".to_string(), "abc".to_string()),
+            ("XFoo".to_string(), "4".to_string()),
+        ]);
+        let text = "echoed XFoo:4 rejected; Tenant:abc";
+        assert_eq!(
+            redact_credentials_with_extra_headers(text, &[], &extra_headers),
+            "echoed XFoo:[REDACTED] rejected; Tenant:[REDACTED]"
+        );
+
+        let json = redact_json_body_with_extra_headers(
+            r#"{"message":"echoed XFoo:4 rejected"}"#,
+            &[],
+            &extra_headers,
+        );
+        assert!(json.contains("XFoo:[REDACTED]"), "{json}");
+        assert!(!json.contains("XFoo:4"), "{json}");
+    }
+
+    #[test]
+    fn short_known_secrets_preserve_json_diagnostics() {
+        let redacted = redact_json_body(r#"{"echo":"4","message":"status=4; HTTP 400"}"#, &["4"]);
+        assert!(redacted.contains(r#""echo":"[REDACTED]""#), "{redacted}");
+        assert!(
+            redacted.contains(r#""message":"status=[REDACTED]; HTTP 400""#),
+            "{redacted}"
+        );
+    }
     #[test]
     fn redacts_authorization_header_with_scheme() {
         for text in [

--- a/crates/nac-core/src/model/redact.rs
+++ b/crates/nac-core/src/model/redact.rs
@@ -64,10 +64,12 @@ fn header_value_re() -> &'static Regex {
 }
 
 /// A `Bearer`/`Basic` token standing alone in prose, without a header name.
+/// The token is captured separately so the replacement can tell credential
+/// material from an ordinary prose word (see `redact_patterns`).
 fn bearer_token_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
-        Regex::new(r"(?i)\b(bearer|basic)\s+[A-Za-z0-9._~+/=:-]{4,}")
+        Regex::new(r"(?i)\b(bearer|basic)\s+([A-Za-z0-9._~+/=:-]{4,})")
             .expect("valid bearer token regex")
     })
 }
@@ -108,7 +110,18 @@ fn redact_patterns(text: &str) -> String {
         .replace_all(&redacted, "$1: [REDACTED]")
         .into_owned();
     redacted = bearer_token_re()
-        .replace_all(&redacted, "$1 [REDACTED]")
+        .replace_all(&redacted, |captures: &regex::Captures<'_>| {
+            // Ordinary prose ("bearer token", "basic authentication") is all
+            // lowercase letters; credential material carries at least one
+            // digit, uppercase letter, or symbol. Masking a prose word would
+            // hide the actionable part of a provider error.
+            let token = &captures[2];
+            if token.bytes().any(|byte| !byte.is_ascii_lowercase()) {
+                format!("{} [REDACTED]", &captures[1])
+            } else {
+                captures[0].to_string()
+            }
+        })
         .into_owned();
     redacted = url_userinfo_re()
         .replace_all(&redacted, "$1[REDACTED]@")
@@ -226,6 +239,30 @@ mod tests {
         assert!(!redacted.contains("sk-live-abcdef"));
         assert!(redacted.contains("Bearer [REDACTED]"));
         assert!(redacted.contains("was rejected"));
+    }
+
+    #[test]
+    fn bearer_pattern_ignores_ordinary_prose() {
+        for text in [
+            "use a bearer token for authentication",
+            "basic authentication is not supported",
+            "the Bearer scheme expects a token",
+        ] {
+            assert_eq!(redact_credentials(text, &[]), text, "{text}");
+        }
+    }
+
+    #[test]
+    fn bearer_pattern_still_matches_credential_shaped_tokens() {
+        for (text, secret) in [
+            ("token Bearer dXNlcjpwYXNz rejected", "dXNlcjpwYXNz"),
+            ("token Bearer abc123def456 rejected", "abc123def456"),
+            ("token Basic QWxhZGRpbjpvcGVu rejected", "QWxhZGRpbjpvcGVu"),
+        ] {
+            let redacted = redact_credentials(text, &[]);
+            assert!(!redacted.contains(secret), "{text} -> {redacted}");
+            assert!(redacted.contains(REDACTED), "{text} -> {redacted}");
+        }
     }
 
     #[test]

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -86,7 +86,9 @@ pub(super) fn provider_stream_error(code: Option<&str>, message: &str) -> Stream
         )
     });
     // The message is provider-controlled text and can echo request credentials
-    // back; the exact secret is not known here, so mask recognizable shapes.
+    // back; the exact secret is not known at the fold layer, so mask
+    // recognizable shapes here. `SseError::fold` redacts the known secrets on
+    // top of this before the message is persisted.
     let message = redact_credentials(message, &[]);
     if retryable {
         StreamFoldError::retryable(message)
@@ -119,11 +121,11 @@ impl SseError {
         }
     }
 
-    fn fold(url: &str, error: StreamFoldError, observable_delta: bool) -> Self {
+    fn fold(url: &str, error: StreamFoldError, observable_delta: bool, secrets: &[&str]) -> Self {
         // The fold error text is provider-controlled and can echo request
-        // credentials back; the exact secret is not known here, so mask
-        // recognizable shapes before the message is persisted.
-        let message = redact_credentials(&error.message, &[]);
+        // credentials back; mask the known secrets and recognizable shapes
+        // before the message is persisted.
+        let message = redact_credentials(&error.message, secrets);
         Self {
             message: format!("model stream from {url} failed: {message}"),
             retryable: error.retryable,
@@ -183,13 +185,17 @@ pub(super) async fn read_sse_response<F: StreamFold>(
     url: &str,
     response: Response,
     mut fold: F,
+    secrets: &[&str],
 ) -> std::result::Result<Value, SseError> {
     let mut reader = SseReader::new(response);
 
     while let Some(frame) = reader.next_frame().await {
         let frame = frame.map_err(|error| {
             SseError::retryable(
-                format!("model stream from {url} failed: {error:#}"),
+                redact_credentials(
+                    &format!("model stream from {url} failed: {error:#}"),
+                    secrets,
+                ),
                 fold.has_observable_delta(),
             )
         })?;
@@ -203,14 +209,19 @@ pub(super) async fn read_sse_response<F: StreamFold>(
             SseError::permanent(
                 format!(
                     "invalid SSE event from {url}: {}\n{}",
-                    redact_credentials(&frame.data, &[]),
+                    redact_credentials(&frame.data, secrets),
                     error
                 ),
                 fold.has_observable_delta(),
             )
         })?;
         if let Err(error) = fold.push(&event) {
-            return Err(SseError::fold(url, error, fold.has_observable_delta()));
+            return Err(SseError::fold(
+                url,
+                error,
+                fold.has_observable_delta(),
+                secrets,
+            ));
         }
         if fold.is_complete() {
             break;
@@ -219,7 +230,7 @@ pub(super) async fn read_sse_response<F: StreamFold>(
 
     let observable_delta = fold.has_observable_delta();
     fold.finish()
-        .map_err(|error| SseError::fold(url, error, observable_delta))
+        .map_err(|error| SseError::fold(url, error, observable_delta, secrets))
 }
 
 /// One dispatched SSE event. Only the payload is kept: providers that also name
@@ -462,6 +473,72 @@ mod tests {
         assert!(!provider_stream_error(None, "failed").is_retryable());
     }
 
+    /// A provider error that echoes the request's API key back in prose must
+    /// not reach the caller intact: `read_sse_response` redacts the known
+    /// secrets on top of the pattern masking the fold layer applies.
+    #[tokio::test]
+    async fn stream_errors_redact_known_secrets() {
+        const CANARY: &str = "sk-canary-sse-0123456789";
+        let events = format!(
+            "data: {{\"error\":{{\"message\":\"invalid key {CANARY} supplied\",\"type\":\"authentication_error\"}}}}\n\n"
+        );
+        let (response, release_server, server) = held_open_sse_response(&events).await;
+        let result = timeout(
+            Duration::from_secs(1),
+            read_sse_response(
+                "http://redaction.test",
+                response,
+                ChatStreamFold::new(None, "reasoning_content"),
+                &[CANARY],
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let error = result
+            .expect("stream read should complete")
+            .expect_err("a provider error event should fail the stream");
+        let message = error.to_string();
+        assert!(!message.contains(CANARY), "{message}");
+        assert!(
+            message.contains(crate::model::redact::REDACTED),
+            "{message}"
+        );
+        assert!(message.contains("invalid key"), "{message}");
+    }
+
+    /// The same redaction covers SSE frames that fail to parse as JSON: the
+    /// raw frame data is quoted into the error and can carry echoed secrets.
+    #[tokio::test]
+    async fn invalid_sse_event_redacts_known_secrets() {
+        const CANARY: &str = "sk-canary-sse-0123456789";
+        let events = format!("data: not json mentioning {CANARY}\n\n");
+        let (response, release_server, server) = held_open_sse_response(&events).await;
+        let result = timeout(
+            Duration::from_secs(1),
+            read_sse_response(
+                "http://redaction.test",
+                response,
+                ChatStreamFold::new(None, "reasoning_content"),
+                &[CANARY],
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let error = result
+            .expect("stream read should complete")
+            .expect_err("an invalid JSON event should fail the stream");
+        let message = error.to_string();
+        assert!(!message.contains(CANARY), "{message}");
+        assert!(
+            message.contains(crate::model::redact::REDACTED),
+            "{message}"
+        );
+    }
+
     #[tokio::test]
     async fn responses_finish_on_terminal_event_before_body_closes() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -508,6 +585,7 @@ mod tests {
                 "http://responses.test",
                 response,
                 ResponsesStreamFold::new(None),
+                &[],
             ),
         )
         .await;
@@ -581,6 +659,7 @@ mod tests {
                 "http://chat-compatible.test",
                 response,
                 ChatStreamFold::new(None, "reasoning_content"),
+                &[],
             ),
         )
         .await;
@@ -618,6 +697,7 @@ mod tests {
             "http://anthropic.test",
             response,
             AnthropicStreamFold::new(None),
+            &[],
         ));
 
         assert!(
@@ -691,6 +771,7 @@ mod tests {
             "http://responses.benchmark",
             response,
             ResponsesStreamFold::new(None),
+            &[],
         )
         .await
         .unwrap();

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -9,10 +9,11 @@
 //! `data: [DONE]` is left to the caller: it is a wire-only sentinel that only
 //! the OpenAI-shaped backends send.
 
+use std::collections::BTreeMap;
 use std::fmt;
 use std::pin::Pin;
 
-use super::redact_credentials;
+use super::{redact_credentials, redact_credentials_with_extra_headers};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
@@ -97,6 +98,17 @@ pub(super) fn provider_stream_error(code: Option<&str>, message: &str) -> Stream
     }
 }
 
+fn redact_request_credentials(
+    text: &str,
+    secrets: &[&str],
+    extra_headers: Option<&BTreeMap<String, String>>,
+) -> String {
+    match extra_headers {
+        Some(extra_headers) => redact_credentials_with_extra_headers(text, secrets, extra_headers),
+        None => redact_credentials(text, secrets),
+    }
+}
+
 impl fmt::Display for StreamFoldError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(&self.message)
@@ -121,13 +133,22 @@ impl SseError {
         }
     }
 
-    fn fold(url: &str, error: StreamFoldError, observable_delta: bool, secrets: &[&str]) -> Self {
+    fn fold(
+        url: &str,
+        error: StreamFoldError,
+        observable_delta: bool,
+        secrets: &[&str],
+        extra_headers: Option<&BTreeMap<String, String>>,
+    ) -> Self {
         // The fold error text is provider-controlled and can echo request
         // credentials back; mask the known secrets and recognizable shapes
         // before the message is persisted.
-        let message = redact_credentials(&error.message, secrets);
+        let message = redact_request_credentials(&error.message, secrets, extra_headers);
         Self {
-            message: format!("model stream from {url} failed: {message}"),
+            message: format!(
+                "model stream from {} failed: {message}",
+                redact_credentials(url, &[])
+            ),
             retryable: error.retryable,
             observable_delta,
         }
@@ -184,17 +205,39 @@ pub(super) trait StreamFold {
 pub(super) async fn read_sse_response<F: StreamFold>(
     url: &str,
     response: Response,
+    fold: F,
+    secrets: &[&str],
+) -> std::result::Result<Value, SseError> {
+    read_sse_response_with_request_secrets(url, response, fold, secrets, None).await
+}
+
+pub(super) async fn read_sse_response_with_extra_headers<F: StreamFold>(
+    url: &str,
+    response: Response,
+    fold: F,
+    secrets: &[&str],
+    extra_headers: &BTreeMap<String, String>,
+) -> std::result::Result<Value, SseError> {
+    read_sse_response_with_request_secrets(url, response, fold, secrets, Some(extra_headers)).await
+}
+
+async fn read_sse_response_with_request_secrets<F: StreamFold>(
+    url: &str,
+    response: Response,
     mut fold: F,
     secrets: &[&str],
+    extra_headers: Option<&BTreeMap<String, String>>,
 ) -> std::result::Result<Value, SseError> {
     let mut reader = SseReader::new(response);
 
     while let Some(frame) = reader.next_frame().await {
         let frame = frame.map_err(|error| {
+            let message =
+                redact_request_credentials(&format!("{error:#}"), secrets, extra_headers);
             SseError::retryable(
-                redact_credentials(
-                    &format!("model stream from {url} failed: {error:#}"),
-                    secrets,
+                format!(
+                    "model stream from {} failed: {message}",
+                    redact_credentials(url, &[])
                 ),
                 fold.has_observable_delta(),
             )
@@ -208,8 +251,9 @@ pub(super) async fn read_sse_response<F: StreamFold>(
         let event: Value = serde_json::from_str(&frame.data).map_err(|error| {
             SseError::permanent(
                 format!(
-                    "invalid SSE event from {url}: {}\n{}",
-                    redact_credentials(&frame.data, secrets),
+                    "invalid SSE event from {}: {}\n{}",
+                    redact_credentials(url, &[]),
+                    redact_request_credentials(&frame.data, secrets, extra_headers),
                     error
                 ),
                 fold.has_observable_delta(),
@@ -221,6 +265,7 @@ pub(super) async fn read_sse_response<F: StreamFold>(
                 error,
                 fold.has_observable_delta(),
                 secrets,
+                extra_headers,
             ));
         }
         if fold.is_complete() {
@@ -230,7 +275,7 @@ pub(super) async fn read_sse_response<F: StreamFold>(
 
     let observable_delta = fold.has_observable_delta();
     fold.finish()
-        .map_err(|error| SseError::fold(url, error, observable_delta, secrets))
+        .map_err(|error| SseError::fold(url, error, observable_delta, secrets, extra_headers))
 }
 
 /// One dispatched SSE event. Only the payload is kept: providers that also name
@@ -506,6 +551,40 @@ mod tests {
             "{message}"
         );
         assert!(message.contains("invalid key"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn stream_errors_redact_extra_header_values() {
+        const CANARY: &str = "lowercaseheaderssecanary";
+        let events = format!(
+            "data: {{\"error\":{{\"message\":\"custom credential {CANARY} was rejected\",\"type\":\"authentication_error\"}}}}\n\n"
+        );
+        let extra_headers = BTreeMap::from([("x-provider-secret".to_string(), CANARY.to_string())]);
+        let (response, release_server, server) = held_open_sse_response(&events).await;
+        let result = timeout(
+            Duration::from_secs(1),
+            read_sse_response_with_extra_headers(
+                "http://redaction.test",
+                response,
+                ChatStreamFold::new(None, "reasoning_content"),
+                &[],
+                &extra_headers,
+            ),
+        )
+        .await;
+
+        let _ = release_server.send(());
+        server.await.unwrap();
+        let message = result
+            .expect("stream read should complete")
+            .expect_err("a provider error event should fail the stream")
+            .to_string();
+        assert!(!message.contains(CANARY), "{message}");
+        assert!(
+            message.contains(crate::model::redact::REDACTED),
+            "{message}"
+        );
+        assert!(message.contains("custom credential"), "{message}");
     }
 
     /// The same redaction covers SSE frames that fail to parse as JSON: the

--- a/crates/nac-core/src/model/sse.rs
+++ b/crates/nac-core/src/model/sse.rs
@@ -12,6 +12,7 @@
 use std::fmt;
 use std::pin::Pin;
 
+use super::redact_credentials;
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures_util::{Stream, StreamExt};
@@ -84,6 +85,9 @@ pub(super) fn provider_stream_error(code: Option<&str>, message: &str) -> Stream
                 | "server_error"
         )
     });
+    // The message is provider-controlled text and can echo request credentials
+    // back; the exact secret is not known here, so mask recognizable shapes.
+    let message = redact_credentials(message, &[]);
     if retryable {
         StreamFoldError::retryable(message)
     } else {
@@ -116,8 +120,12 @@ impl SseError {
     }
 
     fn fold(url: &str, error: StreamFoldError, observable_delta: bool) -> Self {
+        // The fold error text is provider-controlled and can echo request
+        // credentials back; the exact secret is not known here, so mask
+        // recognizable shapes before the message is persisted.
+        let message = redact_credentials(&error.message, &[]);
         Self {
-            message: format!("model stream from {url} failed: {error}"),
+            message: format!("model stream from {url} failed: {message}"),
             retryable: error.retryable,
             observable_delta,
         }
@@ -193,7 +201,11 @@ pub(super) async fn read_sse_response<F: StreamFold>(
         }
         let event: Value = serde_json::from_str(&frame.data).map_err(|error| {
             SseError::permanent(
-                format!("invalid SSE event from {url}: {}\n{error}", frame.data),
+                format!(
+                    "invalid SSE event from {url}: {}\n{}",
+                    redact_credentials(&frame.data, &[]),
+                    error
+                ),
                 fold.has_observable_delta(),
             )
         })?;


### PR DESCRIPTION
## Description

### What

Redact credentials from provider error events and server logs. Provider HTTP error response bodies, redirect `Location` headers, and SSE stream error events are now scrubbed of API keys, bearer tokens, and other secret-shaped values before they are embedded in durable `model_error` session events or written to server stderr.

### Why

Provider error bodies frequently echo request headers back to the client. When a provider returns a 4xx/5xx, the raw body can contain the caller's `Authorization` header, `x-api-key`, or other secrets. Those bodies were previously copied verbatim into `model_error` events (persisted in session history) and server logs, leaking credentials into durable storage and logs.

## Usage

No user-facing API changes. Redaction is applied automatically at every error capture site:

- `send_with_retry_headers` and `try_post_json_with_retry_headers` in `crates/nac-core/src/model/client/mod.rs` — redact the full body (JSON-aware) before truncation, redirect `Location:` values, and every configured extra-header value
- `crates/nac-core/src/model/arcee.rs` — token-refresh, device-code, and redirect error paths
- `crates/nac-core/src/model/chatgpt_codex.rs` — `CodexRequestError`, SSE/JSON parse failures, device-code paths
- `crates/nac-core/src/model/sse.rs` — provider stream error events and invalid SSE frame data
- `crates/nac-core/src/events.rs` — defense-in-depth pattern redaction in the `ModelError` sanitize arm

New module `crates/nac-core/src/model/redact.rs` provides exact secret-value replacement plus pattern redaction for header shapes, bearer/basic tokens, and URL userinfo. Known credentials of any nonzero length are redacted only within untrusted fields, preserving generated status and diagnostic context. JSON bodies are traversed once with a reusable redactor and fall back to text redaction when parsing fails.

## Changelog

- Add `redact.rs` with reusable exact, contextual short-secret, pattern, and JSON-aware redaction (18 unit tests with canary secrets)
- Redact full error bodies before truncation at all provider error capture sites
- Include configured extra-header values; exact-match credentials of four or more bytes and contextually mask 1–3 byte credential values without rewriting ordinary prose, paths, or status codes
- Redact redirect `Location` headers, SSE stream error events, and structured Arcee device errors
- Preserve generated HTTP status and diagnostic prefixes by applying exact replacement only to untrusted fields
- Add defense-in-depth pattern redaction to the `ModelError` sanitize arm in `events.rs`
- Update `ModelError` doc comment to reflect credential redaction

## Validation

- `cargo test -p nac-core --locked redact -- --nocapture` — 26 passed
- `cargo test -p nac-core --locked` — 830 passed across 2 suites; 9 ignored
- `cargo clippy -p nac-core --locked --lib` — completed with only 39 pre-existing warnings outside changed files
- `git diff --check` — PASS
- Prior validation on this PR: workspace check, nac-server tests, nac-catalog-gen tests, macOS build, and Linux musl build passed
- Regression coverage now exercises distinct API-key and custom-header secrets, one-byte credentials without status corruption, short-secret prose/path preservation, compact configured-header echoes, buffered and SSE errors, structured Arcee device errors, SessionEventBus replay, and actual prefixed stderr output

## Bug Evidence

**Before:** Provider HTTP error response bodies were copied unredacted into durable `model_error` session events and server stderr. A controlled local provider echoing request headers in a 400 leaked the API credential + extra-header secret.

**Root cause:** `send_with_retry_headers` and related error paths embedded raw response bodies without redacting credentials. The initial fix tracked backend tokens separately from configured extra headers, skipped known secrets shorter than four bytes, and redacted some already-formatted diagnostic prefixes.

**Fix:** Added centralized redaction across client/mod.rs, arcee.rs, chatgpt_codex.rs, sse.rs, and events.rs. Redaction now derives secrets from the same configured header values sent on the request, exact-matches values of four or more bytes, contextually masks shorter complete credential values, redacts provider-controlled fields before formatting safe status context, and covers session replay plus stderr emission.

**Validation:** Focused redaction coverage passes 26/26 and the full nac-core suite passes 830 tests. The previous controlled extra-header and Arcee device-code reproducers are now permanent passing regressions.

Closes #149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication flows and every provider error path; mistakes could leak secrets or strip actionable error text users need to fix misconfiguration.
> 
> **Overview**
> Provider failures could copy raw HTTP bodies, redirect locations, and stream error text into **durable `ModelError` events**, session replay, and prefixed stderr—often echoing `Authorization`, API keys, or device tokens from the request.
> 
> This PR introduces **`model/redact.rs`** (with a `regex` dependency) to strip known request secrets (including short values and configured extra headers), mask common credential shapes, and walk JSON error bodies before truncation. That redaction is wired through the generic model HTTP client, Arcee and Codex auth flows, SSE parsing, and **`sanitize_external_agent_event`** for `ModelError` as defense in depth.
> 
> Regression tests cover echoed credentials in provider errors, Arcee device-code failures, SSE invalid frames, session bus replay, and subprocess stderr emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b48dc9df92cb98e5b0f833663452ac2fae150e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


