### PR TITLE
fix(storage): release idle session SQLite handles (nac)

### DIFF
--- a/crates/nac-core/src/events.rs
+++ b/crates/nac-core/src/events.rs
@@ -535,6 +535,14 @@ impl SessionEventBus {
         self.delta_sender.receiver_count() > 0
     }
 
+    /// True while any client holds a live subscription to this session's event
+    /// stream (an open SSE connection). The server uses this to decide whether
+    /// a session is safe to evict from its in-memory cache: dropping the
+    /// service would drop the broadcast senders and close every live stream.
+    pub fn has_subscribers(&self) -> bool {
+        self.sender.receiver_count() > 0 || self.delta_sender.receiver_count() > 0
+    }
+
     pub fn subscribe_for_client(&self, client_id: SessionClientId) -> SessionEventSubscription {
         SessionEventSubscription {
             client_id,

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -513,6 +513,13 @@ pub struct SessionService {
     event_bus: SessionEventBus,
     active_operation: Arc<StdMutex<Option<ActiveSessionOperation>>>,
     active_threads: Arc<crate::tools::ActiveThreadRegistry>,
+    /// True when this session executes inside a sandbox container. Dropping
+    /// the last service reference drops the `SandboxSession`, and an owned
+    /// container's `Drop` runs `podman rm -f`; the next resume builds a fresh
+    /// container under a new session key, so container-local state would be
+    /// lost. The server's idle-session eviction uses this to leave sandboxed
+    /// sessions cached.
+    has_sandbox: bool,
     #[cfg(test)]
     frontend_snapshot_after_workspace_gate: Option<Arc<FrontendSnapshotAfterWorkspaceGate>>,
 }
@@ -678,6 +685,7 @@ impl SessionService {
         let session_snapshot = run_config.session.into_snapshot();
         let active_threads = run_config.agent.active_threads_handle();
         let transcript_log = run_config.agent.transcript_log_writer();
+        let has_sandbox = run_config.agent.sandbox_session().is_some();
         // The restored transcript is exactly the store transcript (blob ++
         // log tail) at construction, so the initial scan is an in-memory
         // pass; later scans read only the newly appended tail rows.
@@ -698,6 +706,7 @@ impl SessionService {
             event_bus,
             active_operation: Arc::new(StdMutex::new(None)),
             active_threads,
+            has_sandbox,
             #[cfg(test)]
             frontend_snapshot_after_workspace_gate: None,
         };
@@ -797,6 +806,16 @@ impl SessionService {
     /// would drop the event bus's broadcast senders and close their stream.
     pub fn has_event_subscribers(&self) -> bool {
         self.event_bus.has_subscribers()
+    }
+
+    /// True when this session executes inside a sandbox container. Evicting
+    /// such a session from the server's in-memory cache would drop its
+    /// `SandboxSession`: an owned container's `Drop` runs `podman rm -f`,
+    /// and the next resume builds a fresh container under a new session key,
+    /// so container-local state is lost either way. Idle eviction must skip
+    /// these sessions.
+    pub fn has_sandbox(&self) -> bool {
+        self.has_sandbox
     }
 
     pub fn active_run(&self) -> Option<ActiveRunSnapshot> {
@@ -3162,6 +3181,85 @@ pub(super) mod tests {
             resume_base_cwd: PathBuf::from("/repo"),
         });
         (parts, store_path)
+    }
+
+    #[test]
+    fn has_sandbox_reflects_the_agent_execution_backend() {
+        let (local_parts, local_store) =
+            test_active_service("has_sandbox_local", "has-sandbox-local");
+        assert!(!local_parts.service.has_sandbox());
+        let _ = std::fs::remove_dir_all(local_store.parent().unwrap());
+
+        let store_path = test_store_path("has_sandbox_sandboxed");
+        let client = ModelClient::new_for_test();
+        let agent = Agent::with_config(
+            client.clone(),
+            AgentConfig {
+                command_output_limits: crate::terminal::CommandOutputLimits::default(),
+                mode: AgentMode::Orchestrator,
+                store_path: store_path.clone(),
+                session_id: Some("has-sandbox-sandboxed".to_string()),
+                orchestrator_compaction_threshold: None,
+                initial_messages: Vec::new(),
+                thread_name: None,
+                dispatch_id: None,
+                event_sink: EventSink::none(),
+                workspace_cwd: PathBuf::from("/repo"),
+                config_cwd: PathBuf::from("/repo"),
+                working_directory: "/repo".to_string(),
+                worker_executable: None,
+                sandbox: Some(crate::sandbox::SandboxSession::new_for_test(
+                    crate::sandbox::SandboxSpec {
+                        backend: crate::sandbox::SandboxBackendType::Podman,
+                        image: crate::sandbox::DEFAULT_SANDBOX_IMAGE.to_string(),
+                        mounts: Vec::new(),
+                        workdir: PathBuf::from(crate::sandbox::DEFAULT_SANDBOX_WORKDIR),
+                        gpu_devices: Vec::new(),
+                        shm_size: None,
+                        cpus: 2,
+                        memory_mib: 2048,
+                    },
+                )),
+                ssh: None,
+                mcp: None,
+                skills: None,
+                extra_tool_defs: Vec::new(),
+                agents_md_message: None,
+                thread_timeout_secs: crate::tools::thread::DEFAULT_THREAD_TIMEOUT_SECS,
+                light_client: None,
+            },
+        )
+        .expect("agent config must be valid");
+        let snapshot = sessions::new_snapshot(
+            "has-sandbox-sandboxed".to_string(),
+            PathBuf::from("/repo"),
+            client.model.clone(),
+            client.base_url().to_string(),
+            client.backend(),
+            client.reasoning_effort(),
+            None,
+            None,
+            agent.messages.clone(),
+            None,
+            BTreeMap::new(),
+        );
+        sessions::create_session(&store_path, &snapshot).unwrap();
+        let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+            agent,
+            client,
+            session: OrchestratorSession::Active {
+                session_id: "has-sandbox-sandboxed".to_string(),
+                store_path: store_path.clone(),
+                snapshot,
+            },
+            sandbox_status: "on".to_string(),
+            agents_md_status: "off".to_string(),
+            workspace_display: "/repo".to_string(),
+            workspace_git: Some(GitTarget::local("/repo")),
+            resume_base_cwd: PathBuf::from("/repo"),
+        });
+        assert!(parts.service.has_sandbox());
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
 
     /// Seed the store transcript's legacy prefix: the snapshot blob (what the

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -791,6 +791,14 @@ impl SessionService {
         self.lock_active_operation().is_some()
     }
 
+    /// True while any client holds a live subscription to this session's event
+    /// stream (an open SSE connection). A session with live subscribers must
+    /// not be evicted from the server's in-memory cache: dropping the service
+    /// would drop the event bus's broadcast senders and close their stream.
+    pub fn has_event_subscribers(&self) -> bool {
+        self.event_bus.has_subscribers()
+    }
+
     pub fn active_run(&self) -> Option<ActiveRunSnapshot> {
         match self.lock_active_operation().as_ref() {
             Some(ActiveSessionOperation::Run(active_run)) => Some(active_run.snapshot.clone()),

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1312,9 +1312,13 @@ impl SessionManager {
     /// A session is evicted only when all of these hold:
     /// - it has no active run or compaction,
     /// - nothing outside the map holds a strong reference to it (no in-flight
-    ///   request is using it), and
+    ///   request is using it),
     /// - no client holds a live event-stream subscription (an open SSE
-    ///   connection, which the eviction would close).
+    ///   connection, which the eviction would close), and
+    /// - it does not execute inside a sandbox container: dropping the service
+    ///   would drop the `SandboxSession`, an owned container's `Drop` runs
+    ///   `podman rm -f`, and the next resume builds a fresh container under a
+    ///   new session key, so eviction would destroy container-local state.
     ///
     /// `except` names the session the caller is attaching or creating, which
     /// is skipped so the caller does not evict the very service it is about to
@@ -1328,6 +1332,7 @@ impl SessionManager {
                     && !service.has_active_operation()
                     && Arc::strong_count(service) == 1
                     && !service.has_event_subscribers()
+                    && !service.has_sandbox()
             })
             .map(|(session_id, _)| session_id.clone())
             .collect();

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -1298,10 +1298,50 @@ impl SessionManager {
         probed
     }
 
+    /// Releases the SQLite handles of sessions that are not currently in use.
+    ///
+    /// Every retained session holds two long-lived SQLite connections (the
+    /// transcript log writer and the thread event writer), which in WAL mode
+    /// keep roughly six file descriptors open. Sessions are never removed from
+    /// `active_sessions` on their own, so under a low descriptor limit enough
+    /// session creations exhaust the process's FDs and new sessions start
+    /// failing with HTTP 500s. Evicting an idle session drops the last strong
+    /// reference to its `SessionService`, closing both connections; the next
+    /// attach rebuilds the service from the durable store via `resume_session`.
+    ///
+    /// A session is evicted only when all of these hold:
+    /// - it has no active run or compaction,
+    /// - nothing outside the map holds a strong reference to it (no in-flight
+    ///   request is using it), and
+    /// - no client holds a live event-stream subscription (an open SSE
+    ///   connection, which the eviction would close).
+    ///
+    /// `except` names the session the caller is attaching or creating, which
+    /// is skipped so the caller does not evict the very service it is about to
+    /// use.
+    async fn sweep_idle_sessions(&self, except: Option<&str>) {
+        let mut active = self.inner.active_sessions.write().await;
+        let idle: Vec<String> = active
+            .iter()
+            .filter(|(session_id, service)| {
+                Some(session_id.as_str()) != except
+                    && !service.has_active_operation()
+                    && Arc::strong_count(service) == 1
+                    && !service.has_event_subscribers()
+            })
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        for session_id in idle {
+            active.remove(&session_id);
+            eprintln!("nac: evicted idle session {session_id} to release its SQLite handles");
+        }
+    }
+
     pub async fn create_session(
         &self,
         request: CreateSessionRequest,
     ) -> Result<SessionFrontendSnapshot> {
+        self.sweep_idle_sessions(None).await;
         let location = self.resolve_launch_location(
             request.cwd,
             SshRequest {
@@ -1416,6 +1456,7 @@ impl SessionManager {
     async fn attach_session(&self, session_id: &str) -> Result<Arc<SessionService>> {
         const MAX_ATTEMPTS: usize = 2;
 
+        self.sweep_idle_sessions(Some(session_id)).await;
         let gate = self.lifecycle_gate(session_id);
         let _lifecycle = gate.lock().await;
         for _ in 0..MAX_ATTEMPTS {
@@ -1471,6 +1512,7 @@ impl SessionManager {
         session_id: &str,
         operation_lease: Option<&sessions::SessionOperationLease>,
     ) -> Result<Arc<SessionService>> {
+        self.sweep_idle_sessions(Some(session_id)).await;
         if let Some(service) = self.inner.active_sessions.read().await.get(session_id) {
             return Ok(Arc::clone(service));
         }


### PR DESCRIPTION
## Description

**What.** Releases per-session SQLite handles by evicting idle sessions from the `active_sessions` map.

**Why.** Each retained session holds 2 long-lived SQLite connections (TranscriptLogWriter + ThreadEventWriter), each using ~3 FDs in WAL mode (~6 FDs per session). Sessions were never evicted from `active_sessions` in `SessionManagerInner`, so file descriptors accumulated until exhaustion under the default 256-FD limit, causing HTTP 500s on session creation while `/health` stayed 200.

- Adds `SessionManager::sweep_idle_sessions`, which evicts sessions with no active operation, no event subscribers, and no other live references (only the map holding the `Arc<SessionService>`).
- Calls the sweep at the start of `create_session` and `attach_session` (before acquiring new connections).
- Re-attach after eviction uses the existing cache-miss → `resume_session` path.

## Usage

No user-facing usage change. Operators running long-lived servers with many retained sessions will no longer hit FD exhaustion; idle sessions are evicted and their SQLite handles released when new sessions are created or attached.

## Changelog

- Evicts idle sessions from the `active_sessions` map, releasing their SQLite connections and file descriptors.
- Prevents session-creation outages caused by FD exhaustion under the default 256-FD limit.

## Validation

- `cargo check --workspace --locked` — PASS
- `cargo test --workspace --locked` — 940 passed, 0 failed (3 pre-existing environment failures skipped, identical on clean origin/main)
- `cargo clippy --workspace --locked --all-targets` — no new warnings (one pre-existing deny-lint failure in `crates/nac-core/src/tools/discovery/tests.rs:300` also fails on clean origin/main)
- `cargo fmt --all -- --check` — changed files rustfmt-clean

## Bug Evidence

**Before:** Retained sessions held 2 long-lived SQLite connections each (~6 FDs in WAL mode), never evicted from `active_sessions`, exhausting the 256-FD limit → HTTP 500s on session creation while `/health` stayed 200.

**Root cause:** No idle-session eviction from the `active_sessions` map in `SessionManagerInner`.

**Fix:** Added `sweep_idle_sessions` that evicts sessions with no active operation, no event subscribers, and only the map holding a reference; called at session creation and attach.

**Validation:** `cargo check --workspace --locked` PASS, `cargo test --workspace --locked` 940 passed (3 pre-existing env failures), `cargo clippy --workspace --locked --all-targets` no new warnings.

Addresses #150

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session lifecycle and eviction rules (SSE and sandbox); wrong eviction could drop live streams or sandbox state, though guards are explicit.
> 
> **Overview**
> Adds **idle-session eviction** so long-lived servers stop accumulating per-session SQLite connections (~6 FDs each) until session creation fails with HTTP 500.
> 
> `SessionManager::sweep_idle_sessions` removes entries from `active_sessions` when a session has no active run/compaction, only the map holds an `Arc` (no in-flight request), **no live SSE/event subscribers**, and **no sandbox** (eviction would tear down the container). The sweep runs at the start of `create_session`, `attach_session`, and `attach_session_locked`; the target session is skipped via `except`. Evicted sessions are rebuilt from the store on the next attach.
> 
> `SessionEventBus::has_subscribers` and `SessionService::has_event_subscribers` / `has_sandbox` expose the eviction guards; `has_sandbox` is set from the agent at service construction, with a unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5f634def05af04d8134c74a6eb6c550fde3b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
