### PR TITLE
fix(transcript): bound shared-store recovery work

### DIFF
--- a/crates/nac-core/src/agent/compaction/planning.rs
+++ b/crates/nac-core/src/agent/compaction/planning.rs
@@ -7,9 +7,11 @@ use sha2::{Digest, Sha256};
 
 use crate::events::{CompactionReason, CompactionSkipReason};
 use crate::store::orchestrator_compaction::{
-    append_orchestrator_compaction_checkpoint, load_orchestrator_compaction_checkpoints,
+    append_orchestrator_compaction_checkpoint, latest_orchestrator_compaction_checkpoint_id,
+    load_latest_orchestrator_compaction_checkpoint, load_orchestrator_compaction_checkpoints,
     NewOrchestratorCompactionCheckpoint, OrchestratorCompactionCheckpoint,
 };
+use crate::store::transcript_cursor_survives;
 use crate::types::{Message, ToolDefinition};
 
 pub(in crate::agent) const PROMPT_POLICY_VERSION: u32 = 2;
@@ -66,6 +68,8 @@ pub(in crate::agent) struct CompactionState {
     session_id: String,
     threshold_tokens: Option<u64>,
     active_checkpoint: Option<OrchestratorCompactionCheckpoint>,
+    observed_checkpoint_id: Option<Option<i64>>,
+    observed_system_policy_sha256: Option<[u8; 32]>,
     context_sample: Option<ContextSample>,
 }
 
