### PR TITLE
fix(model): narrow caller-supplied base_url trust boundary to loopback

### DIFF
--- a/crates/nac-core/src/model/backend.rs
+++ b/crates/nac-core/src/model/backend.rs
@@ -125,13 +125,36 @@ fn normalized_host(host: &str) -> String {
     host.trim_end_matches('.').to_ascii_lowercase()
 }
 
+/// Whether a host is loopback, and therefore safe to auto-approve for
+/// credential-bearing requests without an explicit operator opt-in.
+///
+/// Private and link-local networks are deliberately excluded: an attacker who
+/// can influence `base_url` must not be able to aim the model client at an
+/// internal service (e.g. the cloud metadata endpoint `169.254.169.254`) and
+/// have NAC transmit the resolved API key to it. Such hosts must instead be
+/// listed under `[security] trusted_base_url_hosts`.
+fn is_loopback_host(host: &url::Host<&str>) -> bool {
+    match host {
+        url::Host::Domain(domain) => {
+            let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+            domain == "localhost" || domain.ends_with(".localhost")
+        }
+        url::Host::Ipv4(address) => address.is_loopback(),
+        url::Host::Ipv6(address) => address.is_loopback(),
+    }
+}
+
 /// Reject a base URL that would send an API key to an origin the operator
 /// never approved.
 ///
 /// This is the trust boundary for values arriving over the unauthenticated
 /// loopback HTTP API: `config.toml` is edited by hand and is therefore
-/// authoritative, while a request body is not. Loopback and private-network
-/// hosts stay usable without an opt-in so local proxies keep working.
+/// authoritative, while a request body is not. Only loopback hosts are
+/// auto-approved without an opt-in; private/link-local networks (including the
+/// cloud metadata endpoint `169.254.169.254`) must be listed under
+/// `[security] trusted_base_url_hosts` so an attacker who can influence
+/// `base_url` cannot point the client at an internal service and have NAC send
+/// the API key there.
 pub fn validate_caller_supplied_base_url(
     backend: BackendKind,
     base_url: &str,
@@ -154,7 +177,11 @@ pub fn validate_caller_supplied_base_url(
             base_url
         ))
     })?;
-    if types::allows_plaintext_transport(&host) {
+    // Only loopback hosts are auto-approved for credential-bearing requests
+    // arriving over the unauthenticated API. Previously this also approved
+    // every private/link-local address (incl. 169.254.169.254), which let a
+    // caller exfiltrate the API key to an internal/cloud service (SSRF).
+    if is_loopback_host(&host) {
         return Ok(());
     }
 


### PR DESCRIPTION
## Summary
Closes #167.

`validate_caller_supplied_base_url` previously short-circuited its `trusted_base_url_hosts` check for **every** private or link-local host, because `allows_plaintext_transport` returns `true` for `is_private() || is_link_local()`. That includes the cloud metadata endpoint `169.254.169.254` and all RFC1918 ranges, so a caller who could influence `base_url` (the unauthenticated loopback API, `--allow-remote`, or a compromised project config) could aim the model client at an internal service and have NAC transmit the resolved API key to it (SSRF + credential exfiltration).

## Change
- Added `is_loopback_host`, which approves **loopback only** (`localhost`, `127.0.0.0/8`, `::1`).
- `validate_caller_supplied_base_url` now auto-approves loopback hosts and otherwise requires the host to be in `builtin_provider_hosts` or `[security] trusted_base_url_hosts`. Private/link-local hosts that are not explicitly trusted are now rejected.
- `allows_plaintext_transport` is left unchanged for the *HTTPS-enforcement* path in `resolve_model_base_url` (transport-only concern, separate from the credential-sending trust decision).

## Migration
Operators who legitimately point a model at a private/LAN IP (e.g. a local proxy) must now add that host to `[security] trusted_base_url_hosts`. Loopback proxies (`localhost`, `127.0.0.1`) are unaffected.

## Verification
`cargo check -p nac-core` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix on the credential-sending trust boundary for caller-controlled base_url; misconfiguration could block legitimate private proxies until hosts are allowlisted.
> 
> **Overview**
> **Fixes SSRF/credential exfiltration** when callers can set `base_url` on the unauthenticated loopback API: `validate_caller_supplied_base_url` no longer treats all private/link-local hosts as implicitly trusted (it previously reused the same breadth as plaintext HTTP transport).
> 
> Adds **`is_loopback_host`** so only `localhost` / loopback IPs auto-approve sending API keys without operator opt-in. Private and link-local targets (including **`169.254.169.254`**) must match **`builtin_provider_hosts`** or **`[security] trusted_base_url_hosts`**. Plaintext HTTP rules via **`allows_plaintext_transport`** are unchanged.
> 
> Operators pointing models at LAN/private proxies need to add those hosts to **`trusted_base_url_hosts`**; loopback proxies stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a183966e5c9045b19d6169b0b06365ce00437f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->