### PR TITLE
fix(server): confine /filesystem/browse to workspace and home

### DIFF
--- a/crates/nac-server/src/filesystem.rs
+++ b/crates/nac-server/src/filesystem.rs
@@ -63,6 +63,10 @@ pub enum BrowseError {
     NotFound(String),
     NotADirectory(String),
     Unreadable { path: String, reason: String },
+    /// The requested path resolved outside the roots the server is allowed to
+    /// expose (the workspace and the user's home). Returned instead of listing
+    /// an arbitrary host directory over the unauthenticated loopback API.
+    OutsideAllowedRoots(String),
 }
 
 impl std::fmt::Display for BrowseError {
@@ -72,6 +76,9 @@ impl std::fmt::Display for BrowseError {
             Self::NotADirectory(path) => write!(formatter, "path '{path}' is not a directory"),
             Self::Unreadable { path, reason } => {
                 write!(formatter, "could not read directory '{path}': {reason}")
+            }
+            Self::OutsideAllowedRoots(path) => {
+                write!(formatter, "path '{path}' is outside the allowed roots")
             }
         }
     }

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2666,6 +2666,22 @@ async fn browse_filesystem_handler(
     Query(query): Query<filesystem::BrowseQuery>,
 ) -> std::result::Result<Json<filesystem::BrowseListing>, ApiError> {
     let listing = filesystem::browse(&query, &manager.inner.root_cwd)?;
+    // The loopback API is unauthenticated, so confine the picker to the
+    // workspace and the user's home. Without this, any client could enumerate
+    // arbitrary host directories (e.g. /etc, other users' homes). See #168.
+    let allowed_roots: Vec<std::path::PathBuf> = {
+        let mut roots = vec![manager.inner.root_cwd.clone()];
+        if let Some(home) = std::env::var_os("HOME") {
+            roots.push(std::path::PathBuf::from(home));
+        }
+        roots
+    };
+    let target = std::path::Path::new(&listing.path);
+    if !allowed_roots.iter().any(|root| target.starts_with(root)) {
+        return Err(ApiError::from(filesystem::BrowseError::OutsideAllowedRoots(
+            listing.path.clone(),
+        )));
+    }
     Ok(Json(listing))
 }
 
@@ -4619,6 +4635,7 @@ impl From<filesystem::BrowseError> for ApiError {
             filesystem::BrowseError::NotFound(_) => StatusCode::NOT_FOUND,
             filesystem::BrowseError::NotADirectory(_) => StatusCode::BAD_REQUEST,
             filesystem::BrowseError::Unreadable { .. } => StatusCode::FORBIDDEN,
+            filesystem::BrowseError::OutsideAllowedRoots(_) => StatusCode::FORBIDDEN,
         };
         Self {
             status,


### PR DESCRIPTION
## Summary
Closes #168.

`/filesystem/browse` accepted an arbitrary `path` query parameter and listed any directory on the host, with no confinement to the workspace, home, or config directory. Because the loopback API is unauthenticated, any client that could reach it could enumerate arbitrary host directories (e.g. `/etc`, other users' homes), leaking filesystem structure.

## Change
- Added a `BrowseError::OutsideAllowedRoots` variant and mapped it to HTTP 403 in the existing `From<filesystem::BrowseError> for ApiError`.
- `browse_filesystem_handler` now computes the allowed roots (the workspace `root_cwd` and the user's `HOME`) and rejects listings whose canonical path does not start with one of them. Symlink escapes are also blocked, because the resolved (post-`canonicalize`) path is what is checked.
- The `browse` function itself is unchanged (no signature change, no test churn); the confinement lives at the API boundary where the trust decision belongs.

## Notes
This confines the picker to the workspace and the user's own home, which covers the legitimate "pick a working directory / config file" use cases while preventing enumeration of system and other-user directories. A stricter, operator-configurable allowlist can be layered on later.

## Verification
`cargo check -p nac-server` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fix on an unauthenticated endpoint; behavior change may block legitimate paths outside workspace/home that clients previously could browse.
> 
> **Overview**
> Closes a path-enumeration hole on the **unauthenticated** loopback `GET /fs/browse` API: arbitrary `path` values could list host directories outside the session workspace.
> 
> After `filesystem::browse` returns, **`browse_filesystem_handler`** now allows only listings whose **canonical** `listing.path` is under the session **`root_cwd`** or **`HOME`**; anything else becomes **`BrowseError::OutsideAllowedRoots`** and **HTTP 403**. Symlink/`..` escapes are covered because `browse` already canonicalizes before the check.
> 
> The core **`browse`** helper is unchanged; confinement lives at the API boundary with a new error variant and **`Display`** / **`ApiError`** mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c665a533d0f2705636410b53325b04b52ca1b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->