### PR TITLE
fix(server): require public IP-literal Hosts to be allowlisted

### DIFF
--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2288,16 +2288,24 @@ fn is_non_rebindable_host(host: &str) -> bool {
     let Some(bare) = bare_host(host) else {
         return false;
     };
-    // Only loopback hosts bypass the DNS-name allowlist. Previously every
-    // IP-literal Host (including public IPs and 0.0.0.0) was treated as
-    // non-rebindable, which weakened the Host-allowlist defense under
-    // --allow-remote. Non-loopback IP literals now require an explicit entry
-    // in NAC_ALLOWED_HOSTS. See #172.
+    // A browser always sends the name it dialled and cannot forge an
+    // IP-literal Host, so loopback, private, and link-local addresses cannot
+    // be DNS-rebound and keep bypassing the DNS-name allowlist. This preserves
+    // LAN/private-network access (e.g. reaching nac-web from 192.168.x.x).
+    // Public IP literals (including 0.0.0.0) can be supplied by a fronting
+    // proxy under --allow-remote, so they must be explicitly listed in
+    // NAC_ALLOWED_HOSTS rather than bypassing the allowlist. See #172.
     if bare.eq_ignore_ascii_case("localhost") {
         return true;
     }
     match bare.parse::<std::net::IpAddr>() {
-        Ok(address) => address.is_loopback(),
+        Ok(address) => match address {
+            std::net::IpAddr::V4(v4) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+            std::net::IpAddr::V6(v6) => {
+                let leading = v6.segments()[0];
+                v6.is_loopback() || leading & 0xfe00 == 0xfc00 || leading & 0xffc0 == 0xfe80
+            }
+        },
         Err(_) => false,
     }
 }
@@ -5679,7 +5687,14 @@ mod tests {
                 "{host} should not be rebindable"
             );
         }
-        for host in ["example.com", "127.0.0.1.example.com", "[::1", ""] {
+        for host in [
+            "example.com",
+            "127.0.0.1.example.com",
+            "[::1",
+            "",
+            "203.0.113.5",
+            "0.0.0.0",
+        ] {
             assert!(
                 !is_non_rebindable_host(host),
                 "{host} should require an allowlist entry"
@@ -5688,8 +5703,8 @@ mod tests {
 
         for host in ["10.0.0.1", "192.168.1.10:3210", "[fd00::1]:3210"] {
             assert!(
-                !is_non_rebindable_host(host),
-                "{host} is a non-loopback IP literal and must require an allowlist entry"
+                is_non_rebindable_host(host),
+                "{host} is a private/link-local IP literal and cannot be rebound"
             );
         }
     }

--- a/crates/nac-server/src/lib.rs
+++ b/crates/nac-server/src/lib.rs
@@ -2288,7 +2288,18 @@ fn is_non_rebindable_host(host: &str) -> bool {
     let Some(bare) = bare_host(host) else {
         return false;
     };
-    bare.eq_ignore_ascii_case("localhost") || bare.parse::<std::net::IpAddr>().is_ok()
+    // Only loopback hosts bypass the DNS-name allowlist. Previously every
+    // IP-literal Host (including public IPs and 0.0.0.0) was treated as
+    // non-rebindable, which weakened the Host-allowlist defense under
+    // --allow-remote. Non-loopback IP literals now require an explicit entry
+    // in NAC_ALLOWED_HOSTS. See #172.
+    if bare.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    match bare.parse::<std::net::IpAddr>() {
+        Ok(address) => address.is_loopback(),
+        Err(_) => false,
+    }
 }
 
 fn host_is_allowed(host: &str, allowed: &[String]) -> bool {
@@ -5677,8 +5688,8 @@ mod tests {
 
         for host in ["10.0.0.1", "192.168.1.10:3210", "[fd00::1]:3210"] {
             assert!(
-                is_non_rebindable_host(host),
-                "{host} is an IP literal and cannot be rebound"
+                !is_non_rebindable_host(host),
+                "{host} is a non-loopback IP literal and must require an allowlist entry"
             );
         }
     }


### PR DESCRIPTION
## Summary
Closes #172.

`is_non_rebindable_host` (`crates/nac-server/src/lib.rs`) treated **every** IP-literal `Host` as non-rebindable, so it bypassed the `NAC_ALLOWED_HOSTS` DNS-name allowlist — including public IPs and `0.0.0.0`. The comment argues browsers cannot forge an IP-literal `Host`, which is true for *DNS-rebinding* protection, but when nac-web runs with `--allow-remote` behind a reverse proxy an attacker-controlled `Host: <server-public-ip>` still passes the guard without being in `NAC_ALLOWED_HOSTS`, weakening that defense.

## Change
- `is_non_rebindable_host` now returns `true` only for `localhost` and IP addresses that are **loopback, private, or link-local** (`is_loopback || is_private || is_link_local`, matching the existing `allows_plaintext_transport` logic). These cannot be DNS-rebound, so LAN/private-network access (e.g. reaching nac-web from `192.168.x.x`) is preserved exactly as before.
- **Public** IP literals (including `0.0.0.0`) now fall through to the `NAC_ALLOWED_HOSTS` check and must be explicitly listed (or `*`).
- Added coverage: `203.0.113.5` and `0.0.0.0` now assert they require an allowlist entry; the existing private/link-local assertions (`10.0.0.1`, `192.168.1.10`, `fd00::1`) are unchanged because they remain non-rebindable.

## Notes
This is a narrower fix than "loopback-only": restricting private/link-local would break legitimate LAN access and is unnecessary, since those ranges cannot be DNS-rebound. Only public IP literals (the actual `--allow-remote` bypass vector) are tightened.

## Verification
Full `cargo test -p nac-server --lib` passes (98/98).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-guard behavior for remote deployments; misconfigured operators may need to add public IPs to NAC_ALLOWED_HOSTS, but the security fix is intentional and LAN access is preserved.
> 
> **Overview**
> Tightens DNS-rebinding protection for the `Host` header when nac-web runs with remote access. **`is_non_rebindable_host`** no longer treats every IP literal as safe to skip **`NAC_ALLOWED_HOSTS`**; only **`localhost`** and **loopback, private, or link-local** addresses still bypass the allowlist (so LAN use via `192.168.x.x` and similar is unchanged).
> 
> **Public** IP literals—including **`0.0.0.0`**—must now match **`NAC_ALLOWED_HOSTS`** (or `*`), closing a gap where a reverse-proxy **`Host: <public-ip>`** could pass the guard without being listed (#172).
> 
> Unit tests add **`203.0.113.5`** and **`0.0.0.0`** as hosts that require allowlisting and clarify messaging for private/link-local literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669492c9702f1aa697fda44394c0d4f737e59063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->