### PR TITLE
fix(scripts): add opt-in SHA-256 verification to installers

### DIFF
--- a/scripts/install-skill.sh
+++ b/scripts/install-skill.sh
@@ -86,6 +86,26 @@ fetch_file() {
 fetch_file skills/nac-onboarding/SKILL.md "$skill_file"
 fetch_file skills/nac-onboarding/agents/openai.yaml "$metadata_file"
 
+# Optional integrity check for the agent skill that will be loaded and run.
+# Set NAC_SKILL_CHECKSUM to the expected SHA-256 (hex) of SKILL.md. Opt-in, so
+# existing installs are unaffected; a mismatch aborts before the file is moved
+# into the skills directory.
+if [ -n "${NAC_SKILL_CHECKSUM:-}" ]; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$skill_file" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$skill_file" | cut -d' ' -f1)"
+  else
+    echo "NAC_SKILL_CHECKSUM set but neither sha256sum nor shasum is available; refusing to skip verification" >&2
+    exit 1
+  fi
+  if [ "$actual" != "$NAC_SKILL_CHECKSUM" ]; then
+    echo "skill checksum mismatch: expected $NAC_SKILL_CHECKSUM, got $actual" >&2
+    exit 1
+  fi
+  echo "verified nac-onboarding SKILL.md checksum"
+fi
+
 mkdir -p "$skill_dir/agents"
 mv "$skill_file" "$skill_dir/SKILL.md"
 mv "$metadata_file" "$skill_dir/agents/openai.yaml"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,6 +63,27 @@ trap 'rm -rf "$tmpdir"' EXIT INT TERM
 archive="$tmpdir/$asset"
 download "$url" "$archive"
 
+# Optional integrity check. Set NAC_CHECKSUM to the expected SHA-256 (hex) of
+# the release asset to verify it before extraction. This is opt-in, so existing
+# installs are unaffected; when set, a mismatch aborts the install instead of
+# executing a substituted binary. Publishing a SHA256SUMS alongside releases
+# would let operators pin this by default in a follow-up.
+if [ -n "${NAC_CHECKSUM:-}" ]; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$archive" | cut -d' ' -f1)"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$archive" | cut -d' ' -f1)"
+  else
+    echo "NAC_CHECKSUM set but neither sha256sum nor shasum is available; refusing to skip verification" >&2
+    exit 1
+  fi
+  if [ "$actual" != "$NAC_CHECKSUM" ]; then
+    echo "checksum mismatch: expected $NAC_CHECKSUM, got $actual" >&2
+    exit 1
+  fi
+  echo "verified $asset checksum"
+fi
+
 mkdir -p "$INSTALL_DIR"
 tar -xzf "$archive" -C "$tmpdir"
 install -m 755 "$tmpdir/nac-web" "$INSTALL_DIR/nac-web"


### PR DESCRIPTION
## Summary
Closes #171.

`scripts/install.sh` downloads a release tarball over TLS and then extracts and installs the `nac-web` binary **without any integrity verification**. If an attacker can influence `NAC_BASE_URL`/`NAC_REPO` or MITM the (non-pinned) fetch, they can substitute an artifact that is then executed as the user. `install-skill.sh` has the same gap for the agent skill files it loads (which the agent subsequently runs).

## Change
- Added an **opt-in** `NAC_CHECKSUM` (expected SHA-256, hex) verification to `scripts/install.sh`. When `NAC_CHECKSUM` is set, the downloaded archive's SHA-256 is computed (via `sha256sum`, falling back to `shasum -a 256`) and compared; a mismatch aborts the install. When unset, behavior is unchanged, so existing installs are unaffected.
- Added the same opt-in `NAC_SKILL_CHECKSUM` verification to `scripts/install-skill.sh` for the fetched `SKILL.md` (the file that is loaded and executed as an agent skill).

This is a minimal, backward-compatible hardening step. A follow-up would be for the project to publish a `SHA256SUMS` (and ideally a signed manifest) alongside releases so operators can pin `NAC_CHECKSUM` by default.

## Verification
Shell syntax checked with `sh -n` on both scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, backward-compatible hardening in install scripts only; verification is opt-in and does not change default install paths or binary behavior.
> 
> **Overview**
> Adds **optional integrity checks** to the shell installers so operators can pin expected SHA-256 digests before anything is extracted or installed.
> 
> When **`NAC_CHECKSUM`** is set, `install.sh` hashes the downloaded release tarball (via `sha256sum` or `shasum -a 256`) and **aborts on mismatch** before `tar`/`install`. When **`NAC_SKILL_CHECKSUM`** is set, `install-skill.sh` does the same for fetched **`SKILL.md`** before it is moved into the skills directory. If a checksum env var is set but no hasher is available, both scripts **fail closed** rather than skipping verification.
> 
> Default behavior is unchanged when those variables are unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38e5ea8bb3aef7a78598d881ffeb4b4f51768f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->