### PR TITLE
fix(dev): refresh changed frontend dependencies

### DIFF
--- a/start_dev.sh
+++ b/start_dev.sh
@@ -47,12 +47,30 @@ case "$PROFILE" in
     ;;
 esac
 
-if [[ ! -d "$WEB_DIR/node_modules" ]]; then
+DEPENDENCY_STAMP_DIR="$WEB_DIR/node_modules/.nac-dependencies"
+DEPENDENCIES_CURRENT=true
+for file in package.json package-lock.json; do
+  if [[ -f "$WEB_DIR/$file" ]]; then
+    cmp -s "$WEB_DIR/$file" "$DEPENDENCY_STAMP_DIR/$file" || DEPENDENCIES_CURRENT=false
+  elif [[ -f "$DEPENDENCY_STAMP_DIR/$file" ]]; then
+    DEPENDENCIES_CURRENT=false
+  fi
+done
+
+if [[ "$DEPENDENCIES_CURRENT" != true ]]; then
   echo "==> installing frontend dependencies"
   if [[ -f "$WEB_DIR/package-lock.json" ]]; then
     npm --prefix "$WEB_DIR" ci
   else
     npm --prefix "$WEB_DIR" install
+  fi
+
+  mkdir -p "$DEPENDENCY_STAMP_DIR"
+  cp "$WEB_DIR/package.json" "$DEPENDENCY_STAMP_DIR/package.json"
+  if [[ -f "$WEB_DIR/package-lock.json" ]]; then
+    cp "$WEB_DIR/package-lock.json" "$DEPENDENCY_STAMP_DIR/package-lock.json"
+  else
+    rm -f "$DEPENDENCY_STAMP_DIR/package-lock.json"
   fi
 fi
 


### PR DESCRIPTION
## Description

**What.** Makes `start_dev.sh` reinstall frontend dependencies when `package.json` or `package-lock.json` changes.

**Why.** The launcher previously treated any existing `node_modules` directory as current, so pulling a dependency change could leave Vite and Vitest unable to start.

The launcher now keeps exact copies of the dependency manifests under `node_modules/.nac-dependencies`. It runs the existing `npm ci` or `npm install` path when either manifest differs, appears, or disappears, and updates the copies only after installation succeeds. Unchanged launches continue directly to the backend build.

## Bug Evidence

Before this change, `npm test -- src/app/services/queries.test.tsx` failed before Vitest initialized because `vite.config.ts` could not resolve `mathjax-full/package.json`. The committed lockfile contained `mathjax-full`, but the existing `node_modules` tree predated that lockfile and `start_dev.sh` skipped installation solely because the directory existed.

After a local `npm ci`, the focused query test passed. The updated launcher also detected an intentionally stale saved lockfile and reinstalled dependencies before building.

## Usage

Run the development launcher as before:

```bash
./start_dev.sh
```

The first launch with an existing unstamped `node_modules` performs one reconciliation install. Later launches skip installation until either frontend dependency manifest changes.

## Changelog

- Keeps local frontend dependencies synchronized across pulls and branch switches.
- No end-user runtime behavior or dependency-version change.

## Validation

Ran `npm ci --no-audit --no-fund` in the original checkout, then `npm test -- src/app/services/queries.test.tsx`; all 3 focused tests passed. In the PR worktree, `bash -n ./start_dev.sh` passed and the complete web suite passed with 11 files and 55 tests.

Exercised `./start_dev.sh` directly in three states: an unstamped installation ran `npm ci` and reached the backend build, an unchanged second launch skipped installation, and truncating only the saved `package-lock.json` copy caused the next launch to reinstall before building. Each launcher smoke check was stopped after the dependency decision and build startup were observed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only launcher script change with no runtime, auth, or production impact.
> 
> **Overview**
> **`start_dev.sh` no longer treats any existing `node_modules` as up to date.** It compares `package.json` and `package-lock.json` under `crates/nac-server/web` to copies in `node_modules/.nac-dependencies` and runs `npm ci` or `npm install` when they differ, appear, or disappear.
> 
> Stamp files are written only after a successful install. Unchanged manifests still skip install and go straight to the backend build—fixing stale trees after pulls or branch switches (e.g. missing lockfile packages like `mathjax-full`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 242d86d31e6a391f2bcb0bf58f2cb5f1c2fe5799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->