### PR TITLE
fix(release): publish nightly RCs from latest stable

### DIFF
--- a/.github/scripts/rc-release.mjs
+++ b/.github/scripts/rc-release.mjs
@@ -46,12 +46,13 @@ function compareParts(left, right) {
   return 0;
 }
 
-function requireBase(base) {
-  const parsed = parseStableTag(`v${base}`);
-  if (!parsed || parsed.baseText !== base) {
-    throw new Error(`nac-server version must be canonical SemVer, got ${base}`);
-  }
-  return parsed.base;
+function greatestStableRelease(releases) {
+  const stableVersions = releases
+    .filter((release) => !release.draft && !release.prerelease)
+    .map((release) => parseStableTag(release.tag_name))
+    .filter(Boolean);
+  stableVersions.sort((left, right) => compareParts(right.base, left.base));
+  return stableVersions[0] || null;
 }
 
 function requireSha(sha, context) {
@@ -64,7 +65,6 @@ function releaseForTag(releases, tag) {
 }
 
 export async function prepareCandidate(input, api) {
-  const baseParts = requireBase(input.base);
   const sha = requireSha(input.sha, "scheduled source");
   const runNumber = Number(input.runNumber);
   const runAttempt = Number(input.runAttempt);
@@ -76,26 +76,35 @@ export async function prepareCandidate(input, api) {
   }
 
   const releases = await api.listReleases();
-  const stableTag = `v${input.base}`;
-  if (await api.resolveTagOrNull(stableTag)) {
-    return { run: false, reason: `${stableTag} already exists` };
+  const latestStable = greatestStableRelease(releases);
+  if (!latestStable) throw new Error("nightly RCs require a published stable release");
+
+  const latestStableSha = await api.resolveTag(latestStable.tag);
+  if (latestStableSha === sha) {
+    return { run: false, reason: `${latestStable.tag} already publishes ${sha}` };
+  }
+  const comparison = await api.compareCommits(latestStableSha, sha);
+  if (comparison !== "ahead") {
+    throw new Error(
+      `scheduled source is ${comparison} relative to latest stable ${latestStable.tag}`,
+    );
   }
 
-  const stableVersions = releases
-    .filter((release) => !release.draft && !release.prerelease)
-    .map((release) => parseStableTag(release.tag_name))
-    .filter(Boolean);
-  stableVersions.sort((left, right) => compareParts(right.base, left.base));
-  if (stableVersions[0] && compareParts(baseParts, stableVersions[0].base) <= 0) {
-    throw new Error(
-      `release base ${input.base} must be greater than latest stable ${stableVersions[0].baseText}`,
-    );
+  const baseParts = [...latestStable.base];
+  baseParts[2] += 1;
+  if (!Number.isSafeInteger(baseParts[2])) {
+    throw new Error(`cannot increment patch version for ${latestStable.tag}`);
+  }
+  const base = baseParts.join(".");
+  const stableTag = `v${base}`;
+  if (await api.resolveTagOrNull(stableTag)) {
+    return { run: false, reason: `${stableTag} already exists` };
   }
 
   const currentTrain = releases
     .filter((release) => !release.draft && release.prerelease)
     .map((release) => ({ release, parsed: parseRcTag(release.tag_name) }))
-    .filter(({ parsed }) => parsed?.baseText === input.base)
+    .filter(({ parsed }) => parsed?.baseText === base)
     .sort((left, right) => right.parsed.number - left.parsed.number);
   if (currentTrain[0]) {
     const previousSha = await api.resolveTag(currentTrain[0].release.tag_name);
@@ -108,7 +117,7 @@ export async function prepareCandidate(input, api) {
   }
 
   const tag = `${stableTag}-rc.${runNumber}`;
-  const version = `${input.base}-rc.${runNumber}`;
+  const version = `${base}-rc.${runNumber}`;
   const existingRelease = releaseForTag(releases, tag);
   const tagSha = await api.resolveTagOrNull(tag);
 
@@ -126,7 +135,16 @@ export async function prepareCandidate(input, api) {
     if (!existingRelease.prerelease || !matchingSource) {
       throw new Error(`${tag} draft does not match the scheduled candidate`);
     }
-    return { run: true, resume: true, sha, base: input.base, version, tag };
+    return {
+      run: true,
+      resume: true,
+      sha,
+      base,
+      version,
+      tag,
+      latestStableTag: latestStable.tag,
+      latestStableSha,
+    };
   }
 
   if (tagSha) {
@@ -134,11 +152,29 @@ export async function prepareCandidate(input, api) {
     // the draft-versus-standalone decision to the write-scoped publish job,
     // which revalidates both the release and the tag before modifying either.
     if (runAttempt > 1 && tagSha === sha) {
-      return { run: true, resume: true, sha, base: input.base, version, tag };
+      return {
+        run: true,
+        resume: true,
+        sha,
+        base,
+        version,
+        tag,
+        latestStableTag: latestStable.tag,
+        latestStableSha,
+      };
     }
     throw new Error(`${tag} is occupied by a standalone tag`);
   }
-  return { run: true, resume: false, sha, base: input.base, version, tag };
+  return {
+    run: true,
+    resume: false,
+    sha,
+    base,
+    version,
+    tag,
+    latestStableTag: latestStable.tag,
+    latestStableSha,
+  };
 }
 
 export async function validateStableDispatch(tag, api) {
@@ -216,6 +252,17 @@ export class GitHubApi {
       next = linkNext(response.headers.get("link"));
     }
     return releases;
+  }
+
+  async compareCommits(base, head) {
+    const { data } = await this.request(
+      "GET",
+      `/repos/${this.repo}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
+    );
+    if (!["ahead", "behind", "diverged", "identical"].includes(data?.status)) {
+      throw new Error("GitHub compare response had an invalid status");
+    }
+    return data.status;
   }
 
   async resolveTagOrNull(tag) {
@@ -313,6 +360,19 @@ function sameBytes(left, right) {
   return left.equals(right);
 }
 
+async function requireLatestStableSnapshot(input, api, releases) {
+  const expected = parseStableTag(input.latestStableTag);
+  if (!expected) throw new Error("nightly candidate is missing its latest stable tag");
+  const expectedSha = requireSha(input.latestStableSha, expected.tag);
+  const latest = greatestStableRelease(releases);
+  if (!latest || latest.tag !== expected.tag) {
+    throw new Error(`latest stable changed after candidate preparation; expected ${expected.tag}`);
+  }
+  if ((await api.resolveTag(expected.tag)) !== expectedSha) {
+    throw new Error(`${expected.tag} moved after candidate preparation`);
+  }
+}
+
 export async function publishCandidate(input, api) {
   const sha = requireSha(input.sha, "candidate");
   const parsed = parseRcTag(input.tag);
@@ -328,16 +388,16 @@ export async function publishCandidate(input, api) {
   const files = new Map();
   for (const name of EXPECTED_ASSETS) files.set(name, await readFile(`${input.assetDir}/${name}`));
 
-  if (await api.resolveTagOrNull(`v${base}`)) {
-    throw new Error(`stable v${base} appeared before RC publication`);
-  }
-
   let releases = await api.listReleases();
   let release = releaseForTag(releases, input.tag);
   let tagSha = await api.resolveTagOrNull(input.tag);
   if (release && !release.draft) {
     if (!release.prerelease || tagSha !== sha) throw new Error(`${input.tag} is published with conflicting identity`);
     return { alreadyPublished: true, release };
+  }
+  await requireLatestStableSnapshot(input, api, releases);
+  if (await api.resolveTagOrNull(`v${base}`)) {
+    throw new Error(`stable v${base} appeared before RC publication`);
   }
 
   if (release) {
@@ -383,6 +443,8 @@ export async function publishCandidate(input, api) {
       throw new Error(`uploaded asset ${asset.name} failed byte-for-byte verification`);
     }
   }
+  releases = await api.listReleases();
+  await requireLatestStableSnapshot(input, api, releases);
   if (await api.resolveTagOrNull(`v${base}`)) {
     throw new Error(`stable v${base} appeared during RC publication`);
   }
@@ -416,12 +478,8 @@ async function main() {
   const command = process.argv[2];
   const api = repositoryApi();
   if (command === "prepare") {
-    const manifest = await readFile("crates/nac-server/Cargo.toml", "utf8");
-    const match = /^\[package\][\s\S]*?^version\s*=\s*"([^"]+)"/m.exec(manifest);
-    if (!match) throw new Error("could not read nac-server package version");
     const result = await prepareCandidate(
       {
-        base: match[1],
         sha: process.env.GITHUB_SHA,
         runNumber: process.env.GITHUB_RUN_NUMBER,
         runAttempt: process.env.GITHUB_RUN_ATTEMPT,
@@ -431,11 +489,13 @@ async function main() {
     await writeOutputs({
       run: result.run,
       sha: result.sha || process.env.GITHUB_SHA,
-      base: result.base || match[1],
+      base: result.base || "",
       version: result.version || "",
       tag: result.tag || "",
       resume: result.resume || false,
       reason: result.reason || "",
+      latest_stable_tag: result.latestStableTag || "",
+      latest_stable_sha: result.latestStableSha || "",
     });
     console.log(result.reason || `${result.resume ? "resuming" : "preparing"} ${result.tag}`);
   } else if (command === "validate-stable") {
@@ -449,6 +509,8 @@ async function main() {
         runNumber: process.env.GITHUB_RUN_NUMBER,
         runAttempt: process.env.GITHUB_RUN_ATTEMPT,
         assetDir: process.env.ASSET_DIR || "dist",
+        latestStableTag: process.env.LATEST_STABLE_TAG,
+        latestStableSha: process.env.LATEST_STABLE_SHA,
       },
       api,
     );

--- a/.github/scripts/rc-release.test.mjs
+++ b/.github/scripts/rc-release.test.mjs
@@ -18,9 +18,10 @@ const SHA_A = "a".repeat(40);
 const SHA_B = "b".repeat(40);
 
 class FakeApi {
-  constructor({ releases = [], refs = {} } = {}) {
+  constructor({ releases = [], refs = {}, comparisons = {} } = {}) {
     this.releases = structuredClone(releases);
     this.refs = new Map(Object.entries(refs));
+    this.comparisons = new Map(Object.entries(comparisons));
     this.assets = new Map();
     this.created = 0;
     this.published = 0;
@@ -28,6 +29,10 @@ class FakeApi {
 
   async listReleases() {
     return structuredClone(this.releases);
+  }
+
+  async compareCommits(base, head) {
+    return this.comparisons.get(`${base}...${head}`) || (base === head ? "identical" : "ahead");
   }
 
   async resolveTagOrNull(tag) {
@@ -93,7 +98,6 @@ function rc(tag, { draft = false } = {}) {
 
 function input(overrides = {}) {
   return {
-    base: "0.1.2",
     sha: SHA_B,
     runNumber: 42,
     runAttempt: 1,
@@ -112,26 +116,31 @@ test("canonical tag parsers reject malformed prereleases and rc.0", () => {
   assert.equal(parseRcTag("v0.1.2-rc.10")?.number, 10);
 });
 
-test("prepare creates the first candidate and permits run-number gaps", async () => {
-  const api = new FakeApi({ releases: [stable("v0.1.1")], refs: { "v0.1.1": SHA_A } });
+test("prepare creates the next patch candidate from the greatest stable release", async () => {
+  const api = new FakeApi({
+    releases: [stable("v0.1.1"), stable("v0.1.2")],
+    refs: { "v0.1.1": SHA_A, "v0.1.2": SHA_A },
+  });
   const result = await prepareCandidate(input({ runNumber: 900 }), api);
   assert.deepEqual(result, {
     run: true,
     resume: false,
     sha: SHA_B,
-    base: "0.1.2",
-    version: "0.1.2-rc.900",
-    tag: "v0.1.2-rc.900",
+    base: "0.1.3",
+    version: "0.1.3-rc.900",
+    tag: "v0.1.3-rc.900",
+    latestStableTag: "v0.1.2",
+    latestStableSha: SHA_A,
   });
 });
 
 test("prepare orders RC numbers numerically and skips an unchanged SHA", async () => {
   const api = new FakeApi({
-    releases: [stable("v0.1.1"), rc("v0.1.2-rc.10"), rc("v0.1.2-rc.2")],
+    releases: [stable("v0.1.2"), rc("v0.1.3-rc.10"), rc("v0.1.3-rc.2")],
     refs: {
-      "v0.1.1": SHA_A,
-      "v0.1.2-rc.2": SHA_A,
-      "v0.1.2-rc.10": SHA_B,
+      "v0.1.2": SHA_A,
+      "v0.1.3-rc.2": SHA_A,
+      "v0.1.3-rc.10": SHA_B,
     },
   });
   const result = await prepareCandidate(input({ runNumber: 11 }), api);
@@ -142,35 +151,55 @@ test("prepare orders RC numbers numerically and skips an unchanged SHA", async (
 test("prepare accepts changed source while ignoring malformed release tags", async () => {
   const api = new FakeApi({
     releases: [
-      stable("v0.1.1"),
-      rc("v0.1.2-rc.2"),
-      rc("v0.1.2-beta.9"),
-      rc("v0.1.2-rc.0"),
-      rc("v0.1.2-rc.01"),
+      stable("v0.1.2"),
+      rc("v0.1.3-rc.2"),
+      rc("v0.1.3-beta.9"),
+      rc("v0.1.3-rc.0"),
+      rc("v0.1.3-rc.01"),
     ],
-    refs: { "v0.1.1": SHA_A, "v0.1.2-rc.2": SHA_A },
+    refs: { "v0.1.2": SHA_A, "v0.1.3-rc.2": SHA_A },
   });
   const result = await prepareCandidate(input({ runNumber: 10 }), api);
   assert.equal(result.run, true);
-  assert.equal(result.tag, "v0.1.2-rc.10");
+  assert.equal(result.tag, "v0.1.3-rc.10");
 });
 
-test("prepare skips when the stable target tag exists", async () => {
-  const api = new FakeApi({ releases: [stable("v0.1.1")], refs: { "v0.1.2": SHA_A } });
+test("prepare skips when the next stable target tag already exists", async () => {
+  const api = new FakeApi({
+    releases: [stable("v0.1.2")],
+    refs: { "v0.1.2": SHA_A, "v0.1.3": SHA_A },
+  });
   const result = await prepareCandidate(input(), api);
   assert.equal(result.run, false);
   assert.match(result.reason, /already exists/);
 });
 
-test("prepare rejects a base that is not ahead of the greatest stable release", async () => {
-  const api = new FakeApi({ releases: [stable("v0.1.2"), stable("v0.1.1")] });
-  await assert.rejects(prepareCandidate(input(), api), /greater than latest stable 0\.1\.2/);
+test("prepare skips when the latest stable already publishes the scheduled source", async () => {
+  const api = new FakeApi({
+    releases: [stable("v0.1.2"), stable("v0.1.1")],
+    refs: { "v0.1.2": SHA_B, "v0.1.1": SHA_A },
+  });
+  const result = await prepareCandidate(input(), api);
+  assert.equal(result.run, false);
+  assert.match(result.reason, /v0\.1\.2 already publishes/);
+});
+
+test("prepare rejects a scheduled source that does not descend from the latest stable", async () => {
+  const api = new FakeApi({
+    releases: [stable("v0.1.2")],
+    refs: { "v0.1.2": SHA_A },
+    comparisons: { [`${SHA_A}...${SHA_B}`]: "diverged" },
+  });
+  await assert.rejects(prepareCandidate(input(), api), /diverged relative to latest stable/);
 });
 
 test("prepare resumes only a matching same-run draft on a rerun", async () => {
-  const draft = rc("v0.1.2-rc.42", { draft: true });
+  const draft = rc("v0.1.3-rc.42", { draft: true });
   draft.target_commitish = SHA_B;
-  const api = new FakeApi({ releases: [stable("v0.1.1"), draft] });
+  const api = new FakeApi({
+    releases: [stable("v0.1.2"), draft],
+    refs: { "v0.1.2": SHA_A },
+  });
   await assert.rejects(prepareCandidate(input(), api), /only be resumed by a rerun/);
   const result = await prepareCandidate(input({ runAttempt: 2 }), api);
   assert.equal(result.run, true);
@@ -179,8 +208,8 @@ test("prepare resumes only a matching same-run draft on a rerun", async () => {
 
 test("prepare defers a matching hidden draft to the write-scoped rerun", async () => {
   const api = new FakeApi({
-    releases: [stable("v0.1.1")],
-    refs: { "v0.1.2-rc.42": SHA_B },
+    releases: [stable("v0.1.2")],
+    refs: { "v0.1.2": SHA_A, "v0.1.3-rc.42": SHA_B },
   });
   await assert.rejects(prepareCandidate(input(), api), /standalone tag/);
   const result = await prepareCandidate(input({ runAttempt: 2 }), api);
@@ -189,7 +218,10 @@ test("prepare defers a matching hidden draft to the write-scoped rerun", async (
 });
 
 test("prepare rejects a conflicting occupied target tag", async () => {
-  const api = new FakeApi({ releases: [stable("v0.1.1")], refs: { "v0.1.2-rc.42": SHA_A } });
+  const api = new FakeApi({
+    releases: [stable("v0.1.2")],
+    refs: { "v0.1.2": SHA_A, "v0.1.3-rc.42": SHA_A },
+  });
   await assert.rejects(prepareCandidate(input(), api), /standalone tag/);
 });
 
@@ -221,6 +253,9 @@ test("GitHub API follows paginated releases and peels annotated tags", async () 
     if (path === "https://api.github.test/page-2") {
       return { data: [rc("v0.1.2-rc.1")], response: { headers: { get: () => null } } };
     }
+    if (String(path).includes("/compare/")) {
+      return { data: { status: "ahead" }, response: {} };
+    }
     if (String(path).includes("/git/ref/tags/")) {
       return { data: { object: { type: "tag", sha: SHA_A } }, response: {} };
     }
@@ -231,7 +266,8 @@ test("GitHub API follows paginated releases and peels annotated tags", async () 
   };
   assert.equal((await api.listReleases()).length, 2);
   assert.equal(await api.resolveTag("v0.1.2-rc.1"), SHA_B);
-  assert.equal(calls.length, 4);
+  assert.equal(await api.compareCommits(SHA_A, SHA_B), "ahead");
+  assert.equal(calls.length, 5);
 });
 
 async function assetDirectory() {
@@ -243,25 +279,34 @@ async function assetDirectory() {
 function publishInput(assetDir, overrides = {}) {
   return {
     sha: SHA_B,
-    tag: "v0.1.2-rc.42",
+    tag: "v0.1.3-rc.42",
     runNumber: 42,
     runAttempt: 1,
     assetDir,
+    latestStableTag: "v0.1.2",
+    latestStableSha: SHA_A,
     ...overrides,
   };
 }
 
+function publishingApi({ releases = [], refs = {} } = {}) {
+  return new FakeApi({
+    releases: [stable("v0.1.2"), ...releases],
+    refs: { "v0.1.2": SHA_A, ...refs },
+  });
+}
+
 test("publication creates a draft, verifies both assets, then publishes", async () => {
-  const api = new FakeApi();
+  const api = publishingApi();
   const result = await publishCandidate(publishInput(await assetDirectory()), api);
   assert.equal(result.alreadyPublished, false);
   assert.equal(api.created, 1);
   assert.equal(api.published, 1);
   assert.deepEqual(
-    api.releases[0].assets.map((asset) => asset.name).sort(),
+    result.release.assets.map((asset) => asset.name).sort(),
     [...EXPECTED_ASSETS].sort(),
   );
-  assert.equal(api.refs.get("v0.1.2-rc.42"), SHA_B);
+  assert.equal(api.refs.get("v0.1.3-rc.42"), SHA_B);
 });
 
 test("pre-draft artifact failure creates no tag or release", async () => {
@@ -276,19 +321,22 @@ test("a partial matching draft resumes without clobbering its asset", async () =
   const directory = await assetDirectory();
   const firstName = EXPECTED_ASSETS[0];
   const bytes = await readFile(join(directory, firstName));
-  const release = rc("v0.1.2-rc.42", { draft: true });
+  const release = rc("v0.1.3-rc.42", { draft: true });
   release.id = 7;
   release.assets = [{ id: 8, name: firstName }];
-  const api = new FakeApi({ releases: [release], refs: { [release.tag_name]: SHA_B } });
+  const api = publishingApi({
+    releases: [release],
+    refs: { [release.tag_name]: SHA_B },
+  });
   api.assets.set(8, bytes);
   await publishCandidate(publishInput(directory, { runAttempt: 2 }), api);
   assert.equal(api.created, 0);
   assert.equal(api.published, 1);
-  assert.equal(api.releases[0].assets.length, 2);
+  assert.equal(api.releases.find((candidate) => candidate.id === release.id).assets.length, 2);
 });
 
 test("publication rejects a matching standalone tag without a draft", async () => {
-  const api = new FakeApi({ refs: { "v0.1.2-rc.42": SHA_B } });
+  const api = publishingApi({ refs: { "v0.1.3-rc.42": SHA_B } });
   await assert.rejects(
     publishCandidate(publishInput(await assetDirectory(), { runAttempt: 2 }), api),
     /standalone tag blocks publication/,
@@ -298,12 +346,32 @@ test("publication rejects a matching standalone tag without a draft", async () =
 });
 
 test("a published rerun exits without modifying assets", async () => {
-  const release = rc("v0.1.2-rc.42");
+  const release = rc("v0.1.3-rc.42");
   release.id = 9;
   release.assets = EXPECTED_ASSETS.map((name, index) => ({ id: index + 1, name }));
-  const api = new FakeApi({ releases: [release], refs: { [release.tag_name]: SHA_B } });
+  const api = publishingApi({
+    releases: [release],
+    refs: { [release.tag_name]: SHA_B },
+  });
   const result = await publishCandidate(publishInput(await assetDirectory(), { runAttempt: 2 }), api);
   assert.equal(result.alreadyPublished, true);
   assert.equal(api.created, 0);
+  assert.equal(api.published, 0);
+});
+
+test("publication stops if a newer stable release appears during the run", async () => {
+  const api = publishingApi({ refs: { "v0.2.0": SHA_B } });
+  const initialReleases = structuredClone(api.releases);
+  let listCalls = 0;
+  api.listReleases = async () => {
+    listCalls += 1;
+    return listCalls === 1
+      ? structuredClone(initialReleases)
+      : [...structuredClone(initialReleases), stable("v0.2.0")];
+  };
+  await assert.rejects(
+    publishCandidate(publishInput(await assetDirectory()), api),
+    /latest stable changed after candidate preparation/,
+  );
   assert.equal(api.published, 0);
 });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
       version: ${{ steps.rc.outputs.version || steps.stable.outputs.version || steps.ci.outputs.version }}
       tag: ${{ steps.rc.outputs.tag || steps.stable.outputs.tag }}
       is_rc: ${{ github.event_name == 'schedule' }}
+      latest_stable_tag: ${{ steps.rc.outputs.latest_stable_tag }}
+      latest_stable_sha: ${{ steps.rc.outputs.latest_stable_sha }}
 
     steps:
       - uses: actions/checkout@v4
@@ -271,6 +273,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_SHA: ${{ needs.prepare.outputs.sha }}
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          LATEST_STABLE_TAG: ${{ needs.prepare.outputs.latest_stable_tag }}
+          LATEST_STABLE_SHA: ${{ needs.prepare.outputs.latest_stable_sha }}
           ASSET_DIR: dist
         run: node .github/scripts/rc-release.mjs publish
 


### PR DESCRIPTION
## Description

**What.** Derives each scheduled RC train from the greatest published stable release instead of the unchanged Cargo manifest version.

**Why.** After v0.1.2 was published, nightly preparation kept reading version 0.1.2 from `crates/nac-server/Cargo.toml` and skipped every scheduled run because tag v0.1.2 already existed, even though `main` had new commits.

The daily `17 6 * * *` schedule remains unchanged. Scheduled preparation now:

- selects the greatest published stable tag and increments its patch version;
- publishes only when scheduled `main` is ahead of that stable and differs from the latest RC in the current train;
- carries the selected stable tag and SHA into publication and revalidates them before creating and publishing the release, preventing a stale train if another stable release appears during the run.

## Bug Evidence

Before this PR, the current v0.1.2 manifest plus existing v0.1.2 release caused `prepareCandidate` to exit without preparing an RC. With stable v0.1.2 and newer commits on `main`, the planner now produces `v0.1.3-rc.<run-number>`.

Regression coverage also rejects divergent source history and stops publication if a newer stable release appears while artifacts are being built.

## Usage

No operator action is required. The existing nightly schedule runs at 06:17 UTC every day. When `main` is ahead of the latest stable release, the workflow publishes the next patch RC train automatically.

## Changelog

- Restores daily nightly RC publication for changes made after the latest stable release.
- Derives RC patch versions from the latest published stable tag.
- Revalidates stable-release identity before publishing nightly artifacts.

## Validation

Ran `node --test .github/scripts/rc-release.test.mjs`; all 18 tests passed. Also ran `node --check` for both release scripts and `git diff --check` successfully. A seven-persona code review completed; the correctness and security race/ancestry findings were fixed and confirmed closed in follow-up review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and GitHub API gates for what gets published nightly; scope is limited to CI scripts and workflow env wiring, with solid test coverage.
> 
> **Overview**
> **Nightly RC preparation no longer reads `nac-server`’s Cargo version.** Scheduled runs now pick the greatest published stable GitHub release, bump its patch for the RC train (e.g. `v0.1.2` → `v0.1.3-rc.<run>`), and only proceed when `main`’s SHA is **ahead** of that stable (via GitHub compare), not identical, behind, or divergent.
> 
> **Prepare** outputs `latest_stable_tag` and `latest_stable_sha`; **publish** receives them through `release.yml` and calls `requireLatestStableSnapshot` before and after asset work so a newer stable or a moved tag aborts publication. `GitHubApi.compareCommits` backs the ancestry check.
> 
> Tests and fakes were updated for the new versioning rules, compare API, and the mid-run stable-change failure path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a014d2d3b1ef748f25ddd3e3d5ce67e39e7764a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->