@@ -76,15 +80,22 @@ impl CompactionState {
             session_id,
             threshold_tokens,
             active_checkpoint: None,
+            observed_checkpoint_id: None,
+            observed_system_policy_sha256: None,
             context_sample: None,
         }
     }
 
     pub fn restore_newest_valid_checkpoint(&mut self, messages: &[Message]) -> Result<()> {
-        let restored_checkpoint =
-            load_orchestrator_compaction_checkpoints(&self.store_path, &self.session_id)?
-                .into_iter()
-                .find(|checkpoint| checkpoint_is_valid(checkpoint, messages));
+        let observed_checkpoint_id =
+            latest_orchestrator_compaction_checkpoint_id(&self.store_path, &self.session_id)?;
+        let checkpoints =
+            load_orchestrator_compaction_checkpoints(&self.store_path, &self.session_id)?;
+        self.observed_system_policy_sha256 = Some(system_policy_digest(messages));
+        self.observed_checkpoint_id = Some(observed_checkpoint_id);
+        let restored_checkpoint = checkpoints
+            .into_iter()
+            .find(|checkpoint| checkpoint_is_valid(checkpoint, messages));
         let restored_checkpoint_id = restored_checkpoint.as_ref().map(|checkpoint| checkpoint.id);
         let preserve_context_sample = self.context_sample.as_ref().is_some_and(|sample| {
             sample.checkpoint_id == restored_checkpoint_id
@@ -106,9 +117,62 @@ impl CompactionState {
         Ok(())
     }
 
-    pub fn reset_for_transcript_replacement(&mut self) {
+    pub fn restore_checkpoint_if_changed(&mut self, messages: &[Message]) -> Result<()> {
+        let Some(observed_system_policy_sha256) = self.observed_system_policy_sha256 else {
+            return self.restore_newest_valid_checkpoint(messages);
+        };
+        let (newest, checkpoint) =
+            load_latest_orchestrator_compaction_checkpoint(&self.store_path, &self.session_id)?;
+        if self.observed_checkpoint_id == Some(newest) {
+            return Ok(());
+        }
+        let active_checkpoint = match checkpoint {
+            Some(checkpoint)
+                if checkpoint_is_bounded_valid(
+                    &self.store_path,
+                    &self.session_id,
+                    &checkpoint,
+                    observed_system_policy_sha256,
+                )? =>
+            {
+                Some(checkpoint)
+            }
+            _ => None,
+        };
+        self.observed_checkpoint_id = Some(newest);
+        self.context_sample = None;
+        self.active_checkpoint = active_checkpoint;
+        Ok(())
+    }
+
+    pub fn reset_for_restored_transcript(&mut self, messages: &[Message]) {
         self.active_checkpoint = None;
         self.context_sample = None;
+        self.observed_checkpoint_id = None;
+        self.observed_system_policy_sha256 = Some(system_policy_digest(messages));
+    }
+
+    pub fn reconcile_transcript_suffix(
+        &mut self,
+        common_prefix_len: usize,
+        removed: &[Message],
+        added: &[Message],
+    ) {
+        let policy_changed = removed
+            .iter()
+            .chain(added)
+            .any(|message| matches!(message, Message::System { .. }));
+        if policy_changed {
+            if let Some(policy) = &mut self.observed_system_policy_sha256 {
+                xor_system_policy_suffix(policy, common_prefix_len, removed);
+                xor_system_policy_suffix(policy, common_prefix_len, added);
+            }
+        }
+        if !removed.is_empty() || policy_changed {
+            self.active_checkpoint = None;
+            self.context_sample = None;
+            self.observed_checkpoint_id = None;
+        }
     }
 
     pub fn invalidate_context_sample(&mut self) {
@@ -269,6 +333,7 @@ impl CompactionState {
             .active_checkpoint
             .as_ref()
             .map(|checkpoint| checkpoint.id);
+        self.observed_checkpoint_id = Some(checkpoint_id);
         self.context_sample =
             sampled_projection_digest(messages, messages.len(), self.active_checkpoint.as_ref())
                 .map(|sampled_projection_sha256| ContextSample {
@@ -368,6 +433,11 @@ impl CompactionState {
     #[cfg(test)]
     pub fn active_checkpoint_for_test(&self) -> Option<&OrchestratorCompactionCheckpoint> {
         self.active_checkpoint.as_ref()
+    }
+
+    #[cfg(test)]
+    pub fn observed_system_policy_for_test(&self) -> Option<[u8; 32]> {
+        self.observed_system_policy_sha256
     }
 }
 
@@ -530,12 +600,54 @@ fn checkpoint_is_valid(
         && checkpoint.system_policy_sha256 == system_policy_digest(messages)
 }
 
+fn checkpoint_is_bounded_valid(
+    store_path: &std::path::Path,
+    session_id: &str,
+    checkpoint: &OrchestratorCompactionCheckpoint,
+    observed_system_policy_sha256: [u8; 32],
+) -> Result<bool> {
+    let Some(cursor) = checkpoint.transcript_cursor else {
+        return Ok(false);
+    };
+    let boundary = u64::try_from(checkpoint.tail_start_message_index)?;
+    Ok(checkpoint.prompt_policy_version == PROMPT_POLICY_VERSION
+        && boundary <= cursor.next_idx
+        && checkpoint
+            .summary
+            .strip_prefix(HISTORICAL_CONTEXT_PREFIX)
+            .is_some_and(|summary| !summary.trim().is_empty())
+        && checkpoint.system_policy_sha256 == observed_system_policy_sha256
+        && transcript_cursor_survives(store_path, session_id, cursor)?)
+}
+
 #[cfg(test)]
 pub(crate) fn checkpoint_digests(messages: &[Message], boundary: usize) -> ([u8; 32], [u8; 32]) {
     (
         source_prefix_digest(messages, boundary),
         system_policy_digest(messages),
     )
+}
+
+#[cfg(test)]
+thread_local! {
+    static TEST_POLICY_DIGEST_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_HASHED_MESSAGE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_test_hashed_message_count() {
+    TEST_POLICY_DIGEST_COUNT.with(|count| count.set(0));
+    TEST_HASHED_MESSAGE_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn test_hashed_message_count() -> usize {
+    TEST_HASHED_MESSAGE_COUNT.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn test_policy_digest_count() -> usize {
+    TEST_POLICY_DIGEST_COUNT.with(std::cell::Cell::get)
 }
 
 fn source_prefix_digest(messages: &[Message], boundary: usize) -> [u8; 32] {
@@ -552,18 +664,32 @@ fn source_prefix_digest(messages: &[Message], boundary: usize) -> [u8; 32] {
 }
 
 fn system_policy_digest(messages: &[Message]) -> [u8; 32] {
+    #[cfg(test)]
+    TEST_POLICY_DIGEST_COUNT.with(|count| count.set(count.get() + 1));
     let mut hasher = Sha256::new();
-    hasher.update(b"nac-orchestrator-compaction-system-policy-v2\0");
+    hasher.update(b"nac-orchestrator-compaction-system-policy-v3\0");
     hasher.update(PROMPT_POLICY_VERSION.to_be_bytes());
     update_bytes(&mut hasher, NAC_COMPACTION_PROMPT.as_bytes());
     update_bytes(&mut hasher, HISTORICAL_CONTEXT_PREFIX.as_bytes());
-    for message in messages
-        .iter()
-        .filter(|message| matches!(message, Message::System { .. }))
-    {
+    let mut digest: [u8; 32] = hasher.finalize().into();
+    xor_system_policy_suffix(&mut digest, 0, messages);
+    digest
+}
+
+fn xor_system_policy_suffix(digest: &mut [u8; 32], start_idx: usize, messages: &[Message]) {
+    for (offset, message) in messages.iter().enumerate() {
+        if !matches!(message, Message::System { .. }) {
+            continue;
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(b"nac-orchestrator-compaction-system-message-v1\0");
+        hasher.update((start_idx.saturating_add(offset) as u64).to_be_bytes());
         update_serialized(&mut hasher, message);
+        let contribution: [u8; 32] = hasher.finalize().into();
+        for (state, contribution) in digest.iter_mut().zip(contribution) {
+            *state ^= contribution;
+        }
     }
-    hasher.finalize().into()
 }
 
 fn estimate_non_source_tokens(messages: &[Message]) -> u64 {
@@ -598,6 +724,8 @@ pub(super) fn estimate_tool_tokens(tools: &[ToolDefinition]) -> u64 {
 }
 
 fn update_serialized<T: Serialize>(hasher: &mut Sha256, value: &T) {
+    #[cfg(test)]
+    TEST_HASHED_MESSAGE_COUNT.with(|count| count.set(count.get() + 1));
     let serialized = serde_json::to_vec(value).expect("message serialization must succeed");
     update_bytes(hasher, &serialized);
 }

--- a/crates/nac-core/src/agent/compaction/tests/checkpoints.rs
+++ b/crates/nac-core/src/agent/compaction/tests/checkpoints.rs
@@ -69,6 +69,120 @@ fn restore_falls_back_from_newest_invalid_checkpoint() {
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
 #[test]
+fn checkpoint_probe_adopts_a_peer_checkpoint_without_transcript_changes() {
+    let path = temp_store_path("peer_checkpoint_probe");
+    store::initialize(&path).unwrap();
+    store::insert_test_session(&path, "session");
+    let messages = vec![user("old"), assistant("answer"), user("current")];
+    let mut state = state(path.clone(), None);
+    state.restore_newest_valid_checkpoint(&messages).unwrap();
+    assert!(state.active_checkpoint_for_test().is_none());
+    crate::store::TranscriptLogWriter::new(&path)
+        .unwrap()
+        .bootstrap_cursor("session", messages.len() as u64, messages.len() as u64)
+        .unwrap();
+
+    let (source, policy) = checkpoint_digests(&messages, 2);
+    let checkpoint = append_orchestrator_compaction_checkpoint(
+        &path,
+        &NewOrchestratorCompactionCheckpoint {
+            session_id: "session".to_string(),
+            previous_checkpoint_id: None,
+            summary: installed_summary("peer"),
+            tail_start_message_index: 2,
+            source_prefix_sha256: source,
+            system_policy_sha256: policy,
+            prompt_policy_version: PROMPT_POLICY_VERSION,
+            old_context_estimate: 100,
+            summary_prompt_tokens: None,
+            summary_completion_tokens: None,
+            new_context_estimate: 50,
+        },
+    )
+    .unwrap();
+
+    crate::store::fail_next_test_cursor_probe();
+    assert!(state.restore_checkpoint_if_changed(&messages).is_err());
+    assert!(
+        state.active_checkpoint_for_test().is_none(),
+        "failed validation must not partially adopt the peer checkpoint"
+    );
+
+    store::track_connection_opens(&path);
+    super::super::planning::reset_test_hashed_message_count();
+    state.restore_checkpoint_if_changed(&messages).unwrap();
+    assert_eq!(
+        state.active_checkpoint_for_test().map(|active| active.id),
+        Some(checkpoint.id)
+    );
+    assert_eq!(
+        super::super::planning::test_hashed_message_count(),
+        0,
+        "peer checkpoint adoption must not hash transcript messages"
+    );
+    assert_eq!(
+        super::super::planning::test_policy_digest_count(),
+        0,
+        "peer checkpoint adoption must reuse the incrementally maintained policy identity"
+    );
+    assert_eq!(
+        store::tracked_connection_opens(&path),
+        2,
+        "peer checkpoint adoption performs one newest-row read and one cursor-survival probe"
+    );
+    state.restore_checkpoint_if_changed(&messages).unwrap();
+    assert_eq!(
+        state.active_checkpoint_for_test().map(|active| active.id),
+        Some(checkpoint.id)
+    );
+
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+#[test]
+fn policy_identity_reconciles_only_the_changed_system_suffix() {
+    let path = temp_store_path("incremental_policy_identity");
+    store::initialize(&path).unwrap();
+    store::insert_test_session(&path, "session");
+    let messages = (0..4_096)
+        .map(|index| Message::System {
+            content: format!("policy {index}"),
+        })
+        .collect::<Vec<_>>();
+    let mut state = state(path.clone(), None);
+    state.restore_newest_valid_checkpoint(&messages).unwrap();
+    let common_prefix_len = messages.len() - 2;
+    let added = vec![
+        Message::System {
+            content: "replacement policy".to_string(),
+        },
+        user("ordinary suffix"),
+        Message::System {
+            content: "appended policy".to_string(),
+        },
+    ];
+    let mut authoritative = messages[..common_prefix_len].to_vec();
+    authoritative.extend(added.clone());
+
+    super::super::planning::reset_test_hashed_message_count();
+    state.reconcile_transcript_suffix(common_prefix_len, &messages[common_prefix_len..], &added);
+    assert_eq!(
+        super::super::planning::test_policy_digest_count(),
+        0,
+        "suffix reconciliation must not recompute policy identity from full history"
+    );
+    assert_eq!(
+        super::super::planning::test_hashed_message_count(),
+        4,
+        "only two removed and two added System messages are hashed"
+    );
+    let incremental = state.observed_system_policy_for_test().unwrap();
+    let (_, expected) = checkpoint_digests(&authoritative, authoritative.len());
+    assert_eq!(incremental, expected);
+
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
 fn checkpoint_refresh_preserves_sample_for_same_projection_and_invalidates_changed_checkpoint() {
     let path = temp_store_path("sample_refresh");
     store::initialize(&path).unwrap();

--- a/crates/nac-core/src/agent/compaction_integration_tests/lifecycle.rs
+++ b/crates/nac-core/src/agent/compaction_integration_tests/lifecycle.rs
@@ -253,7 +253,7 @@ async fn cancellation_during_summary_keeps_the_prior_checkpoint() {
     agent.set_steering_dispatch_id(Some("run".to_string()));
     agent.messages = messages;
     store_agent_snapshot(&store_path, &agent);
-    agent.restore_compaction_checkpoint().unwrap();
+    agent.initialize_compaction_checkpoint().unwrap();
     let agent = Arc::new(tokio::sync::Mutex::new(agent));
     let task_agent = agent.clone();
     let task = tokio::spawn(async move { task_agent.lock().await.send("current").await });

--- a/crates/nac-core/src/agent/compaction_integration_tests/projection_durability.rs
+++ b/crates/nac-core/src/agent/compaction_integration_tests/projection_durability.rs
@@ -415,7 +415,7 @@ async fn valid_checkpoint_projects_after_restore_when_generation_is_disabled() {
     )
     .unwrap();
 
-    agent.restore_compaction_checkpoint().unwrap();
+    agent.initialize_compaction_checkpoint().unwrap();
     let view = agent
         .prepare_provider_view(&mut TokenUsage::default())
         .await;

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 
@@ -120,6 +120,13 @@ fn light_model_prompt_guidance(light: &ModelClient) -> String {
     )
 }
 
+pub(crate) struct TranscriptRefresh {
+    pub snapshot_len: usize,
+    pub common_prefix_len: usize,
+    pub removed: Vec<Message>,
+    pub changed: bool,
+}
+
 pub struct Agent {
     client: ModelClient,
     pub messages: Vec<Message>,
@@ -141,6 +148,10 @@ pub struct Agent {
     /// delete them from stale in-memory boundaries (shared-store recovery,
     /// issue #146).
     committed_log_len: u64,
+    /// Durable snapshot/log cursor adopted by this process. Exact equality
+    /// makes operation admission independent of accumulated transcript size;
+    /// a mismatch is reconciled from the physical log suffix only.
+    transcript_cursor: Option<crate::store::TranscriptCursor>,
     /// User-facing notice set only when restore repaired a validly encoded
     /// non-contiguous transcript tail.
     transcript_recovery_warning: Option<String>,
@@ -375,6 +386,7 @@ impl Agent {
             appended_steering_ids: HashSet::new(),
             transcript_log,
             committed_log_len,
+            transcript_cursor: None,
             transcript_recovery_warning: None,
             last_usage: None,
             partial_stream: StdMutex::new(ModelStreamDelta::default()),
@@ -795,7 +807,7 @@ impl Agent {
         self.committed_log_len = messages.len() as u64;
         self.messages = messages;
         if let Some(compaction) = &mut self.compaction {
-            compaction.reset_for_transcript_replacement();
+            compaction.reset_for_restored_transcript(&self.messages);
         }
     }
 
@@ -823,8 +835,6 @@ impl Agent {
             self.restore_messages(messages);
             return Ok(None);
         };
-        let mut blob_len = messages.len() as u64;
-        let mut blob_len_usize = messages.len();
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
         if let Some(operation_lease) = operation_lease {
@@ -832,12 +842,29 @@ impl Agent {
                 .validate(&sink.store_path, &session_id)
                 .map_err(anyhow::Error::new)?;
         }
-
-        let mut snapshot_messages = messages;
-        let mut refreshed_blob = None;
+        let capture_writer = writer.clone();
+        let capture_session_id = session_id.clone();
+        let (snapshot_messages, initial_tail, captured_cursor) =
+            tokio::task::spawn_blocking(move || {
+                capture_writer.read_consistent_state(&capture_session_id)
+            })
+            .await
+            .map_err(|error| anyhow!("transcript state read task failed: {error}"))??;
+        let mut refreshed_blob = if transcripts_match(&messages, &snapshot_messages)? {
+            None
+        } else {
+            Some(snapshot_messages.clone())
+        };
+        let mut blob_len = snapshot_messages.len() as u64;
+        let mut blob_len_usize = snapshot_messages.len();
+        let mut snapshot_messages = snapshot_messages;
+        let mut initial_tail = Some(initial_tail);
+        self.transcript_cursor = captured_cursor;
         let mut _acquired_operation_lease = None;
         loop {
-            let mut tail = {
+            let mut tail = if let Some(initial_tail) = initial_tail.take() {
+                initial_tail
+            } else {
                 let writer = writer.clone();
                 let session_id = session_id.clone();
                 tokio::task::spawn_blocking(move || writer.read_from(&session_id, blob_len))
@@ -961,6 +988,14 @@ impl Agent {
                     self.delete_log_tail(merged.len() as u64).await?;
                 }
             }
+            if operation_lease.is_some() || _acquired_operation_lease.is_some() {
+                let snapshot_len = merged.len().min(blob_len_usize) as u64;
+                self.transcript_cursor = Some(writer.bootstrap_cursor(
+                    &session_id,
+                    snapshot_len,
+                    merged.len() as u64,
+                )?);
+            }
             // The durable transcript is now exactly `merged`: every row it
             // holds was committed or adopted by this process.
             self.committed_log_len = merged.len() as u64;
@@ -985,19 +1020,15 @@ impl Agent {
     /// acquired: the lease excludes concurrent peer appends, so the refresh
     /// is race-free and the run starts from the newest durable state.
     ///
-    /// Synchronous counterpart of the async restore: admission is a sync
-    /// path that already performs blocking store reads (config revision,
-    /// compaction checkpoint). Returns the post-refresh durable snapshot
-    /// blob — the rewritten blob when dangling-turn normalization repaired
-    /// it, the unchanged blob otherwise — so the caller can reconcile its
-    /// cached snapshot copy on every admission: a prior admission may have
-    /// repaired the blob and then failed before patching that copy, and the
-    /// retry sees nothing left to repair. `None` only when the session has
-    /// no transcript log.
+    /// The durable cursor is probed first. An exact match does no work
+    /// proportional to transcript history; a mismatch reads only physical
+    /// rows after the newest surviving adopted row. The full restore below is
+    /// retained solely as the one-time legacy bootstrap/corruption repair
+    /// boundary.
     pub fn refresh_transcript_under_lease(
         &mut self,
         operation_lease: &crate::sessions::SessionOperationLease,
-    ) -> Result<Option<Vec<Message>>> {
+    ) -> Result<Option<TranscriptRefresh>> {
         self.transcript_recovery_warning = None;
         let Some(sink) = &self.transcript_log else {
             return Ok(None);
@@ -1007,6 +1038,55 @@ impl Agent {
             .map_err(anyhow::Error::new)?;
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
+
+        if let Some(adopted) = self.transcript_cursor {
+            match writer.reconcile_cursor(&session_id, adopted) {
+                Ok(None) => {
+                    return Ok(Some(TranscriptRefresh {
+                        snapshot_len: usize::try_from(adopted.snapshot_len)
+                            .context("transcript snapshot length overflowed")?,
+                        common_prefix_len: self.messages.len(),
+                        removed: Vec::new(),
+                        changed: false,
+                    }));
+                }
+                Ok(Some(reconciliation))
+                    if incomplete_tool_turn_index(&reconciliation.rows).is_none() =>
+                {
+                    let common_prefix_len = usize::try_from(reconciliation.common_prefix_len)
+                        .context("transcript common-prefix length overflowed")?;
+                    if common_prefix_len > self.messages.len() {
+                        return Err(anyhow!(
+                            "transcript common prefix {common_prefix_len} exceeds local length {}",
+                            self.messages.len()
+                        ));
+                    }
+                    let added_start = common_prefix_len;
+                    let removed = self.messages.split_off(common_prefix_len);
+                    self.messages.extend(reconciliation.rows);
+                    self.committed_log_len = reconciliation.cursor.next_idx;
+                    self.transcript_cursor = Some(reconciliation.cursor);
+                    if let Some(compaction) = &mut self.compaction {
+                        compaction.reconcile_transcript_suffix(
+                            common_prefix_len,
+                            &removed,
+                            &self.messages[added_start..],
+                        );
+                    }
+                    return Ok(Some(TranscriptRefresh {
+                        snapshot_len: usize::try_from(reconciliation.cursor.snapshot_len)
+                            .context("transcript snapshot length overflowed")?,
+                        common_prefix_len,
+                        removed,
+                        changed: true,
+                    }));
+                }
+                Ok(Some(_)) | Err(_) => {
+                    // A malformed/non-contiguous delta or dangling tool turn
+                    // needs the strict lease-held repair path below.
+                }
+            }
+        }
 
         let snapshot_messages = writer.read_snapshot_messages(&session_id)?;
         let blob_len = snapshot_messages.len() as u64;
@@ -1072,59 +1152,113 @@ impl Agent {
             }
         }
 
-        // The durable snapshot blob after the refresh: the rewritten blob
-        // when normalization repaired it, otherwise the unchanged prefix of
-        // the merged transcript.
-        let durable_blob = merged[..merged.len().min(blob_len_usize)].to_vec();
-
-        // The durable transcript is now exactly `merged`.
-        self.committed_log_len = merged.len() as u64;
-        if !transcripts_match(&self.messages, &merged)? {
-            self.restore_messages(merged);
+        let durable_snapshot_len = merged.len().min(blob_len_usize);
+        let common_prefix_len = self
+            .messages
+            .iter()
+            .zip(&merged)
+            .take_while(|(left, right)| {
+                transcripts_match(std::slice::from_ref(*left), std::slice::from_ref(*right))
+                    .unwrap_or(false)
+            })
+            .count();
+        let removed = self.messages.split_off(common_prefix_len);
+        self.messages.truncate(common_prefix_len);
+        self.messages
+            .extend(merged.into_iter().skip(common_prefix_len));
+        self.committed_log_len = self.messages.len() as u64;
+        self.transcript_cursor = Some(writer.bootstrap_cursor(
+            &session_id,
+            durable_snapshot_len as u64,
+            self.committed_log_len,
+        )?);
+        if let Some(compaction) = &mut self.compaction {
+            compaction.reconcile_transcript_suffix(
+                common_prefix_len,
+                &removed,
+                &self.messages[common_prefix_len..],
+            );
         }
-        Ok(Some(durable_blob))
+        Ok(Some(TranscriptRefresh {
+            snapshot_len: durable_snapshot_len,
+            common_prefix_len,
+            removed,
+            changed: true,
+        }))
     }
 
-    /// Stale-transcript guard for the terminal normalization paths (shared
-    /// store, issue #146): `true` when the durable transcript log holds
-    /// rows at or beyond `committed_log_len` — rows this process never
-    /// committed or adopted, so a peer must have appended them while it
-    /// held the operation lease (e.g. the previous run owner crashed and
-    /// this survivor's long-lived agent never re-restored). Deleting the
-    /// log tail from the stale in-memory length would permanently remove
-    /// those committed rows.
+    /// Stale-transcript guard for terminal normalization. Full cursor identity
+    /// detects same-length delete/reappend. The sole mismatch treated as local
+    /// is an append submitted by this Agent but not yet adopted because its
+    /// async task was dropped: that claim advances `committed_log_len` beyond
+    /// the adopted logical end before the blocking transaction starts.
     async fn durable_log_has_rows_past_own_commits(&self) -> Result<bool> {
         let Some(sink) = &self.transcript_log else {
             return Ok(false);
         };
-        let from_idx = self.committed_log_len;
+        let adopted = self.transcript_cursor;
+        let own_end = self.committed_log_len;
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
-        let tail = tokio::task::spawn_blocking(move || writer.read_from(&session_id, from_idx))
+        let current = tokio::task::spawn_blocking(move || writer.current_cursor(&session_id))
             .await
-            .map_err(|error| anyhow!("transcript log read task failed: {error}"))??;
-        Ok(!tail.is_empty())
+            .map_err(|error| anyhow!("transcript cursor read task failed: {error}"))??;
+        if current == adopted {
+            return Ok(false);
+        }
+        let is_claimed_local_append = adopted.zip(current).is_some_and(|(adopted, current)| {
+            own_end > adopted.next_idx && current.next_idx <= own_end
+        });
+        Ok(!is_claimed_local_append)
     }
-
-    /// Adopt the durable transcript (snapshot blob ++ log tail) in memory
-    /// without deleting anything: the read-only half of
-    /// [`Agent::refresh_transcript_under_lease`] for the terminal
-    /// normalization paths, which do not hold the operation lease they
-    /// could pass down. A genuine gap is left for the next lease-held
-    /// restore or admission refresh to repair.
+    /// Adopt a peer's durable delta without deleting anything. Cursor-backed
+    /// sessions decode only rows committed since this process's adopted row;
+    /// the full restore is retained only for a legacy uninitialized cursor.
     async fn reload_transcript_from_store(&mut self) -> Result<()> {
         let Some(sink) = &self.transcript_log else {
             return Ok(());
         };
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
-        let (snapshot, tail) = tokio::task::spawn_blocking(move || {
+        let adopted = self.transcript_cursor;
+        let loaded = tokio::task::spawn_blocking(move || {
+            if let Some(adopted) = adopted {
+                return Ok::<_, anyhow::Error>((
+                    writer.reconcile_cursor(&session_id, adopted)?,
+                    None,
+                ));
+            }
             let snapshot = writer.read_snapshot_messages(&session_id)?;
             let tail = writer.read_from(&session_id, snapshot.len() as u64)?;
-            Ok::<_, anyhow::Error>((snapshot, tail))
+            Ok((None, Some((snapshot, tail))))
         })
         .await
         .map_err(|error| anyhow!("transcript reload task failed: {error}"))??;
+        if let Some(reconciliation) = loaded.0 {
+            let common_prefix_len = usize::try_from(reconciliation.common_prefix_len)
+                .context("transcript common-prefix length overflowed")?;
+            if common_prefix_len > self.messages.len() {
+                return Err(anyhow!(
+                    "transcript common prefix {common_prefix_len} exceeds local length {}",
+                    self.messages.len()
+                ));
+            }
+            let removed = self.messages.split_off(common_prefix_len);
+            self.messages.extend(reconciliation.rows);
+            self.committed_log_len = reconciliation.cursor.next_idx;
+            self.transcript_cursor = Some(reconciliation.cursor);
+            if let Some(compaction) = &mut self.compaction {
+                compaction.reconcile_transcript_suffix(
+                    common_prefix_len,
+                    &removed,
+                    &self.messages[common_prefix_len..],
+                );
+            }
+            return Ok(());
+        }
+        let Some((snapshot, tail)) = loaded.1 else {
+            return Ok(());
+        };
         let mut merged = snapshot;
         let mut expected_idx = merged.len() as u64;
         for (idx, message) in tail {
@@ -1136,7 +1270,7 @@ impl Agent {
             merged.push(message);
             expected_idx = expected_idx
                 .checked_add(1)
-                .ok_or_else(|| anyhow!("transcript log index overflowed"))?;
+                .context("transcript log index overflowed")?;
         }
         self.committed_log_len = merged.len() as u64;
         self.restore_messages(merged);
@@ -1279,19 +1413,22 @@ impl Agent {
         // process's own commits, so terminal normalization trims it instead
         // of mistaking it for a peer's committed row (issue #146).
         let pre_submission_committed = self.committed_log_len;
-        self.committed_log_len = self.committed_log_len.max(start_idx + batch_len);
+        let claimed_end = start_idx
+            .checked_add(batch_len)
+            .context("transcript log index overflowed")?;
+        self.committed_log_len = self.committed_log_len.max(claimed_end);
         let appended = tokio::task::spawn_blocking(move || {
             writer.append_batch(&session_id, start_idx, &messages)
         })
         .await
         .map_err(|error| anyhow!("transcript log append task failed: {error}"))?;
         match appended {
-            Ok(()) => {
+            Ok(cursor) => {
+                self.transcript_cursor = Some(cursor);
                 // Live trigger (step 3): emitted after the log commit,
                 // before the vec push — the store-backed read path sees the
                 // rows immediately.
-                self.event_sink
-                    .emit_transcript_appended(start_idx + batch_len);
+                self.event_sink.emit_transcript_appended(claimed_end);
                 Ok(())
             }
             Err(error) => {
@@ -1319,14 +1456,19 @@ impl Agent {
         // log_transcript_batch for why the straggler from a dropped run
         // task must stay within this process's own commits.
         let pre_submission_committed = self.committed_log_len;
-        self.committed_log_len = self.committed_log_len.max(idx + 1);
-        let appended = tokio::task::spawn_blocking(move || writer.append(&session_id, idx, &message))
-            .await
-            .map_err(|error| anyhow!("transcript log append task failed: {error}"))?;
+        let claimed_end = idx
+            .checked_add(1)
+            .context("transcript log index overflowed")?;
+        self.committed_log_len = self.committed_log_len.max(claimed_end);
+        let appended =
+            tokio::task::spawn_blocking(move || writer.append(&session_id, idx, &message))
+                .await
+                .map_err(|error| anyhow!("transcript log append task failed: {error}"))?;
         match appended {
-            Ok(()) => {
+            Ok(cursor) => {
+                self.transcript_cursor = Some(cursor);
                 // Live trigger (step 3): see log_transcript_batch.
-                self.event_sink.emit_transcript_appended(idx + 1);
+                self.event_sink.emit_transcript_appended(claimed_end);
                 Ok(())
             }
             Err(error) => {
@@ -1370,18 +1512,31 @@ impl Agent {
         };
         let writer = sink.writer.clone();
         let session_id = sink.session_id.clone();
-        tokio::task::spawn_blocking(move || writer.delete_from(&session_id, from_idx))
-            .await
-            .map_err(|error| anyhow!("transcript log tail delete task failed: {error}"))??;
+        let cursor = tokio::task::spawn_blocking(move || {
+            writer.delete_from(&session_id, from_idx)?;
+            writer
+                .current_cursor(&session_id)?
+                .ok_or_else(|| anyhow!("transcript cursor is unavailable after tail deletion"))
+        })
+        .await
+        .map_err(|error| anyhow!("transcript log tail delete task failed: {error}"))??;
+        self.transcript_cursor = Some(cursor);
         self.committed_log_len = self.committed_log_len.min(from_idx);
         Ok(())
     }
 
-    /// Restore the newest checkpoint that still validates against the complete
-    /// canonical transcript, falling back through older append-only rows.
-    pub(crate) fn restore_compaction_checkpoint(&mut self) -> Result<()> {
+    /// Adopt a changed peer checkpoint using only its stored transcript cursor.
+    /// Admission never scans or serializes transcript history.
+    pub(crate) fn initialize_compaction_checkpoint(&mut self) -> Result<()> {
         if let Some(compaction) = &mut self.compaction {
             compaction.restore_newest_valid_checkpoint(&self.messages)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn restore_compaction_checkpoint(&mut self) -> Result<()> {
+        if let Some(compaction) = &mut self.compaction {
+            compaction.restore_checkpoint_if_changed(&self.messages)?;
         }
         Ok(())
     }

--- a/crates/nac-core/src/agent/transcript_log_tests.rs
+++ b/crates/nac-core/src/agent/transcript_log_tests.rs
@@ -742,6 +742,51 @@ async fn restore_reloads_the_snapshot_after_automatically_acquiring_the_lease() 
 }
 
 #[tokio::test]
+async fn restore_rejects_a_same_length_stale_snapshot_cursor() {
+    let store_path = test_store_path("same_length_snapshot_replacement");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let durable = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("durable prompt"),
+        plain_assistant("durable answer"),
+    ];
+    store_snapshot_messages(&store_path, &durable);
+    crate::store::TranscriptLogWriter::new(&store_path)
+        .unwrap()
+        .bootstrap_cursor("session", 3, 3)
+        .unwrap();
+    let stale = vec![
+        Message::System {
+            content: "stored system".to_string(),
+        },
+        user_message("stale prompt"),
+        plain_assistant("stale answer"),
+    ];
+
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    let refreshed = agent
+        .restore_messages_merging_log_tail(stale, None)
+        .await
+        .unwrap()
+        .expect("same-length replacement must refresh the stale snapshot");
+
+    assert!(matches!(&refreshed[1], Message::User { content } if content == "durable prompt"));
+    assert!(
+        matches!(&agent.messages[2], Message::Assistant { content: Some(content), .. } if content == "durable answer")
+    );
+    agent
+        .push_and_log_for_test(user_message("next prompt"))
+        .await
+        .unwrap();
+    assert_eq!(read_log(&store_path, "session")[0].0, 3);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
 async fn cancellation_trims_the_dangling_turn_and_logs_the_marker() {
     let store_path = test_store_path("cancel");
     crate::store::initialize(&store_path).unwrap();
@@ -763,6 +808,7 @@ async fn cancellation_trims_the_dangling_turn_and_logs_the_marker() {
     ];
     let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
     writer.append_batch("session", 0, &seeded).unwrap();
+    agent.transcript_cursor = writer.current_cursor("session").unwrap();
     agent.messages = seeded;
     // The seeded log rows stand in for this process's own commits.
     agent.committed_log_len = agent.messages.len() as u64;
@@ -832,9 +878,12 @@ async fn cancellation_deletes_log_stragglers_from_an_aborted_append() {
                     content: "system".to_string(),
                 },
                 user_message("prompt"),
-                tool_call_assistant(&["call-1"]),
             ],
         )
+        .unwrap();
+    agent.transcript_cursor = writer.current_cursor("session").unwrap();
+    writer
+        .append("session", 2, &tool_call_assistant(&["call-1"]))
         .unwrap();
     // All three log rows stand in for this process's own commits: the
     // straggler append at idx 2 completed after the run task was aborted.
@@ -884,9 +933,12 @@ async fn normalize_dangling_tail_trims_a_straggler_row_the_vec_never_saw() {
                     content: "system".to_string(),
                 },
                 user_message("prompt"),
-                tool_call_assistant(&["call-1"]),
             ],
         )
+        .unwrap();
+    agent.transcript_cursor = writer.current_cursor("session").unwrap();
+    writer
+        .append("session", 2, &tool_call_assistant(&["call-1"]))
         .unwrap();
     // The straggler append at idx 2 was claimed at submission, before the
     // run task was dropped: it stays within this process's own commits.
@@ -925,6 +977,7 @@ async fn normalize_dangling_tail_trims_the_vec_and_log_without_a_marker() {
     ];
     let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
     writer.append_batch("session", 0, &seeded).unwrap();
+    agent.transcript_cursor = writer.current_cursor("session").unwrap();
     agent.messages = seeded;
     // The seeded log rows stand in for this process's own commits.
     agent.committed_log_len = agent.messages.len() as u64;
@@ -950,11 +1003,74 @@ async fn normalize_dangling_tail_trims_the_vec_and_log_without_a_marker() {
         user_message("prompt"),
         plain_assistant("answer"),
     ];
+    clean.transcript_cursor = writer.current_cursor("session").unwrap();
     // The seeded log rows stand in for this process's own commits.
     clean.committed_log_len = clean.messages.len() as u64;
     clean.normalize_dangling_tail().await.unwrap();
     assert_eq!(clean.messages.len(), 3);
     assert_eq!(read_log(&store_path, "session").len(), 2);
+
+    let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+}
+
+#[tokio::test]
+async fn terminal_peer_append_preserves_the_active_compaction_checkpoint() {
+    let store_path = test_store_path("terminal_append_checkpoint");
+    crate::store::initialize(&store_path).unwrap();
+    crate::store::insert_test_session(&store_path, "session");
+    let messages = vec![
+        Message::System {
+            content: "system".to_string(),
+        },
+        user_message("prompt"),
+        plain_assistant("answer"),
+    ];
+    let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+    writer.append_batch("session", 0, &messages).unwrap();
+    let mut agent = orchestrator_agent(store_path.clone(), "session", None);
+    agent.messages = messages.clone();
+    agent.committed_log_len = messages.len() as u64;
+    agent.transcript_cursor = writer.current_cursor("session").unwrap();
+    agent.compaction = Some(super::compaction::CompactionState::new(
+        store_path.clone(),
+        "session".to_string(),
+        Some(1_000),
+    ));
+    let (source, policy) = super::compaction::checkpoint_digests(&messages, 2);
+    let checkpoint =
+        crate::store::orchestrator_compaction::append_orchestrator_compaction_checkpoint(
+            &store_path,
+            &crate::store::orchestrator_compaction::NewOrchestratorCompactionCheckpoint {
+                session_id: "session".to_string(),
+                previous_checkpoint_id: None,
+                summary: super::compaction::installed_summary("prior context"),
+                tail_start_message_index: 2,
+                source_prefix_sha256: source,
+                system_policy_sha256: policy,
+                prompt_policy_version: super::compaction::PROMPT_POLICY_VERSION,
+                old_context_estimate: 100,
+                summary_prompt_tokens: None,
+                summary_completion_tokens: None,
+                new_context_estimate: 50,
+            },
+        )
+        .unwrap();
+    agent.initialize_compaction_checkpoint().unwrap();
+
+    writer
+        .append("session", 3, &user_message("peer prompt"))
+        .unwrap();
+    agent.reload_transcript_from_store().await.unwrap();
+
+    assert_eq!(agent.messages.len(), 4);
+    assert_eq!(
+        agent
+            .compaction
+            .as_ref()
+            .and_then(|state| state.active_checkpoint_for_test())
+            .map(|active| active.id),
+        Some(checkpoint.id)
+    );
 
     let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
 }
@@ -1119,7 +1235,7 @@ async fn refresh_transcript_under_lease_adopts_peer_appends() {
         crate::sessions::SessionOperationLease::try_acquire(&store_path, "session").unwrap();
     let durable_blob = agent.refresh_transcript_under_lease(&lease).unwrap();
     assert_eq!(
-        durable_blob.map(|blob| blob.len()),
+        durable_blob.map(|refresh| refresh.snapshot_len),
         Some(3),
         "the blob itself was not repaired: the refresh returns it unchanged"
     );

--- a/crates/nac-core/src/model/test_http.rs
+++ b/crates/nac-core/src/model/test_http.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -8,6 +9,7 @@ pub(crate) struct ScriptedResponse {
     status: &'static str,
     headers: BTreeMap<String, String>,
     body: String,
+    gate: Option<Arc<(Mutex<bool>, Condvar)>>,
 }
 
 impl ScriptedResponse {
@@ -16,6 +18,7 @@ impl ScriptedResponse {
             status,
             headers: BTreeMap::new(),
             body: body.into(),
+            gate: None,
         }
     }
 
@@ -28,11 +31,17 @@ impl ScriptedResponse {
             status,
             headers: BTreeMap::from([("Location".to_string(), location.into())]),
             body: body.into(),
+            gate: None,
         }
     }
 
     pub(crate) fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.headers.insert(name.into(), value.into());
+        self
+    }
+
+    pub(crate) fn with_gate(mut self, gate: Arc<(Mutex<bool>, Condvar)>) -> Self {
+        self.gate = Some(gate);
         self
     }
 }
@@ -223,6 +232,17 @@ fn read_request(stream: &mut TcpStream) -> CapturedRequest {
 }
 
 fn write_response(stream: &mut TcpStream, response: &ScriptedResponse) {
+    if let Some(gate) = &response.gate {
+        let (released, notification) = &**gate;
+        let mut released = released
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while !*released {
+            released = notification
+                .wait(released)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+    }
     let extra_headers = response
         .headers
         .iter()

--- a/crates/nac-core/src/runtime.rs
+++ b/crates/nac-core/src/runtime.rs
@@ -1437,7 +1437,7 @@ async fn build_resume_config_from_snapshot(
     {
         snapshot.messages = repaired_blob;
     }
-    agent.restore_compaction_checkpoint()?;
+    agent.initialize_compaction_checkpoint()?;
 
     let session_id = snapshot.session_id.clone();
     Ok(OrchestratorRunConfig {

--- a/crates/nac-core/src/session_service.rs
+++ b/crates/nac-core/src/session_service.rs
@@ -500,7 +500,7 @@ pub struct SessionService {
     workspace_git: Option<GitTarget>,
     config_version: Option<i64>,
     session_snapshot: Arc<Mutex<Option<SessionSnapshot>>>,
-    transcript_recovery_warning: Arc<Option<String>>,
+    transcript_recovery_warning: Arc<StdMutex<Option<String>>>,
     /// Shared transcript log writer (orchestrator sessions only). Read paths
     /// go through the same connection as the agent's appends, so store-backed
     /// transcript reads serialize against commit points (step 3).
@@ -568,6 +568,7 @@ enum RunOutcome {
     Failed(String, Option<crate::model::TokenUsage>),
 }
 
+#[derive(Debug)]
 enum OperationAdmissionPreparationError {
     ExternalBusy { session_id: String },
     Coordination { message: SessionCoordinationError },
@@ -575,24 +576,17 @@ enum OperationAdmissionPreparationError {
 
 /// Incremental scan of the merged store transcript (snapshot blob ++
 /// transcript log tail). Rebuilt from the restored transcript at service
-/// construction, then advanced over newly appended rows only (append-only ⇒
-/// a scanned position's User-message content never changes: crash/cancel
-/// normalization trims only dangling Assistant/Tool tail messages, and
-/// compaction rewrites the provider view, never the transcript).
-///
-/// The counts survive scan-cursor rewinds (a shrinking merged length) for
-/// the same reason: `truncate_incomplete_tool_turn` trims only
-/// assistant-with-tool-calls and tool-result tails, never User messages and
-/// never visible responses (assistant messages without tool calls). A
-/// straggler row from an aborted append that is scanned in the cancel
-/// window before its `delete_from` would overcount — the same accepted
-/// imprecision class as `user_copies` (step 3).
+/// construction, then advanced over newly appended rows. Cursor reconciliation
+/// can replace a suffix at reused logical indices; `apply_replacement` reverses
+/// every scanned contribution in that suffix before scanning the authoritative
+/// replacement.
 #[derive(Default)]
 struct TranscriptScanCache {
     /// Raw merged-transcript length scanned so far.
     scanned_len: usize,
     user_count: usize,
     last_user_idx: Option<usize>,
+    user_indices: Vec<usize>,
     /// User message content → surviving copy count. Drives steering coverage
     /// with newest-first pairing (see `covered_orchestrator_steering_ids`).
     user_copies: HashMap<String, usize>,
@@ -617,12 +611,49 @@ impl TranscriptScanCache {
     fn scan_message(&mut self, idx: usize, message: &Message) {
         if let Message::User { content } = message {
             self.user_count += 1;
+            self.user_indices.push(idx);
             self.last_user_idx = Some(idx);
             *self.user_copies.entry(content.clone()).or_insert(0) += 1;
         }
         if is_visible_response(message) {
             self.visible_response_count += 1;
         }
+    }
+
+    fn apply_replacement(
+        &mut self,
+        common_prefix_len: usize,
+        removed: &[Message],
+        authoritative: &[Message],
+    ) {
+        if self.scanned_len > common_prefix_len {
+            let scanned_removed = self.scanned_len - common_prefix_len;
+            if removed.len() < scanned_removed {
+                *self = Self::from_transcript(authoritative);
+                return;
+            }
+            for message in removed.iter().take(scanned_removed).rev() {
+                if let Message::User { content } = message {
+                    self.user_count -= 1;
+                    if let Some(copies) = self.user_copies.get_mut(content) {
+                        *copies -= 1;
+                        if *copies == 0 {
+                            self.user_copies.remove(content);
+                        }
+                    }
+                }
+                if is_visible_response(message) {
+                    self.visible_response_count -= 1;
+                }
+            }
+            self.user_indices.retain(|idx| *idx < common_prefix_len);
+            self.last_user_idx = self.user_indices.last().copied();
+            self.scanned_len = common_prefix_len;
+        }
+        for (idx, message) in authoritative.iter().enumerate().skip(self.scanned_len) {
+            self.scan_message(idx, message);
+        }
+        self.scanned_len = authoritative.len();
     }
 }
 
@@ -690,9 +721,9 @@ impl SessionService {
             agent: Arc::new(Mutex::new(run_config.agent)),
             metadata: Arc::new(metadata.clone()),
             workspace_git,
+            transcript_recovery_warning: Arc::new(StdMutex::new(transcript_recovery_warning)),
             config_version,
             session_snapshot: Arc::new(Mutex::new(session_snapshot)),
-            transcript_recovery_warning: Arc::new(transcript_recovery_warning),
             transcript_log,
             transcript_scan: Arc::new(StdMutex::new(transcript_scan)),
             event_bus,
@@ -1196,9 +1227,13 @@ impl SessionService {
         metadata.extra_headers.clear();
         let snapshot = SessionFrontendSnapshot {
             metadata,
+            transcript_recovery_warning: self
+                .transcript_recovery_warning
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone(),
             messages: loaded_messages.messages,
             message_created_at: loaded_messages.created_at,
-            transcript_recovery_warning: (*self.transcript_recovery_warning).clone(),
             response_timing,
             active_run: self.active_run(),
             active_compaction: self.active_compaction(),
@@ -1829,13 +1864,26 @@ impl SessionService {
                     message: SessionCoordinationError::local_agent_busy(),
                 }
             })?;
-            let durable_blob = agent
-                .refresh_transcript_under_lease(lease)
-                .map_err(|error| OperationAdmissionPreparationError::Coordination {
+            let refresh = agent.refresh_transcript_under_lease(lease);
+            if let Some(warning) = agent.transcript_recovery_warning().map(str::to_owned) {
+                *self
+                    .transcript_recovery_warning
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(warning);
+            }
+            let refresh =
+                refresh.map_err(|error| OperationAdmissionPreparationError::Coordination {
                     message: SessionCoordinationError::store(format!(
                         "failed to refresh the transcript under the operation lease: {error:#}"
                     )),
                 })?;
+            if let Some(refresh) = refresh.as_ref().filter(|refresh| refresh.changed) {
+                self.lock_transcript_scan().apply_replacement(
+                    refresh.common_prefix_len,
+                    &refresh.removed,
+                    &agent.messages,
+                );
+            }
             agent.restore_compaction_checkpoint().map_err(|error| {
                 OperationAdmissionPreparationError::Coordination {
                     message: SessionCoordinationError::store(format!(
@@ -1844,27 +1892,24 @@ impl SessionService {
                 }
             })?;
             drop(agent);
-            if let Some(durable_blob) = durable_blob {
-                // Reconcile the cached snapshot with the durable blob after
-                // every refresh, not only when this admission rewrote the
-                // blob itself: a prior admission may have repaired the blob
-                // and then failed before patching this copy (e.g. snapshot
-                // lock contention), and the retry sees nothing left to
-                // repair. Without the reconcile, store-backed transcript
-                // reads would serve the discarded dangling turn from the
-                // stale pre-repair snapshot for the rest of the process
-                // lifetime (mirrors the resume path in runtime.rs).
+            if let Some(refresh) = refresh {
+                // The durable blob is immutable after cursor bootstrap except
+                // for lease-held prefix truncation. Reconcile by length only;
+                // no admission clones or reparses the trusted snapshot.
                 let mut snapshot = self.session_snapshot.try_lock().map_err(|_| {
                     OperationAdmissionPreparationError::Coordination {
                         message: SessionCoordinationError::local_agent_busy(),
                     }
                 })?;
                 if let Some(snapshot) = snapshot.as_mut() {
-                    // The blob is write-once and repairs only truncate it,
-                    // so an equal length means this copy is already current.
-                    if snapshot.messages.len() != durable_blob.len() {
-                        snapshot.messages = durable_blob;
+                    if snapshot.messages.len() < refresh.snapshot_len {
+                        return Err(OperationAdmissionPreparationError::Coordination {
+                            message: SessionCoordinationError::store(
+                                "durable transcript snapshot unexpectedly grew".to_string(),
+                            ),
+                        });
                     }
+                    snapshot.messages.truncate(refresh.snapshot_len);
                 }
             }
         }
@@ -3069,6 +3114,53 @@ pub(super) mod tests {
     }
 
     #[test]
+    fn transcript_scan_cache_reverses_replaced_indices() {
+        let assistant = |content: &str| Message::Assistant {
+            content: Some(content.to_string()),
+            reasoning_text: None,
+            reasoning_details: None,
+            tool_calls: None,
+            duration_ms: None,
+            model_origin: None,
+            reasoning_field: None,
+        };
+        let original = vec![
+            Message::System {
+                content: "system".to_string(),
+            },
+            Message::User {
+                content: "discarded".to_string(),
+            },
+            assistant("discarded response"),
+            Message::User {
+                content: "also discarded".to_string(),
+            },
+        ];
+        let authoritative = vec![
+            original[0].clone(),
+            Message::User {
+                content: "replacement".to_string(),
+            },
+            assistant("replacement response"),
+            Message::User {
+                content: "replacement".to_string(),
+            },
+        ];
+        let mut cache = TranscriptScanCache::from_transcript(&original);
+
+        cache.apply_replacement(1, &original[1..], &authoritative);
+
+        assert_eq!(cache.scanned_len, authoritative.len());
+        assert_eq!(cache.user_count, 2);
+        assert_eq!(cache.user_indices, vec![1, 3]);
+        assert_eq!(cache.last_user_idx, Some(3));
+        assert_eq!(cache.user_copies.get("replacement"), Some(&2));
+        assert!(!cache.user_copies.contains_key("discarded"));
+        assert!(!cache.user_copies.contains_key("also discarded"));
+        assert_eq!(cache.visible_response_count, 1);
+    }
+
+    #[test]
     fn thread_tool_call_names_ignore_malformed_and_non_thread_calls() {
         let messages = mixed_message_history();
         // Names come from `thread` tool calls only; malformed arguments,
@@ -3214,7 +3306,12 @@ pub(super) mod tests {
         connection
             .execute(
                 "UPDATE sessions
-                 SET messages_json = ?1, visible_message_count = ?2, last_user_prompt = ?3
+                 SET messages_json = ?1,
+                     visible_message_count = ?2,
+                     last_user_prompt = ?3,
+                     transcript_snapshot_len = NULL,
+                     transcript_next_idx = NULL,
+                     transcript_last_row_id = NULL
                  WHERE session_id = ?4",
                 rusqlite::params![
                     serde_json::to_string(&messages).unwrap(),
@@ -5359,48 +5456,65 @@ pub(super) mod tests {
     }
 
     /// Peer process for
-    /// `shared_store_recovery_after_peer_crash_preserves_committed_transcript`:
-    /// plays the run owner on a shared store — acquires the session
-    /// operation lease, commits its run's transcript rows, signals
-    /// readiness, then sleeps holding the lease until the parent SIGKILLs it
-    /// (process death releases the lease).
+    /// `shared_store_recovery_after_peer_crash_preserves_committed_transcript`.
+    /// It runs a real `SessionService`: one operation completes, then a second
+    /// operation commits its user row and blocks in the model request while
+    /// retaining the process-wide operation lease. The parent kills the
+    /// process after observing that second request.
     #[test]
     fn shared_store_peer_process_helper() {
         let Some(store_path) = std::env::var_os("NAC_TEST_SHARED_STORE_STORE") else {
             return;
         };
-        let ready_path = PathBuf::from(std::env::var_os("NAC_TEST_SHARED_STORE_READY").unwrap());
         let session_id = std::env::var("NAC_TEST_SHARED_STORE_SESSION").unwrap();
-        let _lease =
-            sessions::SessionOperationLease::try_acquire(Path::new(&store_path), &session_id)
+        let base_url = std::env::var("NAC_TEST_SHARED_STORE_BASE_URL").unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let store_path = PathBuf::from(store_path);
+            let snapshot = sessions::load_session(&store_path, &session_id).unwrap();
+            let client = ModelClient::new_for_test_server(base_url);
+            let agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
+            let parts = SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+                agent,
+                client,
+                session: OrchestratorSession::Active {
+                    session_id: session_id.clone(),
+                    store_path,
+                    snapshot,
+                },
+                sandbox_status: "off".to_string(),
+                agents_md_status: "off".to_string(),
+                workspace_display: "/repo".to_string(),
+                workspace_git: Some(GitTarget::local("/repo")),
+                resume_base_cwd: PathBuf::from("/repo"),
+            });
+            let mut events = parts.service.subscribe_events();
+            parts
+                .service
+                .try_submit_prompt("peer completed prompt".to_string())
                 .unwrap();
-        let writer = crate::store::TranscriptLogWriter::new(Path::new(&store_path)).unwrap();
-        writer
-            .append(
-                &session_id,
-                1,
-                &Message::User {
-                    content: "peer prompt".to_string(),
-                },
-            )
-            .unwrap();
-        writer
-            .append(
-                &session_id,
-                2,
-                &Message::Assistant {
-                    content: Some("peer answer".to_string()),
-                    reasoning_text: None,
-                    reasoning_details: None,
-                    tool_calls: None,
-                    duration_ms: None,
-                    model_origin: None,
-                    reasoning_field: None,
-                },
-            )
-            .unwrap();
-        std::fs::write(ready_path, b"ready").unwrap();
-        std::thread::sleep(Duration::from_secs(30));
+            loop {
+                let envelope = events.recv().await.unwrap();
+                if matches!(envelope.event, SessionEvent::RunCompleted { .. }) {
+                    break;
+                }
+                assert!(
+                    !matches!(envelope.event, SessionEvent::RunFailed { .. }),
+                    "peer's first operation failed"
+                );
+            }
+            while parts.service.active_run().is_some() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            parts
+                .service
+                .try_submit_prompt("peer interrupted prompt".to_string())
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
     }
 
     /// Regression test for issue #146 (shared-store recovery): two `nac-web`
@@ -5413,18 +5527,48 @@ pub(super) mod tests {
     #[tokio::test]
     async fn shared_store_recovery_after_peer_crash_preserves_committed_transcript() {
         use crate::model::test_http::{ScriptedResponse, ScriptedServer};
+        let response_gate = Arc::new((StdMutex::new(false), std::sync::Condvar::new()));
+        struct KillOnDrop(std::process::Child);
+        impl Drop for KillOnDrop {
+            fn drop(&mut self) {
+                let _ = self.0.kill();
+                let _ = self.0.wait();
+            }
+        }
 
         let store_path = test_store_path("shared_store_recovery");
         let session_id = "session-shared-store".to_string();
-        let server = ScriptedServer::start(vec![ScriptedResponse::json(
-            "200 OK",
+        let ready_path = store_path.parent().unwrap().join("peer-ready");
+        let observer_ready_path = ready_path.clone();
+        let completed_response = || {
             serde_json::json!({
                 "status": "completed",
-                "output": [{"type": "message", "content": [{"type": "output_text", "text": "survivor answer"}]}],
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "peer answer"}]}],
                 "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
             })
-            .to_string(),
-        )]);
+            .to_string()
+        };
+        let server = ScriptedServer::start_observed(
+            vec![
+                ScriptedResponse::json("200 OK", completed_response()),
+                ScriptedResponse::json("200 OK", completed_response())
+                    .with_gate(response_gate.clone()),
+                ScriptedResponse::json(
+                    "200 OK",
+                    serde_json::json!({
+                        "status": "completed",
+                        "output": [{"type": "message", "content": [{"type": "output_text", "text": "survivor answer"}]}],
+                        "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+                    })
+                    .to_string(),
+                ),
+            ],
+            move |index, _| {
+                if index == 1 {
+                    std::fs::write(&observer_ready_path, b"ready").unwrap();
+                }
+            },
+        );
         let client = ModelClient::new_for_test_server(server.base_url.clone());
         let agent = test_agent(client.clone(), store_path.clone(), Some(session_id.clone()));
         let snapshot = sessions::new_snapshot(
@@ -5459,37 +5603,51 @@ pub(super) mod tests {
         // the creation-time transcript (one system message).
         assert_eq!(parts.service.agent.lock().await.messages.len(), 1);
 
-        // The peer process commits its run's transcript rows under the
-        // operation lease, then is killed mid-ownership (SIGKILL): the OS
-        // releases the lease.
-        let ready_path = store_path.parent().unwrap().join("peer-ready");
-        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
-            .args([
-                "--exact",
-                "session_service::tests::shared_store_peer_process_helper",
-                "--nocapture",
-            ])
-            .env("NAC_TEST_SHARED_STORE_STORE", &store_path)
-            .env("NAC_TEST_SHARED_STORE_READY", &ready_path)
-            .env("NAC_TEST_SHARED_STORE_SESSION", &session_id)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .unwrap();
+        // The peer completes one real run, begins another, commits its user
+        // row, and blocks in the second model request while holding the lease.
+        let mut child = KillOnDrop(
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .args([
+                    "--exact",
+                    "session_service::tests::shared_store_peer_process_helper",
+                    "--nocapture",
+                ])
+                .env("NAC_TEST_SHARED_STORE_STORE", &store_path)
+                .env("NAC_TEST_SHARED_STORE_SESSION", &session_id)
+                .env("NAC_TEST_SHARED_STORE_BASE_URL", &server.base_url)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+                .unwrap(),
+        );
         for _ in 0..200 {
             if ready_path.exists() {
                 break;
             }
             assert!(
-                child.try_wait().unwrap().is_none(),
+                child.0.try_wait().unwrap().is_none(),
                 "peer helper exited early"
             );
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
         assert!(ready_path.exists(), "peer helper never became ready");
-        child.kill().unwrap();
-        child.wait().unwrap();
+        let committed_before_kill = crate::store::TranscriptLogWriter::new(&store_path)
+            .unwrap()
+            .read_from(&session_id, 0)
+            .unwrap();
+        assert_eq!(committed_before_kill.len(), 3);
+        assert!(matches!(
+            sessions::SessionOperationLease::try_acquire(&store_path, &session_id),
+            Err(sessions::SessionOperationLeaseError::Busy(_))
+        ));
+        child.0.kill().unwrap();
+        child.0.wait().unwrap();
+        let (released, notification) = &*response_gate;
+        *released
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+        notification.notify_all();
 
         // The survivor accepts the recovery submission. Admission acquires
         // the released lease and must refresh the stale in-memory
@@ -5524,30 +5682,36 @@ pub(super) mod tests {
         }
         assert!(parts.service.active_run().is_none());
 
-        // No committed row was deleted: the peer's prompt and answer, then
-        // the survivor's prompt and answer, are all durable and contiguous.
+        // Every committed row survives: the completed peer run, the
+        // interrupted peer prompt, and the survivor run are contiguous.
         let log = crate::store::TranscriptLogWriter::new(&store_path)
             .unwrap()
             .read_from(&session_id, 0)
             .unwrap();
-        assert_eq!(log.len(), 4);
+        assert_eq!(log.len(), 5);
         assert_eq!(log[0].0, 1);
-        assert!(matches!(log[0].1, Message::User { ref content } if content == "peer prompt"));
+        assert!(
+            matches!(&log[0].1, Message::User { content } if content == "peer completed prompt")
+        );
         assert_eq!(log[1].0, 2);
         assert!(
-            matches!(log[1].1, Message::Assistant { content: Some(ref text), .. } if text == "peer answer")
+            matches!(&log[1].1, Message::Assistant { content: Some(text), .. } if text == "peer answer")
         );
         assert_eq!(log[2].0, 3);
-        assert!(matches!(log[2].1, Message::User { ref content } if content == "survivor prompt"));
-        assert_eq!(log[3].0, 4);
         assert!(
-            matches!(log[3].1, Message::Assistant { content: Some(ref text), .. } if text == "survivor answer")
+            matches!(&log[2].1, Message::User { content } if content == "peer interrupted prompt")
+        );
+        assert_eq!(log[3].0, 4);
+        assert!(matches!(&log[3].1, Message::User { content } if content == "survivor prompt"));
+        assert_eq!(log[4].0, 5);
+        assert!(
+            matches!(&log[4].1, Message::Assistant { content: Some(text), .. } if text == "survivor answer")
         );
 
         // Both processes now serve the same complete transcript: the
         // survivor's in-memory transcript matches the durable store.
         let agent = parts.service.agent.lock().await;
-        assert_eq!(agent.messages.len(), 5);
+        assert_eq!(agent.messages.len(), 6);
         for (idx, message) in &log {
             assert_eq!(
                 serde_json::to_vec(message).unwrap(),
@@ -5555,6 +5719,285 @@ pub(super) mod tests {
             );
         }
         drop(agent);
+
+        let connection = crate::store::open_connection(&store_path).unwrap();
+        let integrity: String = connection
+            .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(integrity, "ok");
+        let (visible_count, last_prompt, run_count): (i64, Option<String>, i64) = connection
+            .query_row(
+                "SELECT visible_message_count, last_user_prompt, run_count
+                 FROM sessions WHERE session_id = ?1",
+                rusqlite::params![session_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(visible_count, 5);
+        assert_eq!(last_prompt.as_deref(), Some("survivor prompt"));
+        assert_eq!(run_count, 3);
+        drop(connection);
+
+        async fn restored_service(
+            store_path: &Path,
+            session_id: &str,
+            base_url: String,
+        ) -> SessionServiceParts {
+            let snapshot = sessions::load_session(store_path, session_id).unwrap();
+            let client = ModelClient::new_for_test_server(base_url);
+            let mut agent = test_agent(
+                client.clone(),
+                store_path.to_path_buf(),
+                Some(session_id.to_string()),
+            );
+            agent
+                .restore_messages_merging_log_tail(snapshot.messages.clone(), None)
+                .await
+                .unwrap();
+            SessionService::from_orchestrator_run_config(OrchestratorRunConfig {
+                agent,
+                client,
+                session: OrchestratorSession::Active {
+                    session_id: session_id.to_string(),
+                    store_path: store_path.to_path_buf(),
+                    snapshot,
+                },
+                sandbox_status: "off".to_string(),
+                agents_md_status: "off".to_string(),
+                workspace_display: "/repo".to_string(),
+                workspace_git: Some(GitTarget::local("/repo")),
+                resume_base_cwd: PathBuf::from("/repo"),
+            })
+        }
+        let fresh_a = restored_service(&store_path, &session_id, server.base_url.clone()).await;
+        let fresh_b = restored_service(&store_path, &session_id, server.base_url.clone()).await;
+        let survivor_snapshot = parts.service.frontend_snapshot().await.unwrap();
+        let fresh_a_snapshot = fresh_a.service.frontend_snapshot().await.unwrap();
+        let fresh_b_snapshot = fresh_b.service.frontend_snapshot().await.unwrap();
+        assert_eq!(
+            serde_json::to_vec(&fresh_a_snapshot.messages).unwrap(),
+            serde_json::to_vec(&survivor_snapshot.messages).unwrap()
+        );
+        assert_eq!(
+            serde_json::to_vec(&fresh_b_snapshot.messages).unwrap(),
+            serde_json::to_vec(&survivor_snapshot.messages).unwrap()
+        );
+        assert_eq!(server.finish().len(), 3);
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+    #[test]
+    fn admission_decodes_only_the_committed_delta() {
+        let (parts, store_path) =
+            test_active_service("bounded_admission_refresh", "bounded-admission-session");
+        let session_id = "bounded-admission-session";
+        let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+        let history = (0..4_096)
+            .map(|index| Message::System {
+                content: format!("history {index}"),
+            })
+            .collect::<Vec<_>>();
+        writer.append_batch(session_id, 1, &history).unwrap();
+
+        drop(parts.service.prepare_operation_admission(None).unwrap());
+        crate::store::reset_test_decode_count();
+        crate::store::reset_test_admission_read_counts();
+        drop(parts.service.prepare_operation_admission(None).unwrap());
+        assert_eq!(
+            crate::store::test_decode_count(),
+            0,
+            "an unchanged admission must not decode transcript rows"
+        );
+        assert_eq!(
+            crate::store::test_admission_read_counts(),
+            (1, 0, 0),
+            "unchanged admission performs one cursor probe, no snapshot read, and selects no rows"
+        );
+
+        let delta = vec![
+            Message::System {
+                content: "delta one".to_string(),
+            },
+            Message::System {
+                content: "delta two".to_string(),
+            },
+            Message::System {
+                content: "delta three".to_string(),
+            },
+        ];
+        writer
+            .append_batch(session_id, 1 + history.len() as u64, &delta)
+            .unwrap();
+        crate::store::reset_test_decode_count();
+        crate::store::reset_test_admission_read_counts();
+        drop(parts.service.prepare_operation_admission(None).unwrap());
+        assert_eq!(
+            crate::store::test_decode_count(),
+            delta.len() + 1,
+            "stale admission may decode only the new rows plus the surviving cursor row"
+        );
+        assert_eq!(
+            crate::store::test_admission_read_counts(),
+            (1, 0, delta.len() + 1),
+            "suffix admission selects only the new rows plus the surviving cursor row"
+        );
+        assert_eq!(
+            parts.service.agent.blocking_lock().messages.len(),
+            1 + history.len() + delta.len()
+        );
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn admission_repair_warning_reaches_frontend_snapshot() {
+        let (parts, store_path) =
+            test_active_service("admission_warning", "admission-warning-session");
+        let session_id = "admission-warning-session";
+        let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
+        writer
+            .append(
+                session_id,
+                1,
+                &Message::User {
+                    content: "trusted prompt".to_string(),
+                },
+            )
+            .unwrap();
+        let gap_entry = crate::store::encode_transcript_log_entry(
+            3,
+            &Message::System {
+                content: "discard me".to_string(),
+            },
+        )
+        .unwrap();
+        let connection = crate::store::open_connection(&store_path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO thread_events (session_id, thread_name, event_json, created_at)
+                 VALUES (?1, ?2, ?3, 'created')",
+                rusqlite::params![
+                    session_id,
+                    crate::store::ORCHESTRATOR_STEERING_TARGET,
+                    gap_entry
+                ],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE sessions
+                 SET transcript_snapshot_len = NULL,
+                     transcript_next_idx = NULL,
+                     transcript_last_row_id = NULL
+                 WHERE session_id = ?1",
+                rusqlite::params![session_id],
+            )
+            .unwrap();
+        drop(connection);
+
+        drop(parts.service.prepare_operation_admission(None).unwrap());
+        let snapshot = parts.service.frontend_snapshot().await.unwrap();
+        let warning = snapshot
+            .transcript_recovery_warning
+            .expect("gap repair must be visible to the frontend");
+        assert!(warning.contains("index 2"), "{warning}");
+        assert!(warning.contains("index 3"), "{warning}");
+
+        let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
+    }
+
+    #[tokio::test]
+    async fn admission_latches_repair_warning_before_a_later_failure() {
+        let (parts, store_path) =
+            test_active_service("admission_warning_failure", "warning-failure-session");
+        let session_id = "warning-failure-session";
+        let dangling = vec![
+            Message::System {
+                content: "system".to_string(),
+            },
+            Message::Assistant {
+                content: None,
+                reasoning_text: None,
+                reasoning_details: None,
+                tool_calls: Some(vec![thread_call("call-1", "{}")]),
+                duration_ms: None,
+                model_origin: None,
+                reasoning_field: None,
+            },
+        ];
+        let gap_entry = crate::store::encode_transcript_log_entry(
+            3,
+            &Message::System {
+                content: "discard me".to_string(),
+            },
+        )
+        .unwrap();
+        let connection = crate::store::open_connection(&store_path).unwrap();
+        connection
+            .execute(
+                "UPDATE sessions
+                 SET messages_json = ?1,
+                     transcript_snapshot_len = NULL,
+                     transcript_next_idx = NULL,
+                     transcript_last_row_id = NULL
+                 WHERE session_id = ?2",
+                rusqlite::params![serde_json::to_string(&dangling).unwrap(), session_id],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO thread_events (session_id, thread_name, event_json, created_at)
+                 VALUES (?1, ?2, ?3, 'created')",
+                rusqlite::params![
+                    session_id,
+                    crate::store::ORCHESTRATOR_STEERING_TARGET,
+                    gap_entry
+                ],
+            )
+            .unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_snapshot_repair
+                 BEFORE UPDATE OF messages_json ON sessions
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected snapshot repair failure');
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+
+        assert!(parts.service.prepare_operation_admission(None).is_err());
+        let snapshot = parts.service.frontend_snapshot().await.unwrap();
+        let warning = snapshot
+            .transcript_recovery_warning
+            .expect("committed gap repair must remain visible after later failure");
+        assert!(warning.contains("index 2"), "{warning}");
+        assert!(warning.contains("index 3"), "{warning}");
+        assert!(
+            crate::store::TranscriptLogWriter::new(&store_path)
+                .unwrap()
+                .read_from(session_id, 0)
+                .unwrap()
+                .is_empty(),
+            "the warning describes a repair that committed before the injected failure"
+        );
+
+        let connection = crate::store::open_connection(&store_path).unwrap();
+        connection
+            .execute_batch("DROP TRIGGER fail_snapshot_repair")
+            .unwrap();
+        drop(connection);
+        drop(parts.service.prepare_operation_admission(None).unwrap());
+        assert!(
+            parts
+                .service
+                .frontend_snapshot()
+                .await
+                .unwrap()
+                .transcript_recovery_warning
+                .is_some(),
+            "a successful retry must not erase the previously latched warning"
+        );
 
         let _ = std::fs::remove_dir_all(store_path.parent().unwrap());
     }

--- a/crates/nac-core/src/sessions/db.rs
+++ b/crates/nac-core/src/sessions/db.rs
@@ -103,9 +103,9 @@ pub fn create_session(path: &Path, snapshot: &SessionSnapshot) -> Result<()> {
 pub fn save_session(path: &Path, snapshot: &SessionSnapshot) -> Result<()> {
     let mut conn = crate::store::open_connection(path)?;
     let tx = conn.transaction()?;
-    // Existing rows only receive run/history state. Model configuration is
-    // independently revisioned so a stale in-memory service cannot undo a
-    // configuration PATCH from another process.
+    // Existing rows receive only non-transcript run state. Transcript blob,
+    // materialized summaries, cursor metadata, and revisioned model settings
+    // retain their dedicated transactional owners.
     insert_or_replace_session(&tx, path, snapshot)?;
     tx.commit()?;
     Ok(())
@@ -841,18 +841,14 @@ fn insert_or_replace_session(
         .as_ref()
         .map(serialize_sandbox)
         .transpose()?;
-    // NEVER-FOLD (DB-direct transcript workset, step 4): this is the only
-    // writer of messages_json — session creation and the legacy full upsert
-    // below. Run end never rewrites the blob (`save_session_run_state`):
-    // the live transcript is the orchestrator transcript log
-    // (store/transcript.rs) and the blob is the write-once system head ++
-    // legacy prefix. DOWNGRADE CAVEAT (user-accepted): builds older than
-    // the transcript-log workset read only messages_json, so they show this
-    // store's history truncated to the blob — invisibility, not corruption;
-    // the log rows are untouched and a current build reads the full
-    // transcript again.
+    // NEVER-FOLD: `messages_json` and the initial transcript cursor are
+    // created together and remain immutable for an existing session. Growing
+    // history lives in the transcript log; the only later blob mutation is
+    // the lease-held prefix-truncation repair in store/transcript.rs.
     let messages_json = serde_json::to_string(&snapshot.messages)
         .context("failed to serialize session messages")?;
+    let transcript_snapshot_len =
+        i64::try_from(snapshot.messages.len()).context("session transcript length overflowed")?;
     let summary_visible_message_count = i64::try_from(visible_message_count(&snapshot.messages))
         .context("session visible message count overflowed")?;
     let summary_last_user_prompt = last_user_prompt(&snapshot.messages);
@@ -887,18 +883,17 @@ fn insert_or_replace_session(
              response_durations_ms_json, created_at, updated_at, host_id, api_key_env,
              extra_headers_json, token_usages_json, config_version,
              orchestrator_compaction_threshold, ssh_port, ssh_identity_file,
-             light_model_json
+             light_model_json, transcript_snapshot_len, transcript_next_idx,
+             transcript_last_row_id
          ) VALUES (
              ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
-             ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25
+             ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25,
+             ?26, ?27, NULL
          )
          ON CONFLICT(session_id) DO UPDATE SET
              cwd = excluded.cwd,
              store_path = excluded.store_path,
              sandbox_json = excluded.sandbox_json,
-             messages_json = excluded.messages_json,
-             visible_message_count = excluded.visible_message_count,
-             last_user_prompt = excluded.last_user_prompt,
              last_response_duration_ms = excluded.last_response_duration_ms,
              previous_response_duration_ms = excluded.previous_response_duration_ms,
              response_durations_ms_json = excluded.response_durations_ms_json,
@@ -935,6 +930,8 @@ fn insert_or_replace_session(
             stored_ssh_port(snapshot.ssh.as_ref()),
             stored_ssh_identity_file(snapshot.ssh.as_ref()),
             light_model_json,
+            transcript_snapshot_len,
+            transcript_snapshot_len,
         ],
     )?;
     Ok(())

--- a/crates/nac-core/src/sessions/mod.rs
+++ b/crates/nac-core/src/sessions/mod.rs
@@ -560,8 +560,8 @@ mod tests {
         let reloaded = load_session(&store_path, "session-foreign").unwrap();
         assert_eq!(reloaded.messages.len(), 1);
         match &reloaded.messages[0] {
-            Message::User { content } => assert_eq!(content, "updated"),
-            other => panic!("expected updated user message, got {:?}", other),
+            Message::User { content } => assert_eq!(content, "hello"),
+            other => panic!("expected immutable user message, got {other:?}"),
         }
 
         let conn = crate::store::open_connection(&store_path).unwrap();
@@ -987,7 +987,7 @@ mod tests {
     }
 
     #[test]
-    fn config_and_history_writes_preserve_each_other_in_both_orders() {
+    fn config_run_state_and_transcript_writes_preserve_each_other_in_both_orders() {
         let _guard = TEST_ENV_LOCK.lock().unwrap();
         let store_path = temp_store_path("config_history_isolation");
 
@@ -1022,8 +1022,7 @@ mod tests {
                 BTreeMap::from([("X-Patched".to_string(), "true".to_string())]);
             config_patch.orchestrator_compaction_threshold = Some(8_192);
 
-            let mut completed_run = load_session(&store_path, session_id).unwrap();
-            completed_run.messages = vec![
+            let committed_messages = vec![
                 Message::User {
                     content: "new prompt".to_string(),
                 },
@@ -1037,6 +1036,8 @@ mod tests {
                     reasoning_field: None,
                 },
             ];
+            let mut completed_run = load_session(&store_path, session_id).unwrap();
+            completed_run.messages = committed_messages.clone();
             completed_run.last_response_duration_ms = Some(250);
             completed_run.previous_response_duration_ms = Some(125);
             completed_run.response_durations_ms = Some(vec![Some(250)]);
@@ -1051,10 +1052,17 @@ mod tests {
             })];
             completed_run.updated_at = "2026-01-02 00:00:00.000000000".to_string();
 
+            let writer = crate::store::TranscriptLogWriter::new(&store_path).unwrap();
             if config_first {
                 update_session_config(&store_path, &config_patch).unwrap();
+                writer
+                    .append_batch(session_id, 0, &committed_messages)
+                    .unwrap();
                 save_session(&store_path, &completed_run).unwrap();
             } else {
+                writer
+                    .append_batch(session_id, 0, &committed_messages)
+                    .unwrap();
                 save_session(&store_path, &completed_run).unwrap();
                 update_session_config(&store_path, &config_patch).unwrap();
             }
@@ -1071,15 +1079,18 @@ mod tests {
             );
             assert_eq!(stored.orchestrator_compaction_threshold, Some(8_192));
             assert_eq!(stored.config_version, 1);
-            assert_eq!(stored.messages.len(), 2);
-            assert!(matches!(
-                stored.messages.first(),
-                Some(Message::User { content }) if content == "new prompt"
-            ));
-            assert!(matches!(
-                stored.messages.get(1),
-                Some(Message::Assistant { content: Some(content), .. }) if content == "new response"
-            ));
+            assert!(
+                stored.messages.is_empty(),
+                "the creation-time snapshot remains immutable"
+            );
+            let stored_transcript = writer.read_from(session_id, 0).unwrap();
+            assert_eq!(stored_transcript.len(), 2);
+            assert!(
+                matches!(&stored_transcript[0].1, Message::User { content } if content == "new prompt")
+            );
+            assert!(
+                matches!(&stored_transcript[1].1, Message::Assistant { content: Some(content), .. } if content == "new response")
+            );
             assert_eq!(stored.last_response_duration_ms, Some(250));
             assert_eq!(stored.previous_response_duration_ms, Some(125));
             assert_eq!(stored.response_durations_ms, Some(vec![Some(250)]));

--- a/crates/nac-core/src/store/orchestrator_compaction.rs
+++ b/crates/nac-core/src/store/orchestrator_compaction.rs
@@ -31,6 +31,10 @@ pub(crate) struct OrchestratorCompactionCheckpoint {
     pub summary_prompt_tokens: Option<u64>,
     pub summary_completion_tokens: Option<u64>,
     pub new_context_estimate: u64,
+    /// Transcript identity captured atomically with checkpoint insertion.
+    /// `None` identifies a legacy checkpoint, which admission never adopts
+    /// without the startup validation pass.
+    pub transcript_cursor: Option<TranscriptCursor>,
     pub created_at: String,
 }
 
@@ -38,7 +42,8 @@ const CHECKPOINT_COLUMNS: &str =
     "id, session_id, previous_checkpoint_id, summary, tail_start_message_index, \
      source_prefix_sha256, system_policy_sha256, prompt_policy_version, \
      old_context_estimate, summary_prompt_tokens, summary_completion_tokens, \
-     new_context_estimate, created_at";
+     new_context_estimate, transcript_snapshot_len, transcript_next_idx, \
+     transcript_last_row_id, created_at";
 
 pub(crate) fn append_orchestrator_compaction_checkpoint(
     path: &Path,
@@ -110,14 +115,16 @@ pub(crate) fn append_orchestrator_compaction_checkpoint(
             ));
         }
     }
+    let transcript_cursor = transcript_cursor(&transaction, &checkpoint.session_id)?;
 
     transaction.execute(
         "INSERT INTO orchestrator_compaction_checkpoints
              (session_id, previous_checkpoint_id, summary, tail_start_message_index,
               source_prefix_sha256, system_policy_sha256, prompt_policy_version,
               old_context_estimate, summary_prompt_tokens, summary_completion_tokens,
-              new_context_estimate, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+              new_context_estimate, transcript_snapshot_len, transcript_next_idx,
+              transcript_last_row_id, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
         params![
             checkpoint.session_id,
             checkpoint.previous_checkpoint_id,
@@ -130,6 +137,13 @@ pub(crate) fn append_orchestrator_compaction_checkpoint(
             summary_prompt_tokens,
             summary_completion_tokens,
             new_context_estimate,
+            transcript_cursor
+                .map(|cursor| i64::try_from(cursor.snapshot_len))
+                .transpose()?,
+            transcript_cursor
+                .map(|cursor| i64::try_from(cursor.next_idx))
+                .transpose()?,
+            transcript_cursor.and_then(|cursor| cursor.last_row_id),
             now_utc(),
         ],
     )?;
@@ -138,6 +152,62 @@ pub(crate) fn append_orchestrator_compaction_checkpoint(
         .ok_or_else(|| anyhow!("inserted orchestrator compaction checkpoint {id} was not found"))?;
     transaction.commit()?;
     Ok(inserted)
+}
+
+pub(crate) fn latest_orchestrator_compaction_checkpoint_id(
+    path: &Path,
+    session_id: &str,
+) -> Result<Option<i64>> {
+    let conn = open_runtime_connection(path)?;
+    conn.query_row(
+        "SELECT MAX(id)
+         FROM orchestrator_compaction_checkpoints
+         WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+    )
+    .map_err(Into::into)
+}
+
+/// Load only the newest physical checkpoint row. A malformed newest row is
+/// reported as absent while preserving its ID, so admission can remember that
+/// it was examined without scanning older history.
+pub(crate) fn load_latest_orchestrator_compaction_checkpoint(
+    path: &Path,
+    session_id: &str,
+) -> Result<(Option<i64>, Option<OrchestratorCompactionCheckpoint>)> {
+    let conn = open_runtime_connection(path)?;
+    let latest_id = conn.query_row(
+        "SELECT MAX(id)
+         FROM orchestrator_compaction_checkpoints
+         WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+    )?;
+    let Some(latest_id) = latest_id else {
+        return Ok((None, None));
+    };
+    match conn
+        .query_row(
+            &format!(
+                "SELECT {CHECKPOINT_COLUMNS}
+                 FROM orchestrator_compaction_checkpoints
+                 WHERE id = ?1 AND session_id = ?2"
+            ),
+            params![latest_id, session_id],
+            map_checkpoint_row,
+        )
+        .optional()
+    {
+        Ok(checkpoint) => Ok((Some(latest_id), checkpoint)),
+        Err(error) if is_checkpoint_decode_error(&error) => {
+            eprintln!(
+                "nac: ignoring malformed newest orchestrator compaction checkpoint {latest_id}: {error}"
+            );
+            Ok((Some(latest_id), None))
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub(crate) fn load_orchestrator_compaction_checkpoints(
@@ -213,7 +283,38 @@ fn map_checkpoint_row(
             .map(|value| token_count_from_sqlite(value, 10))
             .transpose()?,
         new_context_estimate: token_count_from_sqlite(row.get(11)?, 11)?,
-        created_at: row.get(12)?,
+        transcript_cursor: match (
+            row.get::<_, Option<i64>>(12)?,
+            row.get::<_, Option<i64>>(13)?,
+            row.get::<_, Option<i64>>(14)?,
+        ) {
+            (None, None, None) => None,
+            (Some(snapshot_len), Some(next_idx), last_row_id) => Some(TranscriptCursor {
+                snapshot_len: u64::try_from(snapshot_len).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        12,
+                        rusqlite::types::Type::Integer,
+                        Box::new(error),
+                    )
+                })?,
+                next_idx: u64::try_from(next_idx).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        13,
+                        rusqlite::types::Type::Integer,
+                        Box::new(error),
+                    )
+                })?,
+                last_row_id,
+            }),
+            _ => {
+                return Err(rusqlite::Error::FromSqlConversionFailure(
+                    12,
+                    rusqlite::types::Type::Integer,
+                    "partially initialized checkpoint transcript cursor".into(),
+                ));
+            }
+        },
+        created_at: row.get(15)?,
     })
 }
 

--- a/crates/nac-core/src/store/schema.rs
+++ b/crates/nac-core/src/store/schema.rs
@@ -1,11 +1,11 @@
 use super::*;
 
-// 13 adds the light-model columns (`light_model_json` on both `sessions` and
-// `model_configurations`) — `open_runtime_connection` returns early whenever
-// the stored version already equals this one. (12 carries the same schema as
-// 11, which added episodes.status; 10 added the ssh_configurations table; 9
-// the per-session ssh port and key columns.)
-const STORE_SCHEMA_VERSION: i64 = 13;
+// 14 adds the nullable transcript cursor columns used for bounded
+// shared-store admission. Existing sessions remain NULL until their first
+// lease-held bootstrap; new sessions initialize the cursor at creation.
+// `open_runtime_connection` returns early whenever the stored version already
+// equals this one.
+const STORE_SCHEMA_VERSION: i64 = 14;
 
 /// Schema version that introduced `sessions.run_count`. Databases older than
 /// this have never had the column populated from their message history.
@@ -142,10 +142,10 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
             migrate_thread_events(&transaction)?;
             transaction.execute_batch("DROP TABLE IF EXISTS session_overviews")?;
         }
-        2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | STORE_SCHEMA_VERSION => {}
+        2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | STORE_SCHEMA_VERSION => {}
         unsupported => {
             return Err(anyhow!(
-                "unsupported store schema version {unsupported}; this build supports versions 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, and {STORE_SCHEMA_VERSION}"
+                "unsupported store schema version {unsupported}; this build supports versions 0 through {STORE_SCHEMA_VERSION}"
             ));
         }
     }
@@ -172,6 +172,24 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
         "INTEGER NOT NULL DEFAULT 0 CHECK (visible_message_count >= 0)",
     )?;
     ensure_column(&transaction, "sessions", "last_user_prompt", "TEXT")?;
+    ensure_column(
+        &transaction,
+        "sessions",
+        "transcript_snapshot_len",
+        "INTEGER CHECK (transcript_snapshot_len IS NULL OR transcript_snapshot_len >= 0)",
+    )?;
+    ensure_column(
+        &transaction,
+        "sessions",
+        "transcript_next_idx",
+        "INTEGER CHECK (transcript_next_idx IS NULL OR transcript_next_idx >= 0)",
+    )?;
+    ensure_column(
+        &transaction,
+        "sessions",
+        "transcript_last_row_id",
+        "INTEGER CHECK (transcript_last_row_id IS NULL OR transcript_last_row_id > 0)",
+    )?;
     // A remote session records its whole connection, not just the host name, so
     // resume reaches the same machine without depending on the ssh config of
     // whoever restarts nac. NULL means "whatever ssh decides", which is what a
@@ -201,6 +219,24 @@ pub(crate) fn open_connection(path: &Path) -> Result<Connection> {
         backfill_session_summaries(&transaction)?;
     }
     create_orchestrator_compaction_checkpoints_table(&transaction)?;
+    ensure_column(
+        &transaction,
+        "orchestrator_compaction_checkpoints",
+        "transcript_snapshot_len",
+        "INTEGER CHECK (transcript_snapshot_len IS NULL OR transcript_snapshot_len >= 0)",
+    )?;
+    ensure_column(
+        &transaction,
+        "orchestrator_compaction_checkpoints",
+        "transcript_next_idx",
+        "INTEGER CHECK (transcript_next_idx IS NULL OR transcript_next_idx >= 0)",
+    )?;
+    ensure_column(
+        &transaction,
+        "orchestrator_compaction_checkpoints",
+        "transcript_last_row_id",
+        "INTEGER CHECK (transcript_last_row_id IS NULL OR transcript_last_row_id > 0)",
+    )?;
     create_workspace_revisions_table(&transaction)?;
     // Revisions recorded before revert existed cannot say which transcript
     // prefix they describe; NULL is that "unknown", and a revert simply does
@@ -296,6 +332,12 @@ fn create_base_schema(conn: &Connection) -> Result<()> {
              token_usages_json TEXT,
              config_version INTEGER NOT NULL DEFAULT 0 CHECK (config_version >= 0),
              run_count INTEGER NOT NULL DEFAULT 0 CHECK (run_count >= 0),
+             transcript_snapshot_len INTEGER
+                 CHECK (transcript_snapshot_len IS NULL OR transcript_snapshot_len >= 0),
+             transcript_next_idx INTEGER
+                 CHECK (transcript_next_idx IS NULL OR transcript_next_idx >= 0),
+             transcript_last_row_id INTEGER
+                 CHECK (transcript_last_row_id IS NULL OR transcript_last_row_id > 0),
              orchestrator_compaction_threshold INTEGER
                  CHECK (orchestrator_compaction_threshold IS NULL OR
                         (typeof(orchestrator_compaction_threshold) = 'integer' AND
@@ -561,6 +603,12 @@ fn create_orchestrator_compaction_checkpoints_table(conn: &Connection) -> Result
              new_context_estimate INTEGER NOT NULL
                  CHECK (new_context_estimate >= 0
                         AND new_context_estimate <= {max}),
+             transcript_snapshot_len INTEGER
+                 CHECK (transcript_snapshot_len IS NULL OR transcript_snapshot_len >= 0),
+             transcript_next_idx INTEGER
+                 CHECK (transcript_next_idx IS NULL OR transcript_next_idx >= 0),
+             transcript_last_row_id INTEGER
+                 CHECK (transcript_last_row_id IS NULL OR transcript_last_row_id > 0),
              created_at TEXT NOT NULL,
              UNIQUE (session_id, id),
              FOREIGN KEY (session_id, previous_checkpoint_id)

--- a/crates/nac-core/src/store/schema_tests.rs
+++ b/crates/nac-core/src/store/schema_tests.rs
@@ -202,6 +202,9 @@ fn assert_current_schema(conn: &Connection) {
             "summary_prompt_tokens",
             "summary_completion_tokens",
             "new_context_estimate",
+            "transcript_snapshot_len",
+            "transcript_next_idx",
+            "transcript_last_row_id",
             "created_at",
         ]
     );
@@ -855,6 +858,64 @@ fn checkpoint_table_enforces_completed_row_constraints() {
         .unwrap();
     assert_eq!(row_count, 2);
     drop(conn);
+    let _ = std::fs::remove_dir_all(path.parent().unwrap());
+}
+
+#[test]
+fn v13_store_adds_nullable_transcript_cursor_columns() {
+    let path = temp_store_path("v13_transcript_cursor");
+    initialize(&path).unwrap();
+    crate::store::insert_test_session(&path, "legacy");
+    let legacy = open_runtime_connection(&path).unwrap();
+    legacy
+        .execute_batch(
+            "ALTER TABLE sessions DROP COLUMN transcript_last_row_id;
+             ALTER TABLE sessions DROP COLUMN transcript_next_idx;
+             ALTER TABLE sessions DROP COLUMN transcript_snapshot_len;
+             ALTER TABLE orchestrator_compaction_checkpoints
+                 DROP COLUMN transcript_last_row_id;
+             ALTER TABLE orchestrator_compaction_checkpoints
+                 DROP COLUMN transcript_next_idx;
+             ALTER TABLE orchestrator_compaction_checkpoints
+                 DROP COLUMN transcript_snapshot_len;",
+        )
+        .unwrap();
+    legacy.pragma_update(None, "user_version", 13).unwrap();
+    drop(legacy);
+
+    initialize(&path).unwrap();
+    let migrated = open_runtime_connection(&path).unwrap();
+    let columns = table_columns(&migrated, "sessions");
+    for expected in [
+        "transcript_snapshot_len",
+        "transcript_next_idx",
+        "transcript_last_row_id",
+    ] {
+        assert!(columns.iter().any(|column| column == expected));
+    }
+    let cursor: (Option<i64>, Option<i64>, Option<i64>) = migrated
+        .query_row(
+            "SELECT transcript_snapshot_len, transcript_next_idx,
+                    transcript_last_row_id
+             FROM sessions WHERE session_id = 'legacy'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(cursor, (None, None, None));
+    let checkpoint_columns = table_columns(&migrated, "orchestrator_compaction_checkpoints");
+    for expected in [
+        "transcript_snapshot_len",
+        "transcript_next_idx",
+        "transcript_last_row_id",
+    ] {
+        assert!(
+            checkpoint_columns.iter().any(|column| column == expected),
+            "missing checkpoint cursor column {expected}"
+        );
+    }
+
+    drop(migrated);
     let _ = std::fs::remove_dir_all(path.parent().unwrap());
 }
 

--- a/crates/nac-core/src/store/transcript.rs
+++ b/crates/nac-core/src/store/transcript.rs
@@ -10,9 +10,10 @@
 //! The orchestrator transcript is an append-only log in the existing
 //! `thread_events` table: one row per transcript message, written under the
 //! reserved thread name `__orchestrator__` (`ORCHESTRATOR_STEERING_TARGET`).
-//! No schema change: the table already has the needed shape (session_id FK,
-//! thread_name, event_json, created_at) and index (session_id, thread_name,
-//! id).
+//! The row table already supplies the needed `(session_id, thread_name, id)`
+//! index. `sessions` additionally stores a transactional transcript cursor:
+//! immutable snapshot length, logical next index, and newest physical row id.
+//! Admission compares that fixed-size cursor before reading any payload.
 //!
 //! # Payload format (load-bearing)
 //!
@@ -88,11 +89,13 @@
 //! counts (run start vs run end) and `sessions::save_session_run_state`
 //! UPDATEs only run-state columns. Session summaries (visible message count,
 //! last user prompt) are materialized on `sessions`: append updates them in
-//! the same transaction as the log rows, while tail truncation rebuilds them
-//! from blob ++ remaining log. The polling read path therefore never scans
-//! transcript history. DOWNGRADE CAVEAT (accepted by the user): a build older
-//! than the transcript-log workset reads only `messages_json`, so it shows
-//! this store's history truncated to the head/legacy prefix — invisibility,
+//! the same transaction as the log rows. Normal assistant/tool-tail
+//! truncation applies only the deleted suffix's delta; arbitrary user-facing
+//! reverts retain a strict full-summary rebuild. The polling read path never
+//! scans transcript history.
+//! DOWNGRADE CAVEAT (accepted by the user): a build older than the
+//! transcript-log workset reads only `messages_json`, so it shows this store's
+//! history truncated to the head/legacy prefix — invisibility,
 //! not corruption; the log rows are untouched and a current build reads the
 //! full transcript again.
 //!
@@ -180,6 +183,46 @@ struct TranscriptLogPayload {
     nac_transcript_message: TranscriptLogEntry,
 }
 
+#[cfg(test)]
+thread_local! {
+    static TEST_DECODE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_CURSOR_PROBE_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_SNAPSHOT_READ_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_SELECTED_ROW_COUNT: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static TEST_CURSOR_PROBE_FAILURES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_test_decode_count() {
+    TEST_DECODE_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn test_decode_count() -> usize {
+    TEST_DECODE_COUNT.with(std::cell::Cell::get)
+}
+
+#[cfg(test)]
+pub(crate) fn reset_test_admission_read_counts() {
+    TEST_CURSOR_PROBE_COUNT.with(|count| count.set(0));
+    TEST_SNAPSHOT_READ_COUNT.with(|count| count.set(0));
+    TEST_SELECTED_ROW_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(crate) fn test_admission_read_counts() -> (usize, usize, usize) {
+    (
+        TEST_CURSOR_PROBE_COUNT.with(std::cell::Cell::get),
+        TEST_SNAPSHOT_READ_COUNT.with(std::cell::Cell::get),
+        TEST_SELECTED_ROW_COUNT.with(std::cell::Cell::get),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn fail_next_test_cursor_probe() {
+    TEST_CURSOR_PROBE_FAILURES.with(|remaining| remaining.set(1));
+}
+
 /// Encode one transcript log row payload (see the module docs for the exact
 /// wire format).
 pub fn encode_transcript_log_entry(idx: u64, message: &Message) -> Result<String> {
@@ -200,6 +243,8 @@ pub fn encode_transcript_log_entry(idx: u64, message: &Message) -> Result<String
 /// Fully decode a transcript log row payload. Returns `None` when the payload
 /// is not a transcript row (e.g. a regular `AgentEvent` row).
 pub fn decode_transcript_log_entry(event_json: &str) -> Option<TranscriptLogEntry> {
+    #[cfg(test)]
+    TEST_DECODE_COUNT.with(|count| count.set(count.get() + 1));
     serde_json::from_str::<TranscriptLogPayload>(event_json)
         .ok()
         .map(|payload| payload.nac_transcript_message)
@@ -278,6 +323,191 @@ pub struct TranscriptLogWriter {
     connection: Mutex<Connection>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TranscriptCursor {
+    pub snapshot_len: u64,
+    pub next_idx: u64,
+    pub last_row_id: Option<i64>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TranscriptReconciliation {
+    pub cursor: TranscriptCursor,
+    pub common_prefix_len: u64,
+    pub rows: Vec<Message>,
+}
+
+pub(crate) fn transcript_cursor(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Option<TranscriptCursor>> {
+    let (snapshot_len, next_idx, last_row_id) = conn.query_row(
+        "SELECT transcript_snapshot_len, transcript_next_idx, transcript_last_row_id
+         FROM sessions
+         WHERE session_id = ?1",
+        params![session_id],
+        |row| {
+            Ok((
+                row.get::<_, Option<i64>>(0)?,
+                row.get::<_, Option<i64>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+            ))
+        },
+    )?;
+    match (snapshot_len, next_idx, last_row_id) {
+        (None, None, None) => Ok(None),
+        (Some(snapshot_len), Some(next_idx), last_row_id) => {
+            let snapshot_len = u64::try_from(snapshot_len)
+                .context("stored transcript snapshot length was negative")?;
+            let next_idx =
+                u64::try_from(next_idx).context("stored transcript next index was negative")?;
+            if next_idx < snapshot_len {
+                return Err(anyhow!(
+                    "stored transcript cursor ends at {next_idx} before snapshot length {snapshot_len}"
+                ));
+            }
+            Ok(Some(TranscriptCursor {
+                snapshot_len,
+                next_idx,
+                last_row_id,
+            }))
+        }
+        _ => Err(anyhow!(
+            "stored transcript cursor is partially initialized for session {session_id}"
+        )),
+    }
+}
+
+pub(crate) fn transcript_cursor_survives(
+    path: &Path,
+    session_id: &str,
+    checkpoint: TranscriptCursor,
+) -> Result<bool> {
+    #[cfg(test)]
+    {
+        let fail = TEST_CURSOR_PROBE_FAILURES.with(|remaining| {
+            let current = remaining.get();
+            remaining.set(current.saturating_sub(1));
+            current > 0
+        });
+        if fail {
+            anyhow::bail!("injected transcript cursor survival failure");
+        }
+    }
+    let conn = open_runtime_connection(path)?;
+    let Some(current) = transcript_cursor(&conn, session_id)? else {
+        return Ok(false);
+    };
+    if current.snapshot_len != checkpoint.snapshot_len || current.next_idx < checkpoint.next_idx {
+        return Ok(false);
+    }
+    let Some(last_row_id) = checkpoint.last_row_id else {
+        return Ok(checkpoint.next_idx == checkpoint.snapshot_len);
+    };
+    let Some((physical_row_id, entry)) =
+        newest_transcript_row(&conn, session_id, Some(last_row_id))?
+    else {
+        return Ok(false);
+    };
+    Ok(physical_row_id == last_row_id && entry.idx.checked_add(1) == Some(checkpoint.next_idx))
+}
+
+fn newest_transcript_row(
+    conn: &Connection,
+    session_id: &str,
+    at_or_before: Option<i64>,
+) -> Result<Option<(i64, TranscriptLogEntry)>> {
+    let row = match at_or_before {
+        Some(row_id) => conn
+            .query_row(
+                "SELECT id, event_json
+                 FROM thread_events
+                 WHERE session_id = ?1 AND thread_name = ?2 AND id <= ?3
+                 ORDER BY id DESC
+                 LIMIT 1",
+                params![session_id, ORCHESTRATOR_STEERING_TARGET, row_id],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?,
+        None => conn
+            .query_row(
+                "SELECT id, event_json
+                 FROM thread_events
+                 WHERE session_id = ?1 AND thread_name = ?2
+                 ORDER BY id DESC
+                 LIMIT 1",
+                params![session_id, ORCHESTRATOR_STEERING_TARGET],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?,
+    };
+    row.map(|(id, event_json)| {
+        let entry = decode_transcript_log_entry(&event_json).ok_or_else(|| {
+            anyhow!(
+                "thread_events row {id} under '{ORCHESTRATOR_STEERING_TARGET}' is not a transcript log entry"
+            )
+        })?;
+        Ok((id, entry))
+    })
+    .transpose()
+}
+
+fn store_transcript_cursor(
+    conn: &Connection,
+    session_id: &str,
+    snapshot_len: u64,
+    next_idx: u64,
+) -> Result<TranscriptCursor> {
+    let last_row_id = newest_transcript_row(conn, session_id, None)?.map(|(id, _)| id);
+    let updated = conn.execute(
+        "UPDATE sessions
+         SET transcript_snapshot_len = ?1,
+             transcript_next_idx = ?2,
+             transcript_last_row_id = ?3
+         WHERE session_id = ?4",
+        params![
+            i64::try_from(snapshot_len).context("transcript snapshot length overflowed")?,
+            i64::try_from(next_idx).context("transcript next index overflowed")?,
+            last_row_id,
+            session_id
+        ],
+    )?;
+    if updated != 1 {
+        return Err(anyhow!(
+            "transcript cursor update expected one session row, updated {updated}"
+        ));
+    }
+    Ok(TranscriptCursor {
+        snapshot_len,
+        next_idx,
+        last_row_id,
+    })
+}
+
+fn load_or_initialize_cursor(conn: &Connection, session_id: &str) -> Result<TranscriptCursor> {
+    if let Some(cursor) = transcript_cursor(conn, session_id)? {
+        return Ok(cursor);
+    }
+    let snapshot_len: i64 = conn.query_row(
+        "SELECT json_array_length(messages_json) FROM sessions WHERE session_id = ?1",
+        params![session_id],
+        |row| row.get(0),
+    )?;
+    let snapshot_len =
+        u64::try_from(snapshot_len).context("stored session transcript length was negative")?;
+    let next_idx = newest_transcript_row(conn, session_id, None)?
+        .map(|(_, entry)| {
+            entry
+                .idx
+                .checked_add(1)
+                .context("transcript log index overflowed")
+        })
+        .transpose()?
+        .unwrap_or(0)
+        .max(snapshot_len);
+    store_transcript_cursor(conn, session_id, snapshot_len, next_idx)
+}
+
 /// Length of the log tail relative to a snapshot blob of `blob_len` messages,
 /// read from the newest row's `idx`. Callers hold the connection lock, so the
 /// extent cannot shift under a window read taken with it.
@@ -314,8 +544,206 @@ impl TranscriptLogWriter {
         })
     }
 
+    pub(crate) fn current_cursor(&self, session_id: &str) -> Result<Option<TranscriptCursor>> {
+        #[cfg(test)]
+        TEST_CURSOR_PROBE_COUNT.with(|count| count.set(count.get() + 1));
+        let connection = self
+            .connection
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        transcript_cursor(&connection, session_id)
+    }
+
+    pub(crate) fn bootstrap_cursor(
+        &self,
+        session_id: &str,
+        snapshot_len: u64,
+        next_idx: u64,
+    ) -> Result<TranscriptCursor> {
+        let mut connection = self
+            .connection
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let transaction =
+            connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        if let Some(cursor) = transcript_cursor(&transaction, session_id)? {
+            transaction.commit()?;
+            return Ok(cursor);
+        }
+        let newest = newest_transcript_row(&transaction, session_id, None)?;
+        let durable_next_idx = newest
+            .as_ref()
+            .map(|(_, entry)| {
+                entry
+                    .idx
+                    .checked_add(1)
+                    .context("transcript log index overflowed")
+            })
+            .transpose()?
+            .unwrap_or(0)
+            .max(snapshot_len);
+        if durable_next_idx != next_idx {
+            return Err(anyhow!(
+                "cannot bootstrap stale transcript cursor: durable next idx is {durable_next_idx}, local next idx is {next_idx}"
+            ));
+        }
+        let last_row_id = newest.map(|(id, _)| id);
+        let updated = transaction.execute(
+            "UPDATE sessions
+             SET transcript_snapshot_len = ?1,
+                 transcript_next_idx = ?2,
+                 transcript_last_row_id = ?3
+             WHERE session_id = ?4
+               AND transcript_snapshot_len IS NULL
+               AND transcript_next_idx IS NULL
+               AND transcript_last_row_id IS NULL",
+            params![
+                i64::try_from(snapshot_len).context("transcript snapshot length overflowed")?,
+                i64::try_from(next_idx).context("transcript next index overflowed")?,
+                last_row_id,
+                session_id
+            ],
+        )?;
+        if updated != 1 {
+            return Err(anyhow!(
+                "transcript cursor bootstrap expected one uninitialized session row, updated {updated}"
+            ));
+        }
+        let cursor = TranscriptCursor {
+            snapshot_len,
+            next_idx,
+            last_row_id,
+        };
+        transaction.commit()?;
+        Ok(cursor)
+    }
+
+    pub(crate) fn reconcile_cursor(
+        &self,
+        session_id: &str,
+        adopted: TranscriptCursor,
+    ) -> Result<Option<TranscriptReconciliation>> {
+        #[cfg(test)]
+        TEST_CURSOR_PROBE_COUNT.with(|count| count.set(count.get() + 1));
+        let mut connection = self
+            .connection
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let transaction = connection.transaction()?;
+        let Some(cursor) = transcript_cursor(&transaction, session_id)? else {
+            return Err(anyhow!(
+                "transcript cursor is not initialized for session {session_id}"
+            ));
+        };
+        if cursor == adopted {
+            transaction.commit()?;
+            return Ok(None);
+        }
+
+        let surviving = adopted
+            .last_row_id
+            .map(|row_id| newest_transcript_row(&transaction, session_id, Some(row_id)))
+            .transpose()?
+            .flatten();
+        #[cfg(test)]
+        let mut selected_row_count = usize::from(surviving.is_some());
+        let common_prefix_len = surviving
+            .as_ref()
+            .map(|(_, entry)| {
+                entry
+                    .idx
+                    .checked_add(1)
+                    .context("transcript log index overflowed")
+            })
+            .transpose()?
+            .unwrap_or_else(|| adopted.snapshot_len.min(cursor.snapshot_len))
+            .max(cursor.snapshot_len);
+        if common_prefix_len > adopted.next_idx || common_prefix_len > cursor.next_idx {
+            return Err(anyhow!(
+                "transcript cursor common prefix {common_prefix_len} exceeds local end {} or durable end {}",
+                adopted.next_idx,
+                cursor.next_idx
+            ));
+        }
+
+        let mut rows = Vec::new();
+        if let Some(end_row_id) = cursor.last_row_id {
+            let after_row_id = surviving.as_ref().map(|(id, _)| *id).unwrap_or(0);
+            let mut statement = transaction.prepare(
+                "SELECT id, event_json
+                 FROM thread_events
+                 WHERE session_id = ?1 AND thread_name = ?2
+                   AND id > ?3 AND id <= ?4
+                 ORDER BY id ASC",
+            )?;
+            let selected = statement.query_map(
+                params![
+                    session_id,
+                    ORCHESTRATOR_STEERING_TARGET,
+                    after_row_id,
+                    end_row_id
+                ],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+            )?;
+            let mut expected_idx = common_prefix_len;
+            for row in selected {
+                let (id, event_json) = row?;
+                #[cfg(test)]
+                {
+                    selected_row_count += 1;
+                }
+                let entry = decode_transcript_log_entry(&event_json).ok_or_else(|| {
+                    anyhow!(
+                        "thread_events row {id} under '{ORCHESTRATOR_STEERING_TARGET}' is not a transcript log entry"
+                    )
+                })?;
+                if entry.idx < cursor.snapshot_len {
+                    continue;
+                }
+                if entry.idx != expected_idx {
+                    return Err(anyhow!(
+                        "transcript cursor delta is not contiguous: expected idx {expected_idx}, found {}",
+                        entry.idx
+                    ));
+                }
+                let message: Message =
+                    serde_json::from_str(&entry.message_json).with_context(|| {
+                        format!("thread_events row {id} holds an undecodable transcript message")
+                    })?;
+                rows.push(message);
+                expected_idx = expected_idx
+                    .checked_add(1)
+                    .context("transcript log index overflowed")?;
+            }
+            if expected_idx != cursor.next_idx {
+                return Err(anyhow!(
+                    "transcript cursor delta ended at idx {expected_idx}, durable end is {}",
+                    cursor.next_idx
+                ));
+            }
+        } else if common_prefix_len != cursor.next_idx {
+            return Err(anyhow!(
+                "transcript cursor has no log rows but common prefix {common_prefix_len} differs from durable end {}",
+                cursor.next_idx
+            ));
+        }
+        #[cfg(test)]
+        TEST_SELECTED_ROW_COUNT.with(|count| count.set(count.get() + selected_row_count));
+        transaction.commit()?;
+        Ok(Some(TranscriptReconciliation {
+            cursor,
+            common_prefix_len,
+            rows,
+        }))
+    }
+
     /// Append `message` at absolute transcript position `idx`.
-    pub fn append(&self, session_id: &str, idx: u64, message: &Message) -> Result<()> {
+    pub(crate) fn append(
+        &self,
+        session_id: &str,
+        idx: u64,
+        message: &Message,
+    ) -> Result<TranscriptCursor> {
         self.append_batch(session_id, idx, std::slice::from_ref(message))
     }
 
@@ -325,14 +753,22 @@ impl TranscriptLogWriter {
     /// all-or-nothing. Used for the parallel tool-result batch, whose
     /// provider-view invariant requires the complete batch to be durable
     /// together.
-    pub fn append_batch(
+    pub(crate) fn append_batch(
         &self,
         session_id: &str,
         start_idx: u64,
         messages: &[Message],
-    ) -> Result<()> {
+    ) -> Result<TranscriptCursor> {
         if messages.is_empty() {
-            return Ok(());
+            let mut connection = self
+                .connection
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let transaction =
+                connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+            let cursor = load_or_initialize_cursor(&transaction, session_id)?;
+            transaction.commit()?;
+            return Ok(cursor);
         }
         let visible_delta = i64::try_from(crate::sessions::visible_message_count(messages))
             .context("transcript visible message count overflowed")?;
@@ -343,48 +779,24 @@ impl TranscriptLogWriter {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let transaction =
             connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        let blob_len = transaction.query_row(
-            "SELECT json_array_length(messages_json)
-             FROM sessions
-             WHERE session_id = ?1",
-            params![session_id],
-            |row| row.get::<_, i64>(0),
-        )?;
-        let blob_len =
-            u64::try_from(blob_len).context("stored session transcript length was negative")?;
-        let last_row = transaction
-            .query_row(
-                "SELECT id, event_json
-                 FROM thread_events
-                 WHERE session_id = ?1 AND thread_name = ?2
-                 ORDER BY id DESC
-                 LIMIT 1",
-                params![session_id, ORCHESTRATOR_STEERING_TARGET],
-                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
-            )
-            .optional()?;
-        let log_next_idx = match last_row {
-            None => 0,
-            Some((id, event_json)) => {
-                let entry = decode_transcript_log_entry(&event_json).ok_or_else(|| {
-                    anyhow!(
-                        "thread_events row {id} under '{ORCHESTRATOR_STEERING_TARGET}' is not a transcript log entry"
-                    )
-                })?;
-                entry
-                    .idx
-                    .checked_add(1)
-                    .context("transcript log index overflowed")?
-            }
-        };
-        let expected_start_idx = blob_len.max(log_next_idx);
-        if start_idx != expected_start_idx {
+        let cursor = load_or_initialize_cursor(&transaction, session_id)?;
+        if start_idx != cursor.next_idx {
             return Err(anyhow!(
-                "transcript log append is not contiguous: expected start idx {expected_start_idx}, found {start_idx}"
+                "transcript log append is not contiguous: expected start idx {}, found {start_idx}",
+                cursor.next_idx
             ));
         }
+        let batch_len =
+            u64::try_from(messages.len()).context("transcript batch length overflowed")?;
+        let next_idx = start_idx
+            .checked_add(batch_len)
+            .context("transcript log index overflowed")?;
         for (offset, message) in messages.iter().enumerate() {
-            let event_json = encode_transcript_log_entry(start_idx + offset as u64, message)?;
+            let offset = u64::try_from(offset).context("transcript batch offset overflowed")?;
+            let idx = start_idx
+                .checked_add(offset)
+                .context("transcript log index overflowed")?;
+            let event_json = encode_transcript_log_entry(idx, message)?;
             transaction.execute(
                 "INSERT INTO thread_events (session_id, thread_name, event_json, created_at)
                  VALUES (?1, ?2, ?3, ?4)",
@@ -396,12 +808,21 @@ impl TranscriptLogWriter {
                 ],
             )?;
         }
+        let last_row_id = transaction.last_insert_rowid();
         let updated = transaction.execute(
             "UPDATE sessions
              SET visible_message_count = visible_message_count + ?1,
-                 last_user_prompt = COALESCE(?2, last_user_prompt)
-             WHERE session_id = ?3",
-            params![visible_delta, last_user_prompt, session_id],
+                 last_user_prompt = COALESCE(?2, last_user_prompt),
+                 transcript_next_idx = ?3,
+                 transcript_last_row_id = ?4
+             WHERE session_id = ?5",
+            params![
+                visible_delta,
+                last_user_prompt,
+                i64::try_from(next_idx).context("transcript next index overflowed")?,
+                last_row_id,
+                session_id
+            ],
         )?;
         if updated != 1 {
             return Err(anyhow!(
@@ -409,7 +830,11 @@ impl TranscriptLogWriter {
             ));
         }
         transaction.commit()?;
-        Ok(())
+        Ok(TranscriptCursor {
+            snapshot_len: cursor.snapshot_len,
+            next_idx,
+            last_row_id: Some(last_row_id),
+        })
     }
 
     /// Read the full log tail relative to a snapshot blob of `blob_len`
@@ -595,6 +1020,67 @@ impl TranscriptLogWriter {
         }
         Ok(entries)
     }
+    pub(crate) fn read_consistent_state(
+        &self,
+        session_id: &str,
+    ) -> Result<(Vec<Message>, Vec<(u64, Message)>, Option<TranscriptCursor>)> {
+        #[cfg(test)]
+        TEST_SNAPSHOT_READ_COUNT.with(|count| count.set(count.get() + 1));
+        let mut connection = self
+            .connection
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let transaction = connection.transaction()?;
+        let messages_json: String = transaction.query_row(
+            "SELECT messages_json FROM sessions WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get(0),
+        )?;
+        let snapshot: Vec<Message> = serde_json::from_str(&messages_json)
+            .context("failed to parse stored session messages")?;
+        let from_idx = snapshot.len() as u64;
+        let mut statement = transaction.prepare(
+            "SELECT id, event_json
+             FROM thread_events
+             WHERE session_id = ?1 AND thread_name = ?2
+             ORDER BY id ASC",
+        )?;
+        let rows = statement
+            .query_map(params![session_id, ORCHESTRATOR_STEERING_TARGET], |row| {
+                Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+            })?;
+        let mut tail = Vec::new();
+        let mut physical_last_row_id = None;
+        for row in rows {
+            let (id, event_json) = row?;
+            physical_last_row_id = Some(id);
+            let entry = decode_transcript_log_entry(&event_json).ok_or_else(|| {
+                anyhow!(
+                    "thread_events row {id} under '{ORCHESTRATOR_STEERING_TARGET}' is not a transcript log entry"
+                )
+            })?;
+            if entry.idx < from_idx {
+                continue;
+            }
+            let message = serde_json::from_str(&entry.message_json).with_context(|| {
+                format!("thread_events row {id} holds an undecodable transcript message")
+            })?;
+            tail.push((entry.idx, message));
+        }
+        drop(statement);
+        let cursor = transcript_cursor(&transaction, session_id)?.filter(|cursor| {
+            let contiguous_end = tail.iter().try_fold(from_idx, |expected, (idx, _)| {
+                (*idx == expected)
+                    .then(|| expected.checked_add(1))
+                    .flatten()
+            });
+            cursor.snapshot_len == from_idx
+                && contiguous_end == Some(cursor.next_idx)
+                && cursor.last_row_id == physical_last_row_id
+        });
+        transaction.commit()?;
+        Ok((snapshot, tail, cursor))
+    }
 
     /// Read the trusted log tail and atomically repair a validly encoded index
     /// gap. Rows covered by the snapshot remain untouched. At the first tail
@@ -668,6 +1154,7 @@ impl TranscriptLogWriter {
                 transaction.execute("DELETE FROM thread_events WHERE id = ?1", params![id])?;
             }
             refresh_session_summary(&transaction, session_id)?;
+            store_transcript_cursor(&transaction, session_id, blob_len, expected_idx)?;
             Some(TranscriptLogRecovery {
                 expected_idx,
                 found_idx,
@@ -681,9 +1168,9 @@ impl TranscriptLogWriter {
     }
 
     /// Delete committed entries with `idx >= from_idx` (tail truncation for
-    /// crash/cancel normalization). Returns the number of deleted rows.
-    /// Infrequent path: the idx values live inside the JSON payloads, so this
-    /// scans the session's transcript rows and deletes by row id.
+    /// crash/cancel normalization). Cursor-backed sessions read and decode
+    /// only the deleted suffix. Legacy/uninitialized sessions retain the
+    /// full validation fallback below.
     pub fn delete_from(&self, session_id: &str, from_idx: u64) -> Result<usize> {
         let mut connection = self
             .connection
@@ -691,6 +1178,118 @@ impl TranscriptLogWriter {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         let transaction =
             connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+        if let Some(cursor) = transcript_cursor(&transaction, session_id)? {
+            let physical_last_row_id =
+                newest_transcript_row(&transaction, session_id, None)?.map(|(id, _)| id);
+            if physical_last_row_id != cursor.last_row_id {
+                return Err(anyhow!(
+                    "transcript cursor last row {:?} does not match physical last row {:?}",
+                    cursor.last_row_id,
+                    physical_last_row_id
+                ));
+            }
+            if from_idx >= cursor.snapshot_len {
+                if from_idx >= cursor.next_idx {
+                    transaction.commit()?;
+                    return Ok(0);
+                }
+                let delete_count = cursor.next_idx - from_idx;
+                let last_row_id = cursor.last_row_id.ok_or_else(|| {
+                    anyhow!("transcript cursor has a tail extent without a last row id")
+                })?;
+                let selected = {
+                    let mut statement = transaction.prepare(
+                        "SELECT id, event_json
+                         FROM thread_events
+                         WHERE session_id = ?1 AND thread_name = ?2 AND id <= ?3
+                         ORDER BY id DESC
+                         LIMIT ?4",
+                    )?;
+                    let rows = statement.query_map(
+                        params![
+                            session_id,
+                            ORCHESTRATOR_STEERING_TARGET,
+                            last_row_id,
+                            i64::try_from(delete_count)
+                                .context("transcript delete count overflowed")?
+                        ],
+                        |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
+                    )?;
+                    rows.collect::<rusqlite::Result<Vec<_>>>()?
+                };
+                if selected.len() as u64 != delete_count {
+                    return Err(anyhow!(
+                        "transcript suffix expected {delete_count} rows, found {}",
+                        selected.len()
+                    ));
+                }
+                let mut deleted_messages = Vec::with_capacity(selected.len());
+                for (offset, (id, event_json)) in selected.iter().enumerate() {
+                    let entry = decode_transcript_log_entry(event_json).ok_or_else(|| {
+                        anyhow!(
+                            "thread_events row {id} under '{ORCHESTRATOR_STEERING_TARGET}' is not a transcript log entry"
+                        )
+                    })?;
+                    let expected_idx = cursor.next_idx - 1 - offset as u64;
+                    if entry.idx != expected_idx {
+                        return Err(anyhow!(
+                            "transcript suffix is not contiguous: expected idx {expected_idx}, found {}",
+                            entry.idx
+                        ));
+                    }
+                    deleted_messages.push(
+                        serde_json::from_str::<Message>(&entry.message_json).with_context(
+                            || {
+                                format!(
+                                "thread_events row {id} holds an undecodable transcript message"
+                            )
+                            },
+                        )?,
+                    );
+                }
+                let boundary_row_id = selected.last().expect("non-empty suffix").0;
+                let deleted = transaction.execute(
+                    "DELETE FROM thread_events
+                     WHERE session_id = ?1 AND thread_name = ?2
+                       AND id >= ?3 AND id <= ?4",
+                    params![
+                        session_id,
+                        ORCHESTRATOR_STEERING_TARGET,
+                        boundary_row_id,
+                        last_row_id
+                    ],
+                )?;
+                if deleted != selected.len() {
+                    return Err(anyhow!(
+                        "transcript suffix delete expected {} rows, deleted {deleted}",
+                        selected.len()
+                    ));
+                }
+                if deleted_messages
+                    .iter()
+                    .any(|message| matches!(message, Message::User { .. }))
+                {
+                    // Arbitrary user-facing reverts need the previous prompt,
+                    // so retain the strict full-summary fallback on that rare
+                    // destructive path.
+                    refresh_session_summary(&transaction, session_id)?;
+                } else {
+                    let deleted_visible =
+                        i64::try_from(crate::sessions::visible_message_count(&deleted_messages))
+                            .context("deleted transcript visible count overflowed")?;
+                    transaction.execute(
+                        "UPDATE sessions
+                         SET visible_message_count =
+                             MAX(0, visible_message_count - ?1)
+                         WHERE session_id = ?2",
+                        params![deleted_visible, session_id],
+                    )?;
+                }
+                store_transcript_cursor(&transaction, session_id, cursor.snapshot_len, from_idx)?;
+                transaction.commit()?;
+                return Ok(selected.len());
+            }
+        }
         let row_ids = {
             let mut statement = transaction.prepare(
                 "SELECT id, event_json
@@ -721,6 +1320,15 @@ impl TranscriptLogWriter {
         }
         if !row_ids.is_empty() {
             refresh_session_summary(&transaction, session_id)?;
+            let snapshot_len = transcript_cursor(&transaction, session_id)?
+                .map(|cursor| cursor.snapshot_len)
+                .unwrap_or(from_idx);
+            store_transcript_cursor(
+                &transaction,
+                session_id,
+                snapshot_len,
+                from_idx.max(snapshot_len),
+            )?;
         }
         transaction.commit()?;
         Ok(row_ids.len())
@@ -783,6 +1391,7 @@ impl TranscriptLogWriter {
             transaction.execute("DELETE FROM thread_events WHERE id = ?1", params![id])?;
         }
         refresh_session_summary(&transaction, session_id)?;
+        store_transcript_cursor(&transaction, session_id, from_idx, from_idx)?;
         transaction.commit()?;
         Ok(row_ids.len())
     }
@@ -1081,6 +1690,46 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
     }
+    #[test]
+    fn transcript_cursor_detects_same_length_delete_and_reappend() {
+        let path = temp_store_path("cursor_same_length_replacement");
+        initialize(&path).unwrap();
+        crate::store::insert_test_session(&path, "session-a");
+        set_snapshot_messages(
+            &path,
+            "session-a",
+            &[Message::System {
+                content: "head".to_string(),
+            }],
+        );
+        let writer = TranscriptLogWriter::new(&path).unwrap();
+        let adopted = writer
+            .append(
+                "session-a",
+                1,
+                &Message::User {
+                    content: "old".to_string(),
+                },
+            )
+            .unwrap();
+        assert_eq!(writer.delete_from("session-a", 1).unwrap(), 1);
+        let replacement = Message::User {
+            content: "replacement".to_string(),
+        };
+        writer.append("session-a", 1, &replacement).unwrap();
+
+        let reconciliation = writer
+            .reconcile_cursor("session-a", adopted)
+            .unwrap()
+            .expect("same-length physical replacement must change the cursor");
+        assert_eq!(reconciliation.common_prefix_len, 1);
+        assert_eq!(reconciliation.rows.len(), 1);
+        assert_eq!(canonical(&reconciliation.rows[0]), canonical(&replacement));
+        assert_eq!(reconciliation.cursor.next_idx, 2);
+        assert_ne!(reconciliation.cursor.last_row_id, adopted.last_row_id);
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
 
     #[test]
     fn transcript_log_gap_repair_keeps_the_trusted_prefix_and_refreshes_summary() {
@@ -1233,7 +1882,7 @@ mod tests {
     }
 
     #[test]
-    fn transcript_log_summary_refresh_ignores_blob_covered_rows() {
+    fn existing_session_save_cannot_replace_transcript_state() {
         let path = temp_store_path("summary_covered_rows");
         initialize(&path).unwrap();
         let snapshot = crate::sessions::new_snapshot(
@@ -1273,6 +1922,7 @@ mod tests {
             )
             .unwrap();
 
+        let cursor_before_save = writer.current_cursor("session-a").unwrap();
         let mut snapshot = crate::sessions::load_session(&path, "session-a").unwrap();
         snapshot.messages = vec![
             Message::User {
@@ -1289,6 +1939,18 @@ mod tests {
             },
         ];
         crate::sessions::save_session(&path, &snapshot).unwrap();
+        assert!(
+            crate::sessions::load_session(&path, "session-a")
+                .unwrap()
+                .messages
+                .is_empty(),
+            "existing-session save must not replace the immutable snapshot blob"
+        );
+        assert_eq!(
+            writer.current_cursor("session-a").unwrap(),
+            cursor_before_save,
+            "existing-session save must not reset transcript cursor identity"
+        );
 
         writer
             .append_batch(
@@ -1321,7 +1983,7 @@ mod tests {
         assert_eq!(summary.visible_message_count, 2);
         assert_eq!(
             summary.last_user_prompt.as_deref(),
-            Some("blob replacement prompt")
+            Some("stale covered prompt")
         );
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());
@@ -1579,6 +2241,158 @@ mod tests {
         assert_eq!(
             last_transcript_log_user_prompt(&conn, "session-b", 0).unwrap(),
             None
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+    #[test]
+    fn transcript_transactions_roll_back_rows_summaries_and_cursor_together() {
+        let path = temp_store_path("atomic_cursor_rollback");
+        initialize(&path).unwrap();
+        crate::store::insert_test_session(&path, "session");
+        set_snapshot_messages(
+            &path,
+            "session",
+            &[Message::System {
+                content: "system".to_string(),
+            }],
+        );
+        let writer = TranscriptLogWriter::new(&path).unwrap();
+        writer.bootstrap_cursor("session", 1, 1).unwrap();
+        let read_state = || {
+            open_connection(&path)
+                .unwrap()
+                .query_row(
+                    "SELECT messages_json, visible_message_count, last_user_prompt,
+                            transcript_snapshot_len, transcript_next_idx,
+                            transcript_last_row_id
+                     FROM sessions WHERE session_id = 'session'",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, i64>(1)?,
+                            row.get::<_, Option<String>>(2)?,
+                            row.get::<_, Option<i64>>(3)?,
+                            row.get::<_, Option<i64>>(4)?,
+                            row.get::<_, Option<i64>>(5)?,
+                        ))
+                    },
+                )
+                .unwrap()
+        };
+        let before_append = read_state();
+        let connection = open_connection(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_cursor_update
+                 BEFORE UPDATE OF transcript_next_idx ON sessions
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected cursor update failure');
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+
+        assert!(writer
+            .append(
+                "session",
+                1,
+                &Message::User {
+                    content: "rolled back".to_string(),
+                },
+            )
+            .is_err());
+        assert!(writer.read_from("session", 0).unwrap().is_empty());
+        assert_eq!(read_state(), before_append);
+
+        let connection = open_connection(&path).unwrap();
+        connection
+            .execute_batch("DROP TRIGGER fail_cursor_update")
+            .unwrap();
+        drop(connection);
+        writer
+            .append_batch(
+                "session",
+                1,
+                &[
+                    Message::User {
+                        content: "kept prompt".to_string(),
+                    },
+                    Message::Assistant {
+                        content: Some("kept answer".to_string()),
+                        reasoning_text: None,
+                        reasoning_details: None,
+                        tool_calls: None,
+                        duration_ms: None,
+                        model_origin: None,
+                        reasoning_field: None,
+                    },
+                ],
+            )
+            .unwrap();
+        let before_delete = read_state();
+        let connection = open_connection(&path).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER fail_cursor_update
+                 BEFORE UPDATE OF transcript_next_idx ON sessions
+                 BEGIN
+                     SELECT RAISE(ABORT, 'injected cursor update failure');
+                 END;",
+            )
+            .unwrap();
+        drop(connection);
+
+        assert!(writer.delete_from("session", 1).is_err());
+        assert_eq!(writer.read_from("session", 0).unwrap().len(), 2);
+        assert_eq!(read_state(), before_delete);
+        assert!(writer
+            .replace_snapshot_and_delete_from(
+                "session",
+                &[Message::System {
+                    content: "replacement system".to_string(),
+                }],
+            )
+            .is_err());
+        assert_eq!(writer.read_from("session", 0).unwrap().len(), 2);
+        assert_eq!(
+            read_state(),
+            before_delete,
+            "snapshot blob, rows, summaries, and cursor must roll back together"
+        );
+
+        let _ = std::fs::remove_dir_all(path.parent().unwrap());
+    }
+    #[test]
+    fn cursor_delta_query_uses_the_session_thread_id_index() {
+        let path = temp_store_path("cursor_query_plan");
+        initialize(&path).unwrap();
+        crate::store::insert_test_session(&path, "session");
+        let connection = open_connection(&path).unwrap();
+        let mut statement = connection
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT id, event_json
+                 FROM thread_events
+                 WHERE session_id = ?1 AND thread_name = ?2
+                   AND id > ?3 AND id <= ?4
+                 ORDER BY id ASC",
+            )
+            .unwrap();
+        let details = statement
+            .query_map(
+                params!["session", ORCHESTRATOR_STEERING_TARGET, 0_i64, i64::MAX],
+                |row| row.get::<_, String>(3),
+            )
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert!(
+            details
+                .iter()
+                .any(|detail| detail.contains("idx_thread_events_session_thread_id")),
+            "cursor delta query must use the bounded session/thread/id index: {details:?}"
         );
 
         let _ = std::fs::remove_dir_all(path.parent().unwrap());


### PR DESCRIPTION
## Description

**What.** Replaces PR #166's full-history shared-store refresh with a durable transcript cursor and suffix-only reconciliation.

**Why.** The original recovery fix prevents transcript loss, but its admission and cleanup paths still rescan and reserialize complete session history; cursor identity is also required to reject same-length delete/reappend (ABA) replacements safely.

- Persists nullable snapshot length, logical next index, and physical last-row identity on each session.
- Updates transcript rows, materialized summaries, and cursor metadata in one SQLite transaction.
- Reads only rows newer than the adopted cursor; a valid encoded gap is repaired transactionally.
- Keeps `save_session` from overwriting transcript-owned state with a stale in-memory snapshot.
- Stores transcript cursor identity with compaction checkpoints and validates peer checkpoints without rehashing trusted history.
- Reconciles System-policy identity from only the removed and added suffix.
- Latches recovery warnings before later admission failures so frontends surface repaired-history warnings on retry.

## Usage

No user-facing usage change. Recovery after a peer crash remains automatic.

## Bug Evidence

Before this follow-up, each prompt/manual-compaction admission called the complete snapshot-plus-log restore and compared two full transcripts through JSON serialization. A same-length delete/reappend could also retain the old logical length while referring to different physical rows.

The new regressions cover:

- real helper-process death while a shared-store run is active, followed by survivor takeover and restart;
- same-length stale cursor rejection after physical row replacement;
- append admission selecting and decoding only the committed delta;
- transactional rollback of rows, session summaries, and cursor metadata under an injected SQLite failure;
- warning durability when a post-repair admission step fails;
- checkpoint retry after an injected cursor-survival probe failure.

## Changelog

- Bounds steady-state shared-store admission work to one cursor probe plus newly committed rows.
- Preserves transcript, session-summary, scan-cache, warning, and compaction-checkpoint invariants across append, replacement, rollback, crash takeover, and restart.
- Migrates stores to schema version 14 with nullable transcript cursor columns for legacy-safe bootstrap.

## Validation

- `cargo check -p nac-core --all-targets` — passed.
- `cargo test -p nac-core --lib -- --test-threads=1` — 824 passed, 9 ignored.
- `cargo test -p nac-core transcript -- --nocapture` — 52 passed.
- `cargo test -p nac-core session_service::tests -- --nocapture` — 44 passed, 1 ignored.
- `cargo test -p nac-core checkpoint -- --nocapture` — 21 passed.
- `cargo test -p nac-core sessions::tests -- --test-threads=1` — 25 passed.
- Focused crash, rollback, query-plan, same-length cursor, warning, bounded-decoding, and incremental-policy regressions passed.

`cargo clippy -p nac-core --all-targets -- -D warnings` remains blocked by 75 existing package-wide diagnostics outside this change (for example `too_many_arguments`, `await_holding_lock`, and `non_octal_unix_permissions`). `cargo fmt --all -- --check` also reports existing rustfmt-version differences in unchanged files; changed files were formatted directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core shared-store transcript recovery, SQLite transactional boundaries, and compaction checkpoint adoption—areas where bugs could lose or corrupt session history across peer crashes and restarts.
> 
> **Overview**
> Introduces a **durable transcript cursor** (snapshot length, logical `next_idx`, physical last row id) on sessions and compaction checkpoints (schema v14), so shared-store admission compares fixed-size identity instead of rescanning or JSON-serializing full history.
> 
> **Transcript store and agent paths** now update log rows, session summaries, and cursor metadata in one SQLite transaction; `reconcile_cursor` applies only physical rows after the adopted cursor, including detection of **same-length delete/reappend (ABA)** replacements. `save_session` no longer overwrites `messages_json` or cursor fields on existing sessions—growing history stays in the append-only log.
> 
> **Operation admission** probes the cursor first (no work when unchanged), suffix-reconciles in-memory transcript and `TranscriptScanCache` on peer deltas, latches recovery warnings before later failures, and reloads compaction via `restore_checkpoint_if_changed` using checkpoint-stored cursors without rehashing the full transcript. Compaction gains incremental **system-policy identity** (v3 XOR suffix) and bounded peer-checkpoint validation via `transcript_cursor_survives`.
> 
> Legacy full restore remains as bootstrap/corruption repair when the cursor is missing or reconciliation fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec78025f86d4a7073bf2d440fccc9ddce48e634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->