### PR TITLE
fix(transcript): prevent shared-store recovery from truncating transcripts (nac)

### DIFF
--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -1041,9 +1041,13 @@ impl Agent {
     ///
     /// Synchronous counterpart of the async restore: admission is a sync
     /// path that already performs blocking store reads (config revision,
-    /// compaction checkpoint). Returns the rewritten snapshot blob when
-    /// dangling-turn normalization had to repair the blob itself, so the
-    /// caller can refresh its own snapshot copy; `None` otherwise.
+    /// compaction checkpoint). Returns the post-refresh durable snapshot
+    /// blob — the rewritten blob when dangling-turn normalization repaired
+    /// it, the unchanged blob otherwise — so the caller can reconcile its
+    /// cached snapshot copy on every admission: a prior admission may have
+    /// repaired the blob and then failed before patching that copy, and the
+    /// retry sees nothing left to repair. `None` only when the session has
+    /// no transcript log.
     pub fn refresh_transcript_under_lease(
         &mut self,
         operation_lease: &crate::sessions::SessionOperationLease,
@@ -1110,7 +1114,6 @@ impl Agent {
                 .ok_or_else(|| anyhow!("transcript log index overflowed"))?;
         }
 
-        let mut refreshed_blob = None;
         if let Some(incomplete_turn) = incomplete_tool_turn_index(&merged) {
             merged.truncate(incomplete_turn);
             // Trimming below the blob length means the dangling turn lives
@@ -1118,18 +1121,22 @@ impl Agent {
             // and tail together while the operation lease is held.
             if merged.len() < blob_len_usize {
                 writer.replace_snapshot_and_delete_from(&session_id, &merged)?;
-                refreshed_blob = Some(merged.clone());
             } else {
                 writer.delete_from(&session_id, merged.len() as u64)?;
             }
         }
+
+        // The durable snapshot blob after the refresh: the rewritten blob
+        // when normalization repaired it, otherwise the unchanged prefix of
+        // the merged transcript.
+        let durable_blob = merged[..merged.len().min(blob_len_usize)].to_vec();
 
         // The durable transcript is now exactly `merged`.
         self.committed_log_len = merged.len() as u64;
         if !transcripts_match(&self.messages, &merged)? {
             self.restore_messages(merged);
         }
-        Ok(refreshed_blob)
+        Ok(Some(durable_blob))
     }
 
     /// Stale-transcript guard for the terminal normalization paths (shared
@@ -1205,8 +1212,10 @@ impl Agent {
     /// once started, so the log can hold a straggler row at `messages.len()`
     /// that the vec never saw — without the delete, the next append would
     /// reuse that idx and leave duplicate-idx rows for the restore merge.
-    /// The straggler is within this process's own commits
-    /// (`committed_log_len`), so the delete stays below that boundary.
+    /// The straggler stays within this process's own commits because
+    /// appends claim their rows in `committed_log_len` at submission time
+    /// (before the `spawn_blocking` await), so the delete stays below that
+    /// boundary.
     /// Durable rows BEYOND it belong to a peer (shared store, issue #146):
     /// the in-memory transcript is stale, so the durable state is adopted
     /// instead of deleting the peer's committed rows from the stale length.
@@ -1317,15 +1326,38 @@ impl Agent {
         let session_id = sink.session_id.clone();
         let messages = messages.to_vec();
         let batch_len = messages.len() as u64;
-        tokio::task::spawn_blocking(move || writer.append_batch(&session_id, start_idx, &messages))
-            .await
-            .map_err(|error| anyhow!("transcript log append task failed: {error}"))??;
+        // Claim the rows at submission, before the await: a run task
+        // dropped while the blocking append is in flight cannot interrupt
+        // it, so the append still completes without this function ever
+        // resuming. The up-front claim keeps that straggler row within this
+        // process's own commits, so terminal normalization trims it instead
+        // of mistaking it for a peer's committed row (issue #146).
+        let pre_submission_committed = self.committed_log_len;
         self.committed_log_len = self.committed_log_len.max(start_idx + batch_len);
-        // Live trigger (step 3): emitted after the log commit, before the
-        // vec push — the store-backed read path sees the rows immediately.
-        self.event_sink
-            .emit_transcript_appended(start_idx + batch_len);
-        Ok(())
+        let appended = tokio::task::spawn_blocking(move || {
+            writer.append_batch(&session_id, start_idx, &messages)
+        })
+        .await
+        .map_err(|error| anyhow!("transcript log append task failed: {error}"))?;
+        match appended {
+            Ok(()) => {
+                // Live trigger (step 3): emitted after the log commit,
+                // before the vec push — the store-backed read path sees the
+                // rows immediately.
+                self.event_sink
+                    .emit_transcript_appended(start_idx + batch_len);
+                Ok(())
+            }
+            Err(error) => {
+                // The batch commits in one transaction, so a failed append
+                // left no rows behind: release the optimistic claim to keep
+                // the own-commits bound exact. A dropped task never reaches
+                // this rollback — which is exactly the straggler case the
+                // claim exists for.
+                self.committed_log_len = pre_submission_committed;
+                Err(error)
+            }
+        }
     }
 
     /// Append one message to the transcript log at absolute position `idx`
@@ -1337,13 +1369,26 @@ impl Agent {
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
         let message = message.clone();
-        tokio::task::spawn_blocking(move || writer.append(&session_id, idx, &message))
-            .await
-            .map_err(|error| anyhow!("transcript log append task failed: {error}"))??;
+        // Claim the row at submission, before the await — see
+        // log_transcript_batch for why the straggler from a dropped run
+        // task must stay within this process's own commits.
+        let pre_submission_committed = self.committed_log_len;
         self.committed_log_len = self.committed_log_len.max(idx + 1);
-        // Live trigger (step 3): see log_transcript_batch.
-        self.event_sink.emit_transcript_appended(idx + 1);
-        Ok(())
+        let appended = tokio::task::spawn_blocking(move || writer.append(&session_id, idx, &message))
+            .await
+            .map_err(|error| anyhow!("transcript log append task failed: {error}"))?;
+        match appended {
+            Ok(()) => {
+                // Live trigger (step 3): see log_transcript_batch.
+                self.event_sink.emit_transcript_appended(idx + 1);
+                Ok(())
+            }
+            Err(error) => {
+                // Nothing was committed: release the optimistic claim.
+                self.committed_log_len = pre_submission_committed;
+                Err(error)
+            }
+        }
     }
 
     /// Push one message into the transcript, appending it to the log first

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -141,6 +141,13 @@ pub struct Agent {
     /// store/transcript.rs). Present only for orchestrator agents with a
     /// session id — workers (separate `__worker` processes) never log.
     transcript_log: Option<TranscriptLogSink>,
+    /// Exclusive upper bound of transcript log rows this process has
+    /// committed or adopted (restore/refresh). Durable rows at or beyond
+    /// this position were committed by a peer while it held the session
+    /// operation lease, so the terminal normalization paths must never
+    /// delete them from stale in-memory boundaries (shared-store recovery,
+    /// issue #146).
+    committed_log_len: u64,
     /// User-facing notice set only when restore repaired a validly encoded
     /// non-contiguous transcript tail.
     transcript_recovery_warning: Option<String>,
@@ -347,6 +354,9 @@ impl Agent {
             )?,
             AgentMode::Orchestrator => crate::terminal::TerminalManager::new(),
         };
+        // The initial messages are exactly the snapshot blob written at
+        // session creation; the log tail starts at this length.
+        let committed_log_len = messages.len() as u64;
         Ok(Self {
             client,
             messages,
@@ -374,6 +384,7 @@ impl Agent {
             steering_dispatch_id: config.dispatch_id,
             appended_steering_ids: HashSet::new(),
             transcript_log,
+            committed_log_len,
             transcript_recovery_warning: None,
             interrupted_run_recovery: None,
             last_usage: None,
@@ -833,6 +844,9 @@ impl Agent {
                 *stored = fresh.clone();
             }
         }
+        // The restored transcript claims the durable state through its
+        // length: every log row below it was adopted by this process.
+        self.committed_log_len = messages.len() as u64;
         self.messages = messages;
         if let Some(compaction) = &mut self.compaction {
             compaction.reset_for_transcript_replacement();
@@ -1001,9 +1015,179 @@ impl Agent {
                     self.delete_log_tail(merged.len() as u64).await?;
                 }
             }
+            // The durable transcript is now exactly `merged`: every row it
+            // holds was committed or adopted by this process.
+            self.committed_log_len = merged.len() as u64;
             self.restore_messages(merged);
             return Ok(refreshed_blob);
         }
+    }
+
+    /// Re-restore the in-memory transcript from the durable store (snapshot
+    /// blob ++ transcript log tail) while the caller holds the session
+    /// operation lease, normalizing a dangling tool turn exactly like
+    /// [`Agent::restore_messages_merging_log_tail`].
+    ///
+    /// Shared-store recovery (issue #146): a long-lived `SessionService`
+    /// can survive the peer process that owned the previous run. The OS
+    /// releases the peer's operation lease on its death, but this agent's
+    /// in-memory transcript still predates the peer's committed rows, so
+    /// the next run would append at a stale index (rejected by the log's
+    /// contiguity guard) and terminal normalization would delete the peer's
+    /// committed rows from the stale length. Called from
+    /// `SessionService::prepare_operation_admission` after the lease is
+    /// acquired: the lease excludes concurrent peer appends, so the refresh
+    /// is race-free and the run starts from the newest durable state.
+    ///
+    /// Synchronous counterpart of the async restore: admission is a sync
+    /// path that already performs blocking store reads (config revision,
+    /// compaction checkpoint). Returns the rewritten snapshot blob when
+    /// dangling-turn normalization had to repair the blob itself, so the
+    /// caller can refresh its own snapshot copy; `None` otherwise.
+    pub fn refresh_transcript_under_lease(
+        &mut self,
+        operation_lease: &crate::sessions::SessionOperationLease,
+    ) -> Result<Option<Vec<Message>>> {
+        self.transcript_recovery_warning = None;
+        let Some(sink) = &self.transcript_log else {
+            return Ok(None);
+        };
+        operation_lease
+            .validate(&sink.store_path, &sink.session_id)
+            .map_err(anyhow::Error::new)?;
+        let writer = sink.writer.clone();
+        let session_id = sink.session_id.clone();
+
+        let snapshot_messages = writer.read_snapshot_messages(&session_id)?;
+        let blob_len = snapshot_messages.len() as u64;
+        let blob_len_usize = snapshot_messages.len();
+        let mut tail = writer.read_from(&session_id, blob_len)?;
+
+        let mut expected_idx = blob_len;
+        let mut gap = false;
+        for (idx, _) in &tail {
+            if *idx != expected_idx {
+                gap = true;
+                break;
+            }
+            expected_idx = expected_idx
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("transcript log index overflowed"))?;
+        }
+
+        if gap {
+            // The lease is held, so no peer can be appending: a gap is
+            // genuine corruption. Keep the longest contiguous prefix and
+            // atomically delete the untrusted physical suffix, exactly like
+            // the restore path.
+            let (repaired_tail, recovery) =
+                writer.read_tail_repairing_gap(&session_id, blob_len)?;
+            tail = repaired_tail;
+            if let Some(recovery) = recovery {
+                let row_label = if recovery.discarded_rows == 1 {
+                    "row"
+                } else {
+                    "rows"
+                };
+                self.transcript_recovery_warning = Some(format!(
+                    "Recovered this session to its last valid message because transcript index {} was missing. Discarded {} untrusted transcript log {row_label} beginning at index {}.",
+                    recovery.expected_idx, recovery.discarded_rows, recovery.found_idx
+                ));
+            }
+        }
+
+        let mut merged = snapshot_messages;
+        let mut expected_idx = blob_len;
+        for (idx, message) in tail {
+            if idx != expected_idx {
+                return Err(anyhow!(
+                    "transcript log tail is not contiguous with the snapshot: expected idx {expected_idx}, found {idx}"
+                ));
+            }
+            merged.push(message);
+            expected_idx = expected_idx
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("transcript log index overflowed"))?;
+        }
+
+        let mut refreshed_blob = None;
+        if let Some(incomplete_turn) = incomplete_tool_turn_index(&merged) {
+            merged.truncate(incomplete_turn);
+            // Trimming below the blob length means the dangling turn lives
+            // in the write-once snapshot itself, so rewrite the snapshot
+            // and tail together while the operation lease is held.
+            if merged.len() < blob_len_usize {
+                writer.replace_snapshot_and_delete_from(&session_id, &merged)?;
+                refreshed_blob = Some(merged.clone());
+            } else {
+                writer.delete_from(&session_id, merged.len() as u64)?;
+            }
+        }
+
+        // The durable transcript is now exactly `merged`.
+        self.committed_log_len = merged.len() as u64;
+        if !transcripts_match(&self.messages, &merged)? {
+            self.restore_messages(merged);
+        }
+        Ok(refreshed_blob)
+    }
+
+    /// Stale-transcript guard for the terminal normalization paths (shared
+    /// store, issue #146): `true` when the durable transcript log holds
+    /// rows at or beyond `committed_log_len` — rows this process never
+    /// committed or adopted, so a peer must have appended them while it
+    /// held the operation lease (e.g. the previous run owner crashed and
+    /// this survivor's long-lived agent never re-restored). Deleting the
+    /// log tail from the stale in-memory length would permanently remove
+    /// those committed rows.
+    async fn durable_log_has_rows_past_own_commits(&self) -> Result<bool> {
+        let Some(sink) = &self.transcript_log else {
+            return Ok(false);
+        };
+        let from_idx = self.committed_log_len;
+        let writer = sink.writer.clone();
+        let session_id = sink.session_id.clone();
+        let tail = tokio::task::spawn_blocking(move || writer.read_from(&session_id, from_idx))
+            .await
+            .map_err(|error| anyhow!("transcript log read task failed: {error}"))??;
+        Ok(!tail.is_empty())
+    }
+
+    /// Adopt the durable transcript (snapshot blob ++ log tail) in memory
+    /// without deleting anything: the read-only half of
+    /// [`Agent::refresh_transcript_under_lease`] for the terminal
+    /// normalization paths, which do not hold the operation lease they
+    /// could pass down. A genuine gap is left for the next lease-held
+    /// restore or admission refresh to repair.
+    async fn reload_transcript_from_store(&mut self) -> Result<()> {
+        let Some(sink) = &self.transcript_log else {
+            return Ok(());
+        };
+        let writer = sink.writer.clone();
+        let session_id = sink.session_id.clone();
+        let (snapshot, tail) = tokio::task::spawn_blocking(move || {
+            let snapshot = writer.read_snapshot_messages(&session_id)?;
+            let tail = writer.read_from(&session_id, snapshot.len() as u64)?;
+            Ok::<_, anyhow::Error>((snapshot, tail))
+        })
+        .await
+        .map_err(|error| anyhow!("transcript reload task failed: {error}"))??;
+        let mut merged = snapshot;
+        let mut expected_idx = merged.len() as u64;
+        for (idx, message) in tail {
+            if idx != expected_idx {
+                return Err(anyhow!(
+                    "transcript log tail is not contiguous with the snapshot: expected idx {expected_idx}, found {idx}"
+                ));
+            }
+            merged.push(message);
+            expected_idx = expected_idx
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("transcript log index overflowed"))?;
+        }
+        self.committed_log_len = merged.len() as u64;
+        self.restore_messages(merged);
+        Ok(())
     }
 
     /// Trim a dangling tool turn from the transcript AND the transcript log
