### PR TITLE
ci: run lint before tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,10 @@ jobs:
             echo "version=$version"
           } >> "$GITHUB_OUTPUT"
 
-  test-server:
+  lint:
     if: ${{ needs.prepare.outputs.run == 'true' }}
     needs: prepare
     runs-on: ubuntu-latest
-    env:
-      CARGO_PROFILE_TEST_DEBUG: "0"
 
     steps:
       - uses: actions/checkout@v4
@@ -105,8 +103,40 @@ jobs:
         working-directory: crates/nac-server/web
         run: npm ci
 
-      - name: Lint and check formatting
-        run: make lint format-check
+      - name: Lint frontend and backend
+        run: make lint
+
+      - name: Check frontend and backend formatting
+        run: make format-check
+
+  test-server:
+    if: ${{ needs.prepare.outputs.run == 'true' }}
+    needs: [prepare, lint]
+    runs-on: ubuntu-latest
+    env:
+      CARGO_PROFILE_TEST_DEBUG: "0"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: crates/nac-server/web/package-lock.json
+
+      - name: Install web dependencies
+        working-directory: crates/nac-server/web
+        run: npm ci
 
       - name: Typecheck the web app
         working-directory: crates/nac-server/web
@@ -138,7 +168,7 @@ jobs:
 
   test-core:
     if: ${{ needs.prepare.outputs.run == 'true' }}
-    needs: prepare
+    needs: [prepare, lint]
     runs-on: ubuntu-latest
     env:
       CARGO_PROFILE_TEST_DEBUG: "0"


### PR DESCRIPTION
## Description

**What.** Moves frontend and backend lint and formatting into a separate `lint` GitHub Actions check that gates both test suites.

**Why.** Fast static checks should fail before the more expensive server and core test jobs consume runner time.

The new job checks out the immutable SHA produced by `prepare`, installs the Rust and Node tooling needed by the existing Make targets, and runs `make lint` followed by `make format-check`. Both `test-server` and `test-core` now require `lint`, while build and publish topology remains unchanged.

## Usage

No user-facing usage change. Pull requests now show a separate `Release / lint` check, and test jobs start only after it succeeds.

## Changelog

- Adds a dedicated CI lint/format check for frontend and backend code.
- Gates server and core test jobs on successful static checks.
- No runtime behavior change.

## Validation

Validated `.github/workflows/release.yml` with actionlint v1.7.7; the existing `macos-26` label was ignored because that actionlint release predates the hosted label. Ran `npm ci` and `make lint format-check` successfully, covering oxlint, ESLint, clippy with warnings denied, oxfmt check, and cargo fmt check. `git diff --check` also passed. All seven delegated review personas returned clean results.

The PR's hosted `Release` workflow passed end to end. The new `lint` job passed in 2m16s, and GitHub did not start `test-server` or `test-core` until that job completed; both test suites and the aggregate `test` check then passed.