@@ -1021,9 +1205,17 @@ impl Agent {
     /// once started, so the log can hold a straggler row at `messages.len()`
     /// that the vec never saw — without the delete, the next append would
     /// reuse that idx and leave duplicate-idx rows for the restore merge.
+    /// The straggler is within this process's own commits
+    /// (`committed_log_len`), so the delete stays below that boundary.
+    /// Durable rows BEYOND it belong to a peer (shared store, issue #146):
+    /// the in-memory transcript is stale, so the durable state is adopted
+    /// instead of deleting the peer's committed rows from the stale length.
     /// Both terminal paths treat a normalization error as best-effort: the
     /// next restore re-normalizes the stale tail.
     pub async fn normalize_dangling_tail(&mut self) -> Result<()> {
+        if self.durable_log_has_rows_past_own_commits().await? {
+            return self.reload_transcript_from_store().await;
+        }
         truncate_incomplete_tool_turn(&mut self.messages);
         self.delete_log_tail(self.messages.len() as u64).await
     }
@@ -1047,6 +1239,19 @@ impl Agent {
     /// path so the chat can retain dispatched thread cards and their persisted
     /// logs while the resulting transcript remains valid provider history.
     pub async fn append_cancellation_marker_preserving_tools(&mut self) -> Result<()> {
+        if self.durable_log_has_rows_past_own_commits().await? {
+            // Shared-store recovery (issue #146): a peer committed rows this
+            // agent never saw. Adopt the durable state instead of deleting
+            // the peer's committed rows from the stale in-memory length (see
+            // [`Agent::normalize_dangling_tail`]).
+            self.reload_transcript_from_store().await?;
+        } else {
+            // Remove a log row whose blocking append completed after the run
+            // task was aborted but before its in-memory push.
+            self.delete_log_tail(self.messages.len() as u64).await?;
+        }
+        // The missing-result scan deliberately uses the authoritative
+        // in-memory transcript (freshly reloaded when it was stale).
         let missing_results = missing_tool_result_ids(&self.messages)
             .into_iter()
             .map(|tool_call_id| Message::Tool {
@@ -1054,10 +1259,6 @@ impl Agent {
                 content: crate::types::TOOL_CALL_CANCELLED_MARKER.to_string(),
             })
             .collect::<Vec<_>>();
-        // Remove a log row whose blocking append completed after the run task
-        // was aborted but before its in-memory push. The missing-result scan
-        // above deliberately uses the authoritative in-memory transcript.
-        self.delete_log_tail(self.messages.len() as u64).await?;
         self.append_cancellation_tail(missing_results).await
     }
 
@@ -1105,7 +1306,7 @@ impl Agent {
     /// Append `messages` to the transcript log at absolute positions
     /// `start_idx..` via `spawn_blocking` (steering-claim precedent). A no-op
     /// for agents without a transcript log (workers, picker sessions).
-    async fn log_transcript_batch(&self, start_idx: u64, messages: &[Message]) -> Result<()> {
+    async fn log_transcript_batch(&mut self, start_idx: u64, messages: &[Message]) -> Result<()> {
         let Some(sink) = &self.transcript_log else {
             return Ok(());
         };
@@ -1119,6 +1320,7 @@ impl Agent {
         tokio::task::spawn_blocking(move || writer.append_batch(&session_id, start_idx, &messages))
             .await
             .map_err(|error| anyhow!("transcript log append task failed: {error}"))??;
+        self.committed_log_len = self.committed_log_len.max(start_idx + batch_len);
         // Live trigger (step 3): emitted after the log commit, before the
         // vec push — the store-backed read path sees the rows immediately.
         self.event_sink
@@ -1128,7 +1330,7 @@ impl Agent {
 
     /// Append one message to the transcript log at absolute position `idx`
     /// via `spawn_blocking`. A no-op for agents without a transcript log.
-    async fn log_transcript_message(&self, idx: u64, message: &Message) -> Result<()> {
+    async fn log_transcript_message(&mut self, idx: u64, message: &Message) -> Result<()> {
         let Some(sink) = &self.transcript_log else {
             return Ok(());
         };
@@ -1138,6 +1340,7 @@ impl Agent {
         tokio::task::spawn_blocking(move || writer.append(&session_id, idx, &message))
             .await
             .map_err(|error| anyhow!("transcript log append task failed: {error}"))??;
+        self.committed_log_len = self.committed_log_len.max(idx + 1);
         // Live trigger (step 3): see log_transcript_batch.
         self.event_sink.emit_transcript_appended(idx + 1);
         Ok(())
@@ -1185,13 +1388,13 @@ impl Agent {
 
     /// Append the already-staged transcript tail `self.messages[from_idx..]`
     /// to the log (steering commit point: stage→ack→append).
-    async fn log_transcript_tail(&self, from_idx: usize) -> Result<()> {
+    async fn log_transcript_tail(&mut self, from_idx: usize) -> Result<()> {
         let staged = self.messages[from_idx..].to_vec();
         self.log_transcript_batch(from_idx as u64, &staged).await
     }
 
     /// Delete log rows with `idx >= from_idx` (crash/cancel normalization).
-    async fn delete_log_tail(&self, from_idx: u64) -> Result<()> {
+    async fn delete_log_tail(&mut self, from_idx: u64) -> Result<()> {
         let Some(sink) = &self.transcript_log else {
             return Ok(());
         };
@@ -1200,6 +1403,7 @@ impl Agent {
         tokio::task::spawn_blocking(move || writer.delete_from(&session_id, from_idx))
             .await
             .map_err(|error| anyhow!("transcript log tail delete task failed: {error}"))??;
+        self.committed_log_len = self.committed_log_len.min(from_idx);
         Ok(())
     }
 

--- a/crates/nac-core/src/agent/transcript_log_tests.rs
+++ b/crates/nac-core/src/agent/transcript_log_tests.rs
@@ -855,6 +855,58 @@ async fn cancellation_deletes_log_stragglers_from_an_aborted_append() {
 }
 
 #[tokio::test]
+async fn normalize_dangling_tail_trims_a_straggler_row_the_vec_never_saw() {
+    let store_path = test_store_path("normalize_straggler");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+
+    // A run task dropped while its spawn_blocking append was in flight: the
+    // append still completes, leaving a straggler row the vec never saw.
+    // The at-submission claim in log_transcript_batch keeps the row within
+    // this process's own commits (committed_log_len), so run-failure
+    // normalization must trim it — not mistake it for a peer's committed
+    // row and adopt the unmatched assistant tool-call turn, which the next
+    // provider call would reject.
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent.messages = vec![
+        Message::System {
+            content: "system".to_string(),
+        },
+        user_message("prompt"),
+    ];
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer
+        .append_batch(
+            "session",
+            0,
+            &[
+                Message::System {
+                    content: "system".to_string(),
+                },
+                user_message("prompt"),
+                tool_call_assistant(&["call-1"]),
+            ],
+        )
+        .unwrap();
+    // The straggler append at idx 2 was claimed at submission, before the
+    // run task was dropped: it stays within this process's own commits.
+    agent.committed_log_len = 3;
+
+    agent.normalize_dangling_tail().await.unwrap();
+
+    assert_eq!(agent.messages.len(), 2);
+    let log = read_log(&store_path, "session");
+    assert_eq!(
+        log.len(),
+        2,
+        "the straggler row is trimmed from the log, not adopted as a peer row"
+    );
+    assert!(matches!(log[1].1, Message::User { .. }));
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
 async fn normalize_dangling_tail_trims_the_vec_and_log_without_a_marker() {
     let store_path = test_store_path("normalize_failed");
     crate::store::initialize(&store_path).unwrap();
@@ -1065,8 +1117,12 @@ async fn refresh_transcript_under_lease_adopts_peer_appends() {
 
     let lease =
         crate::sessions::SessionOperationLease::try_acquire(&store_path, "session").unwrap();
-    let refreshed_blob = agent.refresh_transcript_under_lease(&lease).unwrap();
-    assert!(refreshed_blob.is_none(), "the blob itself was not repaired");
+    let durable_blob = agent.refresh_transcript_under_lease(&lease).unwrap();
+    assert_eq!(
+        durable_blob.map(|blob| blob.len()),
+        Some(3),
+        "the blob itself was not repaired: the refresh returns it unchanged"
+    );
 
     assert_eq!(agent.messages.len(), 5);
     assert!(matches!(agent.messages[3], Message::User { ref content } if content == "peer prompt"));

--- a/crates/nac-core/src/agent/transcript_log_tests.rs
+++ b/crates/nac-core/src/agent/transcript_log_tests.rs
@@ -764,6 +764,8 @@ async fn cancellation_trims_the_dangling_turn_and_logs_the_marker() {
     let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
     writer.append_batch("session", 0, &seeded).unwrap();
     agent.messages = seeded;
+    // The seeded log rows stand in for this process's own commits.
+    agent.committed_log_len = agent.messages.len() as u64;
 
     agent.append_cancellation_marker().await.unwrap();
 
@@ -788,6 +790,8 @@ async fn cancellation_trims_the_dangling_turn_and_logs_the_marker() {
         user_message("prompt"),
         plain_assistant("answer"),
     ];
+    // The seeded log rows stand in for this process's own commits.
+    clean.committed_log_len = clean.messages.len() as u64;
     clean.append_cancellation_marker().await.unwrap();
     assert_eq!(clean.messages.len(), 4);
     let log = read_log(&store_path, "session");
@@ -832,6 +836,9 @@ async fn cancellation_deletes_log_stragglers_from_an_aborted_append() {
             ],
         )
         .unwrap();
+    // All three log rows stand in for this process's own commits: the
+    // straggler append at idx 2 completed after the run task was aborted.
+    agent.committed_log_len = 3;
 
     agent.append_cancellation_marker().await.unwrap();
 
@@ -867,6 +874,8 @@ async fn normalize_dangling_tail_trims_the_vec_and_log_without_a_marker() {
     let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
     writer.append_batch("session", 0, &seeded).unwrap();
     agent.messages = seeded;
+    // The seeded log rows stand in for this process's own commits.
+    agent.committed_log_len = agent.messages.len() as u64;
 
     agent.normalize_dangling_tail().await.unwrap();
 
@@ -889,9 +898,269 @@ async fn normalize_dangling_tail_trims_the_vec_and_log_without_a_marker() {
         user_message("prompt"),
         plain_assistant("answer"),
     ];
+    // The seeded log rows stand in for this process's own commits.
+    clean.committed_log_len = clean.messages.len() as u64;
     clean.normalize_dangling_tail().await.unwrap();
     assert_eq!(clean.messages.len(), 3);
     assert_eq!(read_log(&store_path, "session").len(), 2);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn normalize_dangling_tail_preserves_rows_committed_by_a_peer() {
+    // Shared-store recovery (issue #146): this agent's in-memory transcript
+    // is stale — a peer appended rows to the shared store while it held the
+    // operation lease (the previous run owner crashed). Run-failure
+    // normalization must adopt the durable state, never delete the peer's
+    // committed rows from the stale in-memory length.
+    let store_path = test_store_path("normalize_stale_peer_rows");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let blob = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("first prompt"),
+        plain_assistant("first answer"),
+    ];
+    store_snapshot_messages(&store_path, &blob);
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent
+        .restore_messages_merging_log_tail(blob, None)
+        .await
+        .unwrap();
+    assert_eq!(agent.messages.len(), 3);
+
+    // A peer commits its run's rows to the shared store while this agent
+    // stays cached.
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer
+        .append_batch(
+            "session",
+            3,
+            &[user_message("peer prompt"), plain_assistant("peer answer")],
+        )
+        .unwrap();
+
+    agent.normalize_dangling_tail().await.unwrap();
+
+    let log = read_log(&store_path, "session");
+    assert_eq!(
+        log.len(),
+        2,
+        "the peer's committed rows must survive the stale agent's normalization"
+    );
+    assert_eq!(log[0].0, 3);
+    assert!(matches!(log[0].1, Message::User { ref content } if content == "peer prompt"));
+    assert_eq!(log[1].0, 4);
+    assert!(
+        matches!(log[1].1, Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+    );
+    assert_eq!(
+        agent.messages.len(),
+        5,
+        "the stale agent adopts the durable transcript instead of truncating it"
+    );
+
+    // The next append lands contiguously at the refreshed length.
+    agent
+        .push_and_log_for_test(user_message("next prompt"))
+        .await
+        .unwrap();
+    let log = read_log(&store_path, "session");
+    assert_eq!(log.len(), 3);
+    assert_eq!(log[2].0, 5);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn cancellation_marker_preserves_rows_committed_by_a_peer() {
+    // The cancel path shares the stale-vec guard (issue #146): peer rows
+    // are adopted, and the cancellation marker appends after them.
+    let store_path = test_store_path("cancel_stale_peer_rows");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let blob = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("first prompt"),
+        plain_assistant("first answer"),
+    ];
+    store_snapshot_messages(&store_path, &blob);
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent
+        .restore_messages_merging_log_tail(blob, None)
+        .await
+        .unwrap();
+
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer
+        .append_batch(
+            "session",
+            3,
+            &[user_message("peer prompt"), plain_assistant("peer answer")],
+        )
+        .unwrap();
+
+    agent
+        .append_cancellation_marker_preserving_tools()
+        .await
+        .unwrap();
+
+    let log = read_log(&store_path, "session");
+    assert_eq!(log.len(), 3);
+    assert_eq!(log[0].0, 3);
+    assert!(matches!(log[0].1, Message::User { ref content } if content == "peer prompt"));
+    assert_eq!(log[1].0, 4);
+    assert!(
+        matches!(log[1].1, Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+    );
+    assert_eq!(log[2].0, 5);
+    assert!(
+        matches!(log[2].1, Message::Assistant { content: Some(ref text), .. } if text == "[run cancelled by user]"),
+        "the cancellation marker must append after the adopted peer rows"
+    );
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn refresh_transcript_under_lease_adopts_peer_appends() {
+    // The admission-time refresh (issue #146): a survivor's cached agent
+    // re-restores from the durable store under the operation lease, so the
+    // run's append cursor matches the durable tail.
+    let store_path = test_store_path("refresh_under_lease");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let blob = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("first prompt"),
+        plain_assistant("first answer"),
+    ];
+    store_snapshot_messages(&store_path, &blob);
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent
+        .restore_messages_merging_log_tail(blob, None)
+        .await
+        .unwrap();
+    assert_eq!(agent.messages.len(), 3);
+
+    // A peer commits its run's rows and crashes; the OS releases its lease.
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer
+        .append_batch(
+            "session",
+            3,
+            &[user_message("peer prompt"), plain_assistant("peer answer")],
+        )
+        .unwrap();
+
+    let lease =
+        crate::sessions::SessionOperationLease::try_acquire(&store_path, "session").unwrap();
+    let refreshed_blob = agent.refresh_transcript_under_lease(&lease).unwrap();
+    assert!(refreshed_blob.is_none(), "the blob itself was not repaired");
+
+    assert_eq!(agent.messages.len(), 5);
+    assert!(matches!(agent.messages[3], Message::User { ref content } if content == "peer prompt"));
+    assert!(
+        matches!(agent.messages[4], Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+    );
+
+    // The run's first append lands contiguously at the refreshed length.
+    agent
+        .push_and_log_for_test(user_message("survivor prompt"))
+        .await
+        .unwrap();
+    let log = read_log(&store_path, "session");
+    assert_eq!(log.len(), 3);
+    assert_eq!(log[2].0, 5);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn refresh_transcript_under_lease_normalizes_a_crashed_peers_dangling_turn() {
+    // The peer crashed between the assistant tool-call commit and the
+    // tool-result batch: the admission refresh trims the dangling turn from
+    // the log under the lease (crash-resume normalization).
+    let store_path = test_store_path("refresh_under_lease_dangling");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let blob = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("first prompt"),
+        plain_assistant("first answer"),
+    ];
+    store_snapshot_messages(&store_path, &blob);
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent
+        .restore_messages_merging_log_tail(blob, None)
+        .await
+        .unwrap();
+
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer
+        .append_batch(
+            "session",
+            3,
+            &[
+                user_message("peer prompt"),
+                tool_call_assistant(&["call-1"]),
+            ],
+        )
+        .unwrap();
+
+    let lease =
+        crate::sessions::SessionOperationLease::try_acquire(&store_path, "session").unwrap();
+    agent.refresh_transcript_under_lease(&lease).unwrap();
+
+    assert_eq!(agent.messages.len(), 4);
+    assert!(matches!(agent.messages[3], Message::User { ref content } if content == "peer prompt"));
+    let log = read_log(&store_path, "session");
+    assert_eq!(
+        log.len(),
+        1,
+        "the crashed peer's dangling tool-call row is trimmed under the lease"
+    );
+    assert_eq!(log[0].0, 3);
+
+    agent
+        .push_and_log_for_test(user_message("survivor prompt"))
+        .await
+        .unwrap();
+    let log = read_log(&store_path, "session");
+    assert_eq!(log[1].0, 4);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[test]
+fn refresh_transcript_under_lease_rejects_a_foreign_lease() {
+    let store_path = test_store_path("refresh_lease_validation");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    crate::store::insert_test_session(&store_path, "other");
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    let foreign_lease =
+        crate::sessions::SessionOperationLease::try_acquire(&store_path, "other").unwrap();
+    assert!(
+        agent
+            .refresh_transcript_under_lease(&foreign_lease)
+            .is_err(),
+        "a lease for a different session must not authorize the refresh"
+    );
 
     let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
 }

--- a/crates/nac-core/src/model/test_http.rs
+++ b/crates/nac-core/src/model/test_http.rs
@@ -60,13 +60,24 @@ impl ScriptedServer {
     where
         F: Fn(usize, &CapturedRequest) + Send + 'static,
     {
+        Self::start_observed_with_timeout(responses, Duration::from_secs(5), observer)
+    }
+
+    pub(crate) fn start_observed_with_timeout<F>(
+        responses: Vec<ScriptedResponse>,
+        timeout: Duration,
+        observer: F,
+    ) -> Self
+    where
+        F: Fn(usize, &CapturedRequest) + Send + 'static,
+    {
         let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind scripted HTTP server");
         listener
             .set_nonblocking(true)
             .expect("set scripted HTTP listener nonblocking");
         let base_url = format!("http://{}", listener.local_addr().unwrap());
         let handle = thread::spawn(move || {
-            let deadline = Instant::now() + Duration::from_secs(5);
+            let deadline = Instant::now() + timeout;
             let mut requests = Vec::with_capacity(responses.len());
             for (index, response) in responses.into_iter().enumerate() {
                 let mut stream = loop {

--- a/crates/nac-core/src/model/test_http.rs
+++ b/crates/nac-core/src/model/test_http.rs
@@ -8,6 +8,7 @@ pub(crate) struct ScriptedResponse {
     status: &'static str,
     headers: BTreeMap<String, String>,
     body: String,
+    send_response: bool,
 }
 
 impl ScriptedResponse {
@@ -16,6 +17,7 @@ impl ScriptedResponse {
             status,
             headers: BTreeMap::new(),
             body: body.into(),
+            send_response: true,
         }
     }
 
@@ -28,11 +30,17 @@ impl ScriptedResponse {
             status,
             headers: BTreeMap::from([("Location".to_string(), location.into())]),
             body: body.into(),
+            send_response: true,
         }
     }
 
     pub(crate) fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.headers.insert(name.into(), value.into());
+        self
+    }
+
+    pub(crate) fn drop_connection(mut self) -> Self {
+        self.send_response = false;
         self
     }
 }
@@ -97,7 +105,9 @@ impl ScriptedServer {
                 let request = read_request(&mut stream);
                 observer(index, &request);
                 requests.push(request);
-                write_response(&mut stream, &response);
+                if response.send_response {
+                    write_response(&mut stream, &response);
+                }
             }
             requests
         });

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -1990,7 +1990,7 @@ impl SessionService {
                     message: SessionCoordinationError::local_agent_busy(),
                 }
             })?;
-            let repaired_blob = agent
+            let durable_blob = agent
                 .refresh_transcript_under_lease(lease)
                 .map_err(|error| OperationAdmissionPreparationError::Coordination {
                     message: SessionCoordinationError::store(format!(
@@ -2005,18 +2005,27 @@ impl SessionService {
                 }
             })?;
             drop(agent);
-            if let Some(repaired_blob) = repaired_blob {
-                // Dangling-turn normalization rewrote the blob itself:
-                // install the repaired blob so store-backed transcript reads
-                // do not serve the discarded turn from the stale pre-repair
-                // snapshot (mirrors the resume path in runtime.rs).
+            if let Some(durable_blob) = durable_blob {
+                // Reconcile the cached snapshot with the durable blob after
+                // every refresh, not only when this admission rewrote the
+                // blob itself: a prior admission may have repaired the blob
+                // and then failed before patching this copy (e.g. snapshot
+                // lock contention), and the retry sees nothing left to
+                // repair. Without the reconcile, store-backed transcript
+                // reads would serve the discarded dangling turn from the
+                // stale pre-repair snapshot for the rest of the process
+                // lifetime (mirrors the resume path in runtime.rs).
                 let mut snapshot = self.session_snapshot.try_lock().map_err(|_| {
                     OperationAdmissionPreparationError::Coordination {
                         message: SessionCoordinationError::local_agent_busy(),
                     }
                 })?;
                 if let Some(snapshot) = snapshot.as_mut() {
-                    snapshot.messages = repaired_blob;
+                    // The blob is write-once and repairs only truncate it,
+                    // so an equal length means this copy is already current.
+                    if snapshot.messages.len() != durable_blob.len() {
+                        snapshot.messages = durable_blob;
+                    }
                 }
             }
         }
@@ -6001,6 +6010,77 @@ pub(super) mod tests {
             );
         }
         drop(agent);
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    /// Regression test for the stale-snapshot Bugbot finding: an admission
+    /// that repairs the snapshot blob but fails before patching the cached
+    /// snapshot (e.g. snapshot lock contention) must not leave the stale
+    /// pre-repair blob cached for the process lifetime. The next admission
+    /// sees nothing left to repair, so it reconciles the cached snapshot
+    /// with the durable blob the refresh returns on every admission.
+    #[tokio::test]
+    async fn admission_reconciles_a_snapshot_left_stale_by_a_prior_repair() {
+        let (parts, store_path) =
+            test_active_service("admission_stale_snapshot", "stale-snapshot-session");
+
+        // The durable blob was already repaired by a prior admission
+        // attempt: it holds only the complete turn.
+        let repaired_blob = vec![
+            Message::System {
+                content: "system".to_string(),
+            },
+            Message::User {
+                content: "prompt".to_string(),
+            },
+        ];
+        seed_store_transcript(&parts, repaired_blob.clone()).await;
+
+        // ...but that attempt failed before patching the cached snapshot,
+        // which still serves the discarded dangling tool-call turn.
+        let mut stale_blob = repaired_blob.clone();
+        stale_blob.push(Message::Assistant {
+            content: None,
+            reasoning_text: None,
+            reasoning_details: None,
+            tool_calls: Some(vec![crate::types::ToolCall {
+                id: "call-1".to_string(),
+                call_type: "function".to_string(),
+                function: crate::types::FunctionCall {
+                    name: "read".to_string(),
+                    arguments: "{}".to_string(),
+                },
+            }]),
+            duration_ms: None,
+            model_origin: None,
+            reasoning_field: None,
+        });
+        parts
+            .service
+            .session_snapshot
+            .lock()
+            .await
+            .as_mut()
+            .unwrap()
+            .messages = stale_blob;
+
+        // The retry finds nothing left to repair in the durable store, yet
+        // must still heal the cached snapshot from the durable blob.
+        let lease = match parts.service.prepare_operation_admission(None) {
+            Ok(lease) => lease,
+            Err(_) => panic!("admission must succeed for the fresh session"),
+        };
+        drop(lease);
+
+        let snapshot = parts.service.session_snapshot.lock().await;
+        let messages = &snapshot.as_ref().unwrap().messages;
+        assert_eq!(
+            messages.len(),
+            repaired_blob.len(),
+            "the cached snapshot no longer serves the discarded dangling turn"
+        );
+        assert!(matches!(messages[1], Message::User { .. }));
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -2473,6 +2473,10 @@ impl SessionService {
             },
             (RunOutcome::Failed(message, _), None) => SessionEvent::RunFailed { message },
         };
+        #[cfg(test)]
+        if let SessionEvent::RunFailed { message } = &terminal_event {
+            eprintln!("nac test: unsanitized run failure: {message}");
+        }
         self.event_bus
             .emit_with_context(terminal_event, Some(run_id.clone()), client_id);
         self.clear_finished_run(&run_id);

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -5922,7 +5922,7 @@ pub(super) mod tests {
             std::sync::mpsc::sync_channel(1);
         let (release_interrupted_sender, release_interrupted_receiver) =
             std::sync::mpsc::sync_channel(1);
-        let server = ScriptedServer::start_observed(
+        let server = ScriptedServer::start_observed_with_timeout(
             vec![
                 ScriptedResponse::json(
                     "200 OK",
@@ -5952,6 +5952,7 @@ pub(super) mod tests {
                     .to_string(),
                 ),
             ],
+            Duration::from_secs(30),
             move |index, _request| {
                 if index == 1 {
                     interrupted_ready_sender.send(()).unwrap();

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -1974,13 +1974,29 @@ impl SessionService {
         // The caller holds the local operation-state lock and the lease above
         // excludes other processes. Refresh before publishing active state so
         // every run and manual compaction starts from the newest valid durable
-        // checkpoint, including direct callers.
-        if operation_lease.is_some() {
+        // state, including direct callers.
+        //
+        // The transcript refresh is load-bearing for shared-store recovery
+        // (issue #146): this long-lived service can survive the peer process
+        // that owned the previous run. The OS releases the peer's lease on
+        // its death, but the cached agent's in-memory transcript still
+        // predates the peer's committed rows — a run started from it would
+        // append at a stale index (rejected by the log's contiguity guard)
+        // and terminal normalization would delete the peer's committed rows
+        // from the stale length. Re-restoring under the lease is race-free.
+        if let Some(lease) = operation_lease.as_ref() {
             let mut agent = self.agent.try_lock().map_err(|_| {
                 OperationAdmissionPreparationError::Coordination {
                     message: SessionCoordinationError::local_agent_busy(),
                 }
             })?;
+            let repaired_blob = agent
+                .refresh_transcript_under_lease(lease)
+                .map_err(|error| OperationAdmissionPreparationError::Coordination {
+                    message: SessionCoordinationError::store(format!(
+                        "failed to refresh the transcript under the operation lease: {error:#}"
+                    )),
+                })?;
             agent.restore_compaction_checkpoint().map_err(|error| {
                 OperationAdmissionPreparationError::Coordination {
                     message: SessionCoordinationError::store(format!(
@@ -1988,6 +2004,21 @@ impl SessionService {
                     )),
                 }
             })?;
+            drop(agent);
+            if let Some(repaired_blob) = repaired_blob {
+                // Dangling-turn normalization rewrote the blob itself:
+                // install the repaired blob so store-backed transcript reads
+                // do not serve the discarded turn from the stale pre-repair
+                // snapshot (mirrors the resume path in runtime.rs).
+                let mut snapshot = self.session_snapshot.try_lock().map_err(|_| {
+                    OperationAdmissionPreparationError::Coordination {
+                        message: SessionCoordinationError::local_agent_busy(),
+                    }
+                })?;
+                if let Some(snapshot) = snapshot.as_mut() {
+                    snapshot.messages = repaired_blob;
+                }
+            }
         }
 
         Ok(operation_lease)
@@ -5769,6 +5800,207 @@ pub(super) mod tests {
         assert!(
             matches!(log[2].1, Message::Assistant { content: Some(ref text), .. } if text == "recovered")
         );
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    /// Peer process for
+    /// `shared_store_recovery_after_peer_crash_preserves_committed_transcript`:
+    /// plays the run owner on a shared store — acquires the session
+    /// operation lease, commits its run's transcript rows, signals
+    /// readiness, then sleeps holding the lease until the parent SIGKILLs it
+    /// (process death releases the lease).
+    #[test]
+    fn shared_store_peer_process_helper() {
+        let Some(store_path) = std::env::var_os("NAC_TEST_SHARED_STORE_STORE") else {
+            return;
+        };
+        let ready_path = PathBuf::from(std::env::var_os("NAC_TEST_SHARED_STORE_READY").unwrap());
+        let session_id = std::env::var("NAC_TEST_SHARED_STORE_SESSION").unwrap();
+        let _lease =
+            sessions::SessionOperationLease::try_acquire(Path::new(&store_path), &session_id)
+                .unwrap();
+        let writer = crate::store::TranscriptLogWriter::new(Path::new(&store_path)).unwrap();
+        writer
+            .append(
+                &session_id,
+                1,
+                &Message::User {
+                    content: "peer prompt".to_string(),
+                },
+            )
+            .unwrap();
+        writer
+            .append(
+                &session_id,
+                2,
+                &Message::Assistant {
+                    content: Some("peer answer".to_string()),
+                    reasoning_text: None,
+                    reasoning_details: None,
+                    tool_calls: None,
+                    duration_ms: None,
+                    model_origin: None,
+                    reasoning_field: None,
+                },
+            )
+            .unwrap();
+        std::fs::write(ready_path, b"ready").unwrap();
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    /// Regression test for issue #146 (shared-store recovery): two `nac-web`
+    /// processes share one SQLite store. The peer (child process) commits
+    /// transcript rows under the operation lease and is killed; this
+    /// service's long-lived cached agent still holds the pre-peer in-memory
+    /// transcript. Accepting the recovery submission must refresh the stale
+    /// transcript under the released lease: the run must succeed, and no
+    /// committed row may be deleted.
+    #[tokio::test]
+    async fn shared_store_recovery_after_peer_crash_preserves_committed_transcript() {
+        use crate::model::test_http::{ScriptedResponse, ScriptedServer};
+
+        let store_path = test_store_path("shared_store_recovery");
+        let session_id = "session-shared-store".to_string();
+        let server = ScriptedServer::start(vec![ScriptedResponse::json(
+            "200 OK",
+            serde_json::json!({
+                "status": "completed",
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "survivor answer"}]}],
+                "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+            })
+            .to_string(),
+        )]);
+        let client = ModelClient::new_for_test_server(server.base_url.clone());
+        let agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
+        let snapshot = sessions::new_snapshot(
+            session_id.clone(),
+            PathBuf::from("/repo"),
+            client.model.clone(),
+            client.base_url().to_string(),
+            client.backend(),
+            client.reasoning_effort(),
+            None,
+            None,
+            agent.messages.clone(),
+            None,
+            BTreeMap::new(),
+        );
+        sessions::create_session(&store_path, &snapshot).unwrap();
+        let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+            agent,
+            client,
+            session: OrchestratorSession::Active {
+                session_id: session_id.clone(),
+                store_path: store_path.clone(),
+                snapshot,
+            },
+            sandbox_status: "off".to_string(),
+            agents_md_status: "off".to_string(),
+            workspace_display: "/repo".to_string(),
+            workspace_git: Some(GitTarget::local("/repo")),
+            resume_base_cwd: PathBuf::from("/repo"),
+        });
+        // The survivor's cached agent is stale from the start: it holds only
+        // the creation-time transcript (one system message).
+        assert_eq!(parts.service.agent.lock().await.messages.len(), 1);
+
+        // The peer process commits its run's transcript rows under the
+        // operation lease, then is killed mid-ownership (SIGKILL): the OS
+        // releases the lease.
+        let ready_path = store_path.parent().unwrap().join("peer-ready");
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "session_service::tests::shared_store_peer_process_helper",
+                "--nocapture",
+            ])
+            .env("NAC_TEST_SHARED_STORE_STORE", &store_path)
+            .env("NAC_TEST_SHARED_STORE_READY", &ready_path)
+            .env("NAC_TEST_SHARED_STORE_SESSION", &session_id)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        for _ in 0..200 {
+            if ready_path.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "peer helper exited early"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(ready_path.exists(), "peer helper never became ready");
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        // The survivor accepts the recovery submission. Admission acquires
+        // the released lease and must refresh the stale in-memory
+        // transcript from the durable store before the run appends.
+        let mut events = parts.service.subscribe_events();
+        parts
+            .service
+            .try_submit_prompt("survivor prompt".to_string())
+            .unwrap();
+        let terminal = loop {
+            let envelope = tokio::time::timeout(Duration::from_secs(5), events.recv())
+                .await
+                .expect("timed out waiting for the recovery run's terminal event")
+                .unwrap();
+            if matches!(
+                envelope.event,
+                SessionEvent::RunFailed { .. } | SessionEvent::RunCompleted { .. }
+            ) {
+                break envelope;
+            }
+        };
+        assert!(
+            matches!(terminal.event, SessionEvent::RunCompleted { ref response, .. } if response == "survivor answer"),
+            "the recovery run must complete from the refreshed transcript: {:?}",
+            terminal.event
+        );
+        for _ in 0..100 {
+            if parts.service.active_run().is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(parts.service.active_run().is_none());
+
+        // No committed row was deleted: the peer's prompt and answer, then
+        // the survivor's prompt and answer, are all durable and contiguous.
+        let log = crate::store::TranscriptLogWriter::new(&store_path)
+            .unwrap()
+            .read_from(&session_id, 0)
+            .unwrap();
+        assert_eq!(log.len(), 4);
+        assert_eq!(log[0].0, 1);
+        assert!(matches!(log[0].1, Message::User { ref content } if content == "peer prompt"));
+        assert_eq!(log[1].0, 2);
+        assert!(
+            matches!(log[1].1, Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+        );
+        assert_eq!(log[2].0, 3);
+        assert!(matches!(log[2].1, Message::User { ref content } if content == "survivor prompt"));
+        assert_eq!(log[3].0, 4);
+        assert!(
+            matches!(log[3].1, Message::Assistant { content: Some(ref text), .. } if text == "survivor answer")
+        );
+
+        // Both processes now serve the same complete transcript: the
+        // survivor's in-memory transcript matches the durable store.
+        let agent = parts.service.agent.lock().await;
+        assert_eq!(agent.messages.len(), 5);
+        for (idx, message) in &log {
+            assert_eq!(
+                serde_json::to_vec(message).unwrap(),
+                serde_json::to_vec(&agent.messages[*idx as usize]).unwrap()
+            );
+        }
+        drop(agent);
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -2473,10 +2473,6 @@ impl SessionService {
             },
             (RunOutcome::Failed(message, _), None) => SessionEvent::RunFailed { message },
         };
-        #[cfg(test)]
-        if let SessionEvent::RunFailed { message } = &terminal_event {
-            eprintln!("nac test: unsanitized run failure: {message}");
-        }
         self.event_bus
             .emit_with_context(terminal_event, Some(run_id.clone()), client_id);
         self.clear_finished_run(&run_id);
@@ -6037,8 +6033,7 @@ pub(super) mod tests {
         // The survivor acquires the released lease, adopts the peer's
         // completed exchange plus interrupted prompt, and appends after them.
         let mut events = parts.service.subscribe_events();
-        let mut agent_events = parts.service.subscribe_agent_events();
-        parts
+        let survivor_run = parts
             .service
             .try_submit_prompt("survivor prompt".to_string())
             .unwrap();
@@ -6047,29 +6042,23 @@ pub(super) mod tests {
                 .await
                 .expect("timed out waiting for the recovery run's terminal event")
                 .unwrap();
-            if matches!(
-                envelope.event,
-                SessionEvent::RunFailed { .. } | SessionEvent::RunCompleted { .. }
-            ) {
+            if envelope.run_id.as_ref() == Some(&survivor_run.run_id)
+                && matches!(
+                    envelope.event,
+                    SessionEvent::RunFailed { .. } | SessionEvent::RunCompleted { .. }
+                )
+            {
                 break envelope;
             }
         };
-        if !matches!(
-            &terminal.event,
-            SessionEvent::RunCompleted { response, .. } if response == "survivor answer"
-        ) {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-            let mut model_errors = Vec::new();
-            while let Ok(event) = agent_events.try_recv() {
-                if let AgentEvent::ModelError { message, .. } = event {
-                    model_errors.push(message);
-                }
-            }
-            panic!(
-                "the recovery run must complete from the refreshed transcript: {:?}; model errors: {model_errors:?}",
-                terminal.event
-            );
-        }
+        assert!(
+            matches!(
+                &terminal.event,
+                SessionEvent::RunCompleted { response, .. } if response == "survivor answer"
+            ),
+            "the recovery run must complete from the refreshed transcript: {:?}",
+            terminal.event
+        );
         for _ in 0..100 {
             if parts.service.active_run().is_none() {
                 break;

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -5941,7 +5941,8 @@ pub(super) mod tests {
                         "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
                     })
                     .to_string(),
-                ),
+                )
+                .drop_connection(),
                 ScriptedResponse::json(
                     "200 OK",
                     serde_json::json!({

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -6033,6 +6033,7 @@ pub(super) mod tests {
         // The survivor acquires the released lease, adopts the peer's
         // completed exchange plus interrupted prompt, and appends after them.
         let mut events = parts.service.subscribe_events();
+        let mut agent_events = parts.service.subscribe_agent_events();
         parts
             .service
             .try_submit_prompt("survivor prompt".to_string())
@@ -6049,11 +6050,22 @@ pub(super) mod tests {
                 break envelope;
             }
         };
-        assert!(
-            matches!(&terminal.event, SessionEvent::RunCompleted { response, .. } if response == "survivor answer"),
-            "the recovery run must complete from the refreshed transcript: {:?}",
-            terminal.event
-        );
+        if !matches!(
+            &terminal.event,
+            SessionEvent::RunCompleted { response, .. } if response == "survivor answer"
+        ) {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let mut model_errors = Vec::new();
+            while let Ok(event) = agent_events.try_recv() {
+                if let AgentEvent::ModelError { message, .. } = event {
+                    model_errors.push(message);
+                }
+            }
+            panic!(
+                "the recovery run must complete from the refreshed transcript: {:?}; model errors: {model_errors:?}",
+                terminal.event
+            );
+        }
         for _ in 0..100 {
             if parts.service.active_run().is_none() {
                 break;

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -2005,27 +2005,42 @@ impl SessionService {
                 }
             })?;
             drop(agent);
-            if let Some(durable_blob) = durable_blob {
-                // Reconcile the cached snapshot with the durable blob after
-                // every refresh, not only when this admission rewrote the
-                // blob itself: a prior admission may have repaired the blob
-                // and then failed before patching this copy (e.g. snapshot
-                // lock contention), and the retry sees nothing left to
-                // repair. Without the reconcile, store-backed transcript
-                // reads would serve the discarded dangling turn from the
-                // stale pre-repair snapshot for the rest of the process
-                // lifetime (mirrors the resume path in runtime.rs).
+            if let (Some(session_id), Some(durable_blob)) =
+                (self.metadata.session_id.as_deref(), durable_blob)
+            {
+                // Reconcile every run-state field that the next completion
+                // persists, not only the transcript blob. A peer may have
+                // committed token and timing history before releasing the
+                // lease; retaining the stale cached values would make this
+                // process overwrite that history at its next run end.
+                //
+                // Load after transcript repair so `durable_blob` and the
+                // persisted run state describe the same lease-held store
+                // state. Keep cached identity/configuration fields: cwd is
+                // runtime-canonicalized, and the config revision was checked
+                // above.
+                let durable_snapshot =
+                    sessions::load_session(&self.metadata.store_path, session_id).map_err(
+                        |error| OperationAdmissionPreparationError::Coordination {
+                            message: SessionCoordinationError::store(format!(
+                                "failed to refresh durable session run state: {error:#}"
+                            )),
+                        },
+                    )?;
                 let mut snapshot = self.session_snapshot.try_lock().map_err(|_| {
                     OperationAdmissionPreparationError::Coordination {
                         message: SessionCoordinationError::local_agent_busy(),
                     }
                 })?;
                 if let Some(snapshot) = snapshot.as_mut() {
-                    // The blob is write-once and repairs only truncate it,
-                    // so an equal length means this copy is already current.
-                    if snapshot.messages.len() != durable_blob.len() {
-                        snapshot.messages = durable_blob;
-                    }
+                    snapshot.messages = durable_blob;
+                    snapshot.last_response_duration_ms = durable_snapshot.last_response_duration_ms;
+                    snapshot.previous_response_duration_ms =
+                        durable_snapshot.previous_response_duration_ms;
+                    snapshot.response_durations_ms = durable_snapshot.response_durations_ms;
+                    snapshot.token_usages = durable_snapshot.token_usages;
+                    snapshot.unattributed_token_usage = durable_snapshot.unattributed_token_usage;
+                    snapshot.updated_at = durable_snapshot.updated_at;
                 }
             }
         }
@@ -5813,73 +5828,137 @@ pub(super) mod tests {
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
 
-    /// Peer process for
-    /// `shared_store_recovery_after_peer_crash_preserves_committed_transcript`:
-    /// plays the run owner on a shared store — acquires the session
-    /// operation lease, commits its run's transcript rows, signals
-    /// readiness, then sleeps holding the lease until the parent SIGKILLs it
-    /// (process death releases the lease).
-    #[test]
-    fn shared_store_peer_process_helper() {
+    /// Subprocess for
+    /// `shared_store_recovery_after_peer_crash_preserves_committed_transcript`.
+    /// In `run` mode it completes one real service run, starts a second run,
+    /// and waits in model I/O while holding the operation lease. In `inspect`
+    /// mode it restores the durable transcript as a freshly started process
+    /// and writes that view for the parent to compare.
+    #[tokio::test]
+    async fn shared_store_peer_process_helper() {
         let Some(store_path) = std::env::var_os("NAC_TEST_SHARED_STORE_STORE") else {
             return;
         };
-        let ready_path = PathBuf::from(std::env::var_os("NAC_TEST_SHARED_STORE_READY").unwrap());
+        let store_path = PathBuf::from(store_path);
         let session_id = std::env::var("NAC_TEST_SHARED_STORE_SESSION").unwrap();
-        let _lease =
-            sessions::SessionOperationLease::try_acquire(Path::new(&store_path), &session_id)
+        let base_url = std::env::var("NAC_TEST_SHARED_STORE_BASE_URL").unwrap();
+        let mode =
+            std::env::var("NAC_TEST_SHARED_STORE_MODE").unwrap_or_else(|_| "run".to_string());
+        let client = ModelClient::new_for_test_server(base_url);
+        let mut agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
+        let snapshot = sessions::load_session(&store_path, &session_id).unwrap();
+        agent
+            .restore_messages_merging_log_tail(snapshot.messages.clone(), None)
+            .await
+            .unwrap();
+
+        if mode == "inspect" {
+            let output_path =
+                PathBuf::from(std::env::var_os("NAC_TEST_SHARED_STORE_OUTPUT").unwrap());
+            std::fs::write(output_path, serde_json::to_vec(&agent.messages).unwrap()).unwrap();
+            return;
+        }
+
+        let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+            agent,
+            client,
+            session: OrchestratorSession::Active {
+                session_id,
+                store_path,
+                snapshot,
+            },
+            sandbox_status: "off".to_string(),
+            agents_md_status: "off".to_string(),
+            workspace_display: "/repo".to_string(),
+            workspace_git: Some(GitTarget::local("/repo")),
+            resume_base_cwd: PathBuf::from("/repo"),
+        });
+        let mut events = parts.service.subscribe_events();
+        parts
+            .service
+            .try_submit_prompt("peer completed prompt".to_string())
+            .unwrap();
+        loop {
+            let envelope = tokio::time::timeout(Duration::from_secs(5), events.recv())
+                .await
+                .expect("timed out waiting for the peer's completed run")
                 .unwrap();
-        let writer = crate::store::TranscriptLogWriter::new(Path::new(&store_path)).unwrap();
-        writer
-            .append(
-                &session_id,
-                1,
-                &Message::User {
-                    content: "peer prompt".to_string(),
-                },
-            )
+            if matches!(
+                &envelope.event,
+                SessionEvent::RunCompleted { response, .. } if response == "peer answer"
+            ) {
+                break;
+            }
+        }
+        for _ in 0..100 {
+            if parts.service.active_run().is_none() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(parts.service.active_run().is_none());
+
+        parts
+            .service
+            .try_submit_prompt("peer interrupted prompt".to_string())
             .unwrap();
-        writer
-            .append(
-                &session_id,
-                2,
-                &Message::Assistant {
-                    content: Some("peer answer".to_string()),
-                    reasoning_text: None,
-                    reasoning_details: None,
-                    tool_calls: None,
-                    duration_ms: None,
-                    model_origin: None,
-                    reasoning_field: None,
-                },
-            )
-            .unwrap();
-        std::fs::write(ready_path, b"ready").unwrap();
-        std::thread::sleep(Duration::from_secs(30));
+        tokio::time::sleep(Duration::from_secs(30)).await;
     }
 
-    /// Regression test for issue #146 (shared-store recovery): two `nac-web`
-    /// processes share one SQLite store. The peer (child process) commits
-    /// transcript rows under the operation lease and is killed; this
-    /// service's long-lived cached agent still holds the pre-peer in-memory
-    /// transcript. Accepting the recovery submission must refresh the stale
-    /// transcript under the released lease: the run must succeed, and no
-    /// committed row may be deleted.
+    /// Regression test for issue #146 (shared-store recovery): a child
+    /// process completes one real run, starts another, and is SIGKILLed while
+    /// its model request holds the session operation lease. A survivor with a
+    /// stale cached service must adopt every committed transcript row and
+    /// persisted run-state field before running. A fresh post-recovery
+    /// process must then restore the same transcript, with counters and
+    /// SQLite integrity intact.
     #[tokio::test]
     async fn shared_store_recovery_after_peer_crash_preserves_committed_transcript() {
         use crate::model::test_http::{ScriptedResponse, ScriptedServer};
 
         let store_path = test_store_path("shared_store_recovery");
         let session_id = "session-shared-store".to_string();
-        let server = ScriptedServer::start(vec![ScriptedResponse::json(
-            "200 OK",
-            serde_json::json!({
-                "status": "completed",
-                "output": [{"type": "message", "content": [{"type": "output_text", "text": "survivor answer"}]}],
-                "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
-            })
-            .to_string(),
-        )]);
+        let (interrupted_ready_sender, interrupted_ready_receiver) =
+            std::sync::mpsc::sync_channel(1);
+        let (release_interrupted_sender, release_interrupted_receiver) =
+            std::sync::mpsc::sync_channel(1);
+        let server = ScriptedServer::start_observed(
+            vec![
+                ScriptedResponse::json(
+                    "200 OK",
+                    serde_json::json!({
+                        "status": "completed",
+                        "output": [{"type": "message", "content": [{"type": "output_text", "text": "peer answer"}]}],
+                        "usage": {"input_tokens": 101, "output_tokens": 11, "total_tokens": 112}
+                    })
+                    .to_string(),
+                ),
+                ScriptedResponse::json(
+                    "200 OK",
+                    serde_json::json!({
+                        "status": "completed",
+                        "output": [{"type": "message", "content": [{"type": "output_text", "text": "killed answer"}]}],
+                        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+                    })
+                    .to_string(),
+                ),
+                ScriptedResponse::json(
+                    "200 OK",
+                    serde_json::json!({
+                        "status": "completed",
+                        "output": [{"type": "message", "content": [{"type": "output_text", "text": "survivor answer"}]}],
+                        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+                    })
+                    .to_string(),
+                ),
+            ],
+            move |index, _request| {
+                if index == 1 {
+                    interrupted_ready_sender.send(()).unwrap();
+                    release_interrupted_receiver.recv().unwrap();
+                }
+            },
+        );
         let client = ModelClient::new_for_test_server(server.base_url.clone());
         let agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
         let snapshot = sessions::new_snapshot(
@@ -5910,14 +5989,19 @@ pub(super) mod tests {
             workspace_git: Some(GitTarget::local("/repo")),
             resume_base_cwd: PathBuf::from("/repo"),
         });
-        // The survivor's cached agent is stale from the start: it holds only
-        // the creation-time transcript (one system message).
+        // The survivor's cached agent and run accounting predate both peer
+        // runs.
         assert_eq!(parts.service.agent.lock().await.messages.len(), 1);
+        assert!(parts
+            .service
+            .session_snapshot
+            .lock()
+            .await
+            .as_ref()
+            .unwrap()
+            .token_usages
+            .is_empty());
 
-        // The peer process commits its run's transcript rows under the
-        // operation lease, then is killed mid-ownership (SIGKILL): the OS
-        // releases the lease.
-        let ready_path = store_path.parent().unwrap().join("peer-ready");
         let mut child = std::process::Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
@@ -5925,30 +6009,27 @@ pub(super) mod tests {
                 "--nocapture",
             ])
             .env("NAC_TEST_SHARED_STORE_STORE", &store_path)
-            .env("NAC_TEST_SHARED_STORE_READY", &ready_path)
             .env("NAC_TEST_SHARED_STORE_SESSION", &session_id)
+            .env("NAC_TEST_SHARED_STORE_BASE_URL", &server.base_url)
+            .env("NAC_TEST_SHARED_STORE_MODE", "run")
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()
             .unwrap();
-        for _ in 0..200 {
-            if ready_path.exists() {
-                break;
-            }
-            assert!(
-                child.try_wait().unwrap().is_none(),
-                "peer helper exited early"
-            );
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(ready_path.exists(), "peer helper never became ready");
+        interrupted_ready_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("peer never reached its interrupted model request");
+        assert!(
+            child.try_wait().unwrap().is_none(),
+            "peer helper exited before SIGKILL"
+        );
         child.kill().unwrap();
         child.wait().unwrap();
+        release_interrupted_sender.send(()).unwrap();
 
-        // The survivor accepts the recovery submission. Admission acquires
-        // the released lease and must refresh the stale in-memory
-        // transcript from the durable store before the run appends.
+        // The survivor acquires the released lease, adopts the peer's
+        // completed exchange plus interrupted prompt, and appends after them.
         let mut events = parts.service.subscribe_events();
         parts
             .service
@@ -5967,7 +6048,7 @@ pub(super) mod tests {
             }
         };
         assert!(
-            matches!(terminal.event, SessionEvent::RunCompleted { ref response, .. } if response == "survivor answer"),
+            matches!(&terminal.event, SessionEvent::RunCompleted { response, .. } if response == "survivor answer"),
             "the recovery run must complete from the refreshed transcript: {:?}",
             terminal.event
         );
@@ -5979,38 +6060,98 @@ pub(super) mod tests {
         }
         assert!(parts.service.active_run().is_none());
 
-        // No committed row was deleted: the peer's prompt and answer, then
-        // the survivor's prompt and answer, are all durable and contiguous.
         let log = crate::store::TranscriptLogWriter::new(&store_path)
             .unwrap()
             .read_from(&session_id, 0)
             .unwrap();
-        assert_eq!(log.len(), 4);
+        assert_eq!(log.len(), 5);
         assert_eq!(log[0].0, 1);
-        assert!(matches!(log[0].1, Message::User { ref content } if content == "peer prompt"));
+        assert!(
+            matches!(&log[0].1, Message::User { content } if content == "peer completed prompt")
+        );
         assert_eq!(log[1].0, 2);
         assert!(
-            matches!(log[1].1, Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+            matches!(&log[1].1, Message::Assistant { content: Some(text), .. } if text == "peer answer")
         );
         assert_eq!(log[2].0, 3);
-        assert!(matches!(log[2].1, Message::User { ref content } if content == "survivor prompt"));
-        assert_eq!(log[3].0, 4);
         assert!(
-            matches!(log[3].1, Message::Assistant { content: Some(ref text), .. } if text == "survivor answer")
+            matches!(&log[2].1, Message::User { content } if content == "peer interrupted prompt")
+        );
+        assert_eq!(log[3].0, 4);
+        assert!(matches!(&log[3].1, Message::User { content } if content == "survivor prompt"));
+        assert_eq!(log[4].0, 5);
+        assert!(
+            matches!(&log[4].1, Message::Assistant { content: Some(text), .. } if text == "survivor answer")
         );
 
-        // Both processes now serve the same complete transcript: the
-        // survivor's in-memory transcript matches the durable store.
         let agent = parts.service.agent.lock().await;
-        assert_eq!(agent.messages.len(), 5);
+        assert_eq!(agent.messages.len(), 6);
         for (idx, message) in &log {
             assert_eq!(
                 serde_json::to_vec(message).unwrap(),
                 serde_json::to_vec(&agent.messages[*idx as usize]).unwrap()
             );
         }
+        let survivor_messages = serde_json::to_vec(&agent.messages).unwrap();
         drop(agent);
 
+        // The recovery run must append its accounting to the peer's durable
+        // history rather than overwriting that history from the survivor's
+        // stale cached snapshot.
+        let loaded = sessions::load_session(&store_path, &session_id).unwrap();
+        assert_eq!(loaded.token_usages.len(), 2);
+        assert_eq!(loaded.token_usages[0].as_ref().unwrap().input_tokens, 101);
+        assert_eq!(loaded.token_usages[1].as_ref().unwrap().input_tokens, 10);
+        let durations = loaded.response_durations_ms.as_ref().unwrap();
+        assert_eq!(durations.len(), 2);
+        assert!(durations[0].is_some());
+        assert!(durations[1].is_some());
+
+        let summary = sessions::list_sessions(&store_path)
+            .unwrap()
+            .into_iter()
+            .find(|summary| summary.session_id == session_id)
+            .unwrap();
+        assert_eq!(summary.visible_message_count, 5);
+        assert_eq!(summary.last_user_prompt.as_deref(), Some("survivor prompt"));
+        assert_eq!(summary.run_count, 3);
+        let connection = crate::store::open_connection(&store_path).unwrap();
+        let integrity: String = connection
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(integrity, "ok");
+        drop(connection);
+
+        // A new process after recovery must restore the same complete
+        // transcript as the still-live survivor.
+        let restarted_output = store_path
+            .parent()
+            .unwrap()
+            .join("restarted-transcript.json");
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "session_service::tests::shared_store_peer_process_helper",
+                "--nocapture",
+            ])
+            .env("NAC_TEST_SHARED_STORE_STORE", &store_path)
+            .env("NAC_TEST_SHARED_STORE_SESSION", &session_id)
+            .env("NAC_TEST_SHARED_STORE_BASE_URL", &server.base_url)
+            .env("NAC_TEST_SHARED_STORE_MODE", "inspect")
+            .env("NAC_TEST_SHARED_STORE_OUTPUT", &restarted_output)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .unwrap();
+        assert!(status.success(), "restarted peer helper failed");
+        assert_eq!(
+            std::fs::read(&restarted_output).unwrap(),
+            survivor_messages,
+            "restarted and surviving processes must serve the same transcript"
+        );
+
+        assert_eq!(server.finish().len(), 3);
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }
 


### PR DESCRIPTION
## Description

**What.** Prevents shared-store recovery from truncating committed transcripts or overwriting peer run-state accounting after a process crash.

**Why.** A surviving `SessionService` can outlive the process that last held the operation lease. Without rehydration, its cached agent and session snapshot can predate durable transcript rows, token usage, and timing history committed by that peer.

After admission acquires the session operation lease, the agent now reloads the durable snapshot plus transcript-log tail before starting work. Genuine gaps are repaired under the lease, dangling tool turns are normalized, and the cached session snapshot adopts the repaired blob plus every run-end-persisted accounting field. Terminal normalization also tracks rows committed or adopted by the process so stale in-memory boundaries cannot delete peer rows; in-flight blocking append stragglers remain attributable to the process that submitted them.

Closes #146.

## Usage

No user-facing usage change. Shared-store recovery after a peer crash preserves committed history automatically; no configuration or API changes are required.

## Changelog

- Refreshes cached transcript state under the operation lease before run or compaction admission.
- Preserves peer-committed transcript rows in run-failure and cancellation normalization paths.
- Reconciles cached token usage and response timing history from the durable session before the survivor persists its next run.
- Adds unit coverage for stale peer rows, append stragglers, dangling turns, snapshot repair, and lease validation.
- Adds a subprocess regression that completes a peer run, kills the peer during a second active run, recovers through a stale survivor, and verifies a fresh process restores the same state.

## Bug Evidence

Before this change, a survivor accepted recovery after the prior owner was killed, failed a non-contiguous append, and normalized from its stale in-memory transcript length. That path permanently deleted the prior owner's committed assistant output and later user prompt. A stale cached run-state snapshot could also overwrite the peer's token and timing history when the survivor completed its next run.

The regression now drives a real child `SessionService`: it completes one exchange, submits another prompt, and is killed while blocked in model I/O holding the lease. The stale survivor then recovers and completes a new run. The test asserts five contiguous durable rows, retained peer and survivor usage/timing slots, `visible_message_count = 5`, `run_count = 3`, the final user prompt, `PRAGMA integrity_check = ok`, and byte-identical transcripts from the survivor and a freshly restored subprocess.

## Validation

`cargo test -p nac-core shared_store_recovery_after_peer_crash_preserves_committed_transcript -- --nocapture` passed the active-run SIGKILL and restart regression (1 passed). `cargo test -p nac-core --locked --no-fail-fast` passed 812 tests across two suites with 9 ignored. `cargo check --workspace --locked --all-targets` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes durable transcript semantics, admission, and cancel/failure normalization—incorrect bounds could still truncate history or corrupt shared sessions; mitigated by broad tests including a multi-process SIGKILL scenario.
> 
> **Overview**
> Fixes **shared-store recovery** when a long-lived `SessionService` outlives the process that last held the session operation lease. Without rehydration, stale in-memory transcripts caused **contiguous-append failures** and **terminal normalization** that deleted **peer-committed log rows** from an outdated length.
> 
> The agent now maintains **`committed_log_len`** (rows this process committed or adopted). Log appends **claim indices before** the blocking write so in-flight **stragglers** still count as own commits and can be trimmed safely; failed appends roll the claim back. **Run-failure and cancellation** paths detect durable rows beyond that bound and **reload** snapshot + log tail instead of deleting from the stale vec length.
> 
> On **operation admission**, **`refresh_transcript_under_lease`** reloads the durable transcript (gap repair and dangling-tool normalization under the lease), and the cached session snapshot is reconciled with the durable blob plus **token usage and response timing** so the next run does not overwrite peer history. A subprocess regression covers peer SIGKILL mid-run; unit tests cover peer rows, stragglers, lease validation, and stale cached snapshots after repair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1373b871e15f206273bb1af0cc301e31c76715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->