### PR TITLE
fix(core): stop identical failing tool rounds

### DIFF
--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -71,6 +71,62 @@ fn render_orchestrator_system_prompt(working_directory: &str, thread_timeout_sec
 const EMPTY_TURN_NUDGE: &str = "Your last turn arrived empty: no answer and no tool call. \
 Reply with your answer as ordinary text, or issue the tool call you meant to make.";
 
+/// Flash-class models can ignore a correct tool error and retry the same call
+/// forever (`write` + `expected_revision: null` on an existing file). The
+/// error stays on the tool result; this only stops the worker after the
+/// identical failing round has repeated enough times to be a loop.
+const REPEATED_TOOL_FAILURE_LIMIT: usize = 3;
+
+fn tool_call_path(calls: &[ToolCall], call_id: &str) -> String {
+    calls
+        .iter()
+        .find(|call| call.id == call_id)
+        .and_then(|call| serde_json::from_str::<serde_json::Value>(&call.function.arguments).ok())
+        .and_then(|value| {
+            value
+                .get("path")
+                .and_then(|path| path.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_default()
+}
+
+fn tool_result_error_code(result: &ToolResult) -> String {
+    result
+        .content
+        .as_text()
+        .and_then(|text| serde_json::from_str::<serde_json::Value>(text).ok())
+        .and_then(|value| {
+            value
+                .get("error")
+                .and_then(|error| error.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "error".to_string())
+}
+
+fn failed_tool_round_signature(
+    calls: &[ToolCall],
+    results: &[(String, String, ToolResult)],
+) -> Option<String> {
+    let mut parts: Vec<String> = results
+        .iter()
+        .filter(|(_, _, result)| result.is_error)
+        .map(|(id, name, result)| {
+            format!(
+                "{name}\t{}\t{}",
+                tool_call_path(calls, id),
+                tool_result_error_code(result)
+            )
+        })
+        .collect();
+    if parts.is_empty() {
+        return None;
+    }
+    parts.sort();
+    Some(parts.join("\n"))
+}
+
 fn duration_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
@@ -513,6 +569,8 @@ impl Agent {
 
         let mut iteration = 0usize;
         let mut empty_turn_nudged = false;
+        let mut last_failure_signature: Option<String> = None;
+        let mut repeated_failures = 0usize;
         let mut accumulated_usage = TokenUsage::default();
         loop {
             self.append_pending_steering_checked().await?;
@@ -722,13 +780,33 @@ impl Agent {
 
             let tool_calls = response.assistant.tool_calls.unwrap_or_default();
             let results = execute_tools_parallel(
-                tool_calls,
+                tool_calls.clone(),
                 self.tool_runtime.clone(),
                 self.client.clone(),
                 self.event_sink.clone(),
                 self.thread_name.clone(),
             )
             .await;
+            let repeated_identical_failure =
+                match failed_tool_round_signature(&tool_calls, &results) {
+                    Some(signature)
+                        if last_failure_signature.as_deref() == Some(signature.as_str()) =>
+                    {
+                        repeated_failures = repeated_failures.saturating_add(1);
+                        repeated_failures >= REPEATED_TOOL_FAILURE_LIMIT
+                    }
+                    Some(signature) => {
+                        last_failure_signature = Some(signature);
+                        repeated_failures = 1;
+                        false
+                    }
+                    None => {
+                        last_failure_signature = None;
+                        repeated_failures = 0;
+                        false
+                    }
+                };
+            let failure_signature = last_failure_signature.clone();
             let tool_messages =
                 finalize_tool_results(&self.messages, results, &self.event_sink, &self.thread_name);
 
@@ -759,6 +837,18 @@ impl Agent {
             // only after the complete batch is both durable and appended.
             if let Err(error) = self.push_batch_and_log(tool_messages).await {
                 self.last_usage = Some(accumulated_usage.clone());
+                self.emit(AgentEvent::Error {
+                    thread_name: self.thread_name.clone(),
+                    message: error.to_string(),
+                });
+                self.tool_runtime.terminal_manager.remove_all().await;
+                return Err(error);
+            }
+            if repeated_identical_failure {
+                let detail = failure_signature.unwrap_or_default().replace('\t', " ");
+                let error = anyhow!(
+                    "Stopped after {REPEATED_TOOL_FAILURE_LIMIT} identical tool failures: {detail}"
+                );
                 self.emit(AgentEvent::Error {
                     thread_name: self.thread_name.clone(),
                     message: error.to_string(),

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -74,7 +74,10 @@ Reply with your answer as ordinary text, or issue the tool call you meant to mak
 /// Flash-class models can ignore a correct tool error and retry the same call
 /// forever (`write` + `expected_revision: null` on an existing file). The
 /// error stays on the tool result; this only stops the worker after the
-/// identical failing round has repeated enough times to be a loop.
+/// identical failing round has repeated enough times to be a loop. The stop
+/// is reported as `ModelError` so the parent dispatch keeps the reason (plain
+/// `Error` is reduced to "operation failed" before it leaves the worker) and
+/// the orchestrator sees it on the `thread` tool result.
 const REPEATED_TOOL_FAILURE_LIMIT: usize = 3;
 
 fn tool_call_path(calls: &[ToolCall], call_id: &str) -> String {
@@ -849,7 +852,11 @@ impl Agent {
                 let error = anyhow!(
                     "Stopped after {REPEATED_TOOL_FAILURE_LIMIT} identical tool failures: {detail}"
                 );
-                self.emit(AgentEvent::Error {
+                // Same channel as a provider refusal: the message survives
+                // sanitization and is captured as `WorkerRun.model_error`,
+                // which `worker_failure_details` puts on the orchestrator's
+                // thread tool result.
+                self.emit(AgentEvent::ModelError {
                     thread_name: self.thread_name.clone(),
                     message: error.to_string(),
                 });

--- a/crates/nac-core/src/agent/mod.rs
+++ b/crates/nac-core/src/agent/mod.rs
@@ -80,54 +80,69 @@ Reply with your answer as ordinary text, or issue the tool call you meant to mak
 /// the orchestrator sees it on the `thread` tool result.
 const REPEATED_TOOL_FAILURE_LIMIT: usize = 3;
 
-fn tool_call_path(calls: &[ToolCall], call_id: &str) -> String {
+fn canonical_tool_arguments(raw: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| serde_json::to_string(&value).ok())
+        .unwrap_or_else(|| raw.to_string())
+}
+
+fn tool_call_arguments<'a>(calls: &'a [ToolCall], call_id: &str) -> &'a str {
     calls
         .iter()
         .find(|call| call.id == call_id)
-        .and_then(|call| serde_json::from_str::<serde_json::Value>(&call.function.arguments).ok())
-        .and_then(|value| {
-            value
-                .get("path")
-                .and_then(|path| path.as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_default()
+        .map(|call| call.function.arguments.as_str())
+        .unwrap_or("")
 }
 
-fn tool_result_error_code(result: &ToolResult) -> String {
-    result
-        .content
-        .as_text()
-        .and_then(|text| serde_json::from_str::<serde_json::Value>(text).ok())
-        .and_then(|value| {
-            value
-                .get("error")
-                .and_then(|error| error.as_str())
-                .map(str::to_string)
-        })
-        .unwrap_or_else(|| "error".to_string())
+fn tool_result_error_identity(result: &ToolResult) -> String {
+    let Some(text) = result.content.as_text() else {
+        return "error".to_string();
+    };
+    match serde_json::from_str::<serde_json::Value>(text) {
+        Ok(value) => match value.get("error") {
+            Some(error) => serde_json::to_string(error).unwrap_or_else(|_| error.to_string()),
+            None => serde_json::to_string(&value).unwrap_or_else(|_| text.to_string()),
+        },
+        Err(_) => text.to_string(),
+    }
 }
 
-fn failed_tool_round_signature(
+struct FailedToolRound {
+    signature: String,
+    detail: String,
+}
+
+fn failed_tool_round(
     calls: &[ToolCall],
     results: &[(String, String, ToolResult)],
-) -> Option<String> {
-    let mut parts: Vec<String> = results
-        .iter()
-        .filter(|(_, _, result)| result.is_error)
-        .map(|(id, name, result)| {
-            format!(
-                "{name}\t{}\t{}",
-                tool_call_path(calls, id),
-                tool_result_error_code(result)
-            )
-        })
-        .collect();
-    if parts.is_empty() {
+) -> Option<FailedToolRound> {
+    let mut signature_parts = Vec::new();
+    let mut detail_parts = Vec::new();
+    for (id, name, result) in results {
+        if !result.is_error {
+            continue;
+        }
+        let arguments = tool_call_arguments(calls, id);
+        let error = tool_result_error_identity(result);
+        signature_parts.push(format!(
+            "{name}\t{}\t{error}",
+            canonical_tool_arguments(arguments)
+        ));
+        detail_parts.push(format!(
+            "{name} {} {error}",
+            preview_tool_args(name, arguments)
+        ));
+    }
+    if signature_parts.is_empty() {
         return None;
     }
-    parts.sort();
-    Some(parts.join("\n"))
+    signature_parts.sort();
+    detail_parts.sort();
+    Some(FailedToolRound {
+        signature: signature_parts.join("\n"),
+        detail: preview(&detail_parts.join("; "), 400),
+    })
 }
 
 fn duration_millis(duration: Duration) -> u64 {
@@ -573,6 +588,7 @@ impl Agent {
         let mut iteration = 0usize;
         let mut empty_turn_nudged = false;
         let mut last_failure_signature: Option<String> = None;
+        let mut last_failure_detail = String::new();
         let mut repeated_failures = 0usize;
         let mut accumulated_usage = TokenUsage::default();
         loop {
@@ -790,26 +806,28 @@ impl Agent {
                 self.thread_name.clone(),
             )
             .await;
-            let repeated_identical_failure =
-                match failed_tool_round_signature(&tool_calls, &results) {
-                    Some(signature)
-                        if last_failure_signature.as_deref() == Some(signature.as_str()) =>
-                    {
-                        repeated_failures = repeated_failures.saturating_add(1);
-                        repeated_failures >= REPEATED_TOOL_FAILURE_LIMIT
-                    }
-                    Some(signature) => {
-                        last_failure_signature = Some(signature);
-                        repeated_failures = 1;
-                        false
-                    }
-                    None => {
-                        last_failure_signature = None;
-                        repeated_failures = 0;
-                        false
-                    }
-                };
-            let failure_signature = last_failure_signature.clone();
+            let repeated_identical_failure = match failed_tool_round(&tool_calls, &results) {
+                Some(round)
+                    if last_failure_signature.as_deref() == Some(round.signature.as_str()) =>
+                {
+                    last_failure_detail = round.detail;
+                    repeated_failures = repeated_failures.saturating_add(1);
+                    repeated_failures >= REPEATED_TOOL_FAILURE_LIMIT
+                }
+                Some(round) => {
+                    last_failure_signature = Some(round.signature);
+                    last_failure_detail = round.detail;
+                    repeated_failures = 1;
+                    false
+                }
+                None => {
+                    last_failure_signature = None;
+                    last_failure_detail.clear();
+                    repeated_failures = 0;
+                    false
+                }
+            };
+            let failure_detail = last_failure_detail.clone();
             let tool_messages =
                 finalize_tool_results(&self.messages, results, &self.event_sink, &self.thread_name);
 
@@ -848,9 +866,8 @@ impl Agent {
                 return Err(error);
             }
             if repeated_identical_failure {
-                let detail = failure_signature.unwrap_or_default().replace('\t', " ");
                 let error = anyhow!(
-                    "Stopped after {REPEATED_TOOL_FAILURE_LIMIT} identical tool failures: {detail}"
+                    "Stopped after {REPEATED_TOOL_FAILURE_LIMIT} identical tool failures: {failure_detail}"
                 );
                 // Same channel as a provider refusal: the message survives
                 // sanitization and is captured as `WorkerRun.model_error`,

--- a/crates/nac-core/src/agent/preview.rs
+++ b/crates/nac-core/src/agent/preview.rs
@@ -177,6 +177,11 @@ pub(crate) fn preview_tool_result(name: &str, result: &ToolResult) -> String {
             return preview(&summary, 160);
         }
     }
+    if matches!(name, "read" | "write" | "edit") {
+        if let Some(summary) = preview_json_tool_result(trimmed) {
+            return preview(&summary, 160);
+        }
+    }
 
     let lines: Vec<&str> = rendered
         .lines()
@@ -193,6 +198,25 @@ pub(crate) fn preview_tool_result(name: &str, result: &ToolResult) -> String {
     }
 
     preview(&format!("{}{more}", lines[0]), 160)
+}
+
+fn preview_json_tool_result(content: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    if let Some(error) = parsed.get("error").and_then(|value| value.as_str()) {
+        let message = parsed
+            .get("message")
+            .and_then(|value| value.as_str())
+            .unwrap_or("");
+        return Some(if message.is_empty() {
+            error.to_string()
+        } else {
+            format!("{error}: {message}")
+        });
+    }
+    parsed
+        .get("path")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
 }
 
 /// Marks a preview that stands in for more than the one line it shows.

--- a/crates/nac-core/src/agent/preview.rs
+++ b/crates/nac-core/src/agent/preview.rs
@@ -172,6 +172,12 @@ pub(crate) fn preview_tool_result(name: &str, result: &ToolResult) -> String {
         return "ok".to_string();
     }
 
+    if result.is_error {
+        if let Some(message) = json_string_field(trimmed, "message") {
+            return preview(&message, 160);
+        }
+    }
+
     if name == "exec_command" {
         if let Some(summary) = preview_exec_command_result(trimmed) {
             return preview(&summary, 160);
@@ -200,18 +206,29 @@ pub(crate) fn preview_tool_result(name: &str, result: &ToolResult) -> String {
     preview(&format!("{}{more}", lines[0]), 160)
 }
 
+fn json_string_field(content: &str, key: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(content)
+        .ok()?
+        .get(key)?
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
 fn preview_json_tool_result(content: &str) -> Option<String> {
     let parsed = serde_json::from_str::<serde_json::Value>(content).ok()?;
-    if let Some(error) = parsed.get("error").and_then(|value| value.as_str()) {
-        let message = parsed
+    if parsed.get("error").is_some() {
+        if let Some(message) = parsed
             .get("message")
             .and_then(|value| value.as_str())
-            .unwrap_or("");
-        return Some(if message.is_empty() {
-            error.to_string()
-        } else {
-            format!("{error}: {message}")
-        });
+            .filter(|value| !value.is_empty())
+        {
+            return Some(message.to_string());
+        }
+        if let Some(error) = parsed.get("error").and_then(|value| value.as_str()) {
+            return Some(error.to_string());
+        }
+        return None;
     }
     parsed
         .get("path")

--- a/crates/nac-core/src/agent/tests.rs
+++ b/crates/nac-core/src/agent/tests.rs
@@ -622,3 +622,203 @@ async fn cancelled_image_result_still_emits_finished_event() {
 
     let _ = std::fs::remove_dir_all(root);
 }
+
+fn test_tool_call(id: &str, name: &str, arguments: &str) -> ToolCall {
+    ToolCall {
+        id: id.to_string(),
+        call_type: "function".to_string(),
+        function: crate::types::FunctionCall {
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+        },
+    }
+}
+
+fn json_tool_error(id: &str, name: &str, body: serde_json::Value) -> (String, String, ToolResult) {
+    (
+        id.to_string(),
+        name.to_string(),
+        ToolResult {
+            content: (body.to_string()).into(),
+            is_error: true,
+        },
+    )
+}
+
+fn text_tool_error(id: &str, name: &str, text: &str) -> (String, String, ToolResult) {
+    (
+        id.to_string(),
+        name.to_string(),
+        ToolResult::text(text, true),
+    )
+}
+
+#[test]
+fn failed_tool_round_matches_identical_create_only_writes() {
+    let calls = vec![test_tool_call(
+        "c1",
+        "write",
+        r#"{ "path": "docker-compose.yml", "contents": "services:\n", "expected_revision": null }"#,
+    )];
+    let results = vec![json_tool_error(
+        "c1",
+        "write",
+        serde_json::json!({
+            "error": "already_exists",
+            "message": "file already exists: docker-compose.yml",
+            "current_revision": "sha256:abc",
+        }),
+    )];
+    let first = failed_tool_round(&calls, &results).expect("failing write round");
+    let second = failed_tool_round(
+        &[test_tool_call(
+            "c2",
+            "write",
+            r#"{"contents":"services:\n","expected_revision":null,"path":"docker-compose.yml"}"#,
+        )],
+        &[json_tool_error(
+            "c2",
+            "write",
+            serde_json::json!({
+                "error": "already_exists",
+                "message": "file already exists: docker-compose.yml",
+                "current_revision": "sha256:abc",
+            }),
+        )],
+    )
+    .expect("retried write round");
+
+    assert_eq!(first.signature, second.signature);
+    assert!(first.detail.contains("write"));
+    assert!(first.detail.contains("docker-compose.yml"));
+    assert!(first.detail.contains("already_exists"));
+    assert!(
+        !first.detail.contains("services:"),
+        "stop detail must not dump write contents: {}",
+        first.detail
+    );
+}
+
+#[test]
+fn failed_tool_round_does_not_collapse_unrelated_failures() {
+    let write = failed_tool_round(
+        &[test_tool_call(
+            "w",
+            "write",
+            r#"{"path":"a.yml","expected_revision":null}"#,
+        )],
+        &[json_tool_error(
+            "w",
+            "write",
+            serde_json::json!({ "error": "already_exists" }),
+        )],
+    )
+    .unwrap();
+    let other_write = failed_tool_round(
+        &[test_tool_call(
+            "w2",
+            "write",
+            r#"{"path":"b.yml","expected_revision":null}"#,
+        )],
+        &[json_tool_error(
+            "w2",
+            "write",
+            serde_json::json!({ "error": "already_exists" }),
+        )],
+    )
+    .unwrap();
+    let thread_a = failed_tool_round(
+        &[test_tool_call(
+            "t1",
+            "thread",
+            r#"{"name":"worker-a","action":"build"}"#,
+        )],
+        &[text_tool_error(
+            "t1",
+            "thread",
+            "Thread 'worker-a' failed (exit 1):\nboom",
+        )],
+    )
+    .unwrap();
+    let thread_b = failed_tool_round(
+        &[test_tool_call(
+            "t2",
+            "thread",
+            r#"{"name":"worker-b","action":"test"}"#,
+        )],
+        &[text_tool_error(
+            "t2",
+            "thread",
+            "Thread 'worker-b' failed (exit 1):\nboom",
+        )],
+    )
+    .unwrap();
+    let grep_a = failed_tool_round(
+        &[test_tool_call("g1", "grep", r#"{"pattern":"foo"}"#)],
+        &[json_tool_error(
+            "g1",
+            "grep",
+            serde_json::json!({
+                "error": { "code": "invalid_regex", "message": "bad", "path": null }
+            }),
+        )],
+    )
+    .unwrap();
+    let grep_b = failed_tool_round(
+        &[test_tool_call("g2", "grep", r#"{"pattern":"bar"}"#)],
+        &[json_tool_error(
+            "g2",
+            "grep",
+            serde_json::json!({
+                "error": { "code": "invalid_regex", "message": "bad", "path": null }
+            }),
+        )],
+    )
+    .unwrap();
+    let exec_a = failed_tool_round(
+        &[test_tool_call(
+            "e1",
+            "exec_command",
+            r#"{"cmd":"ls missing-a"}"#,
+        )],
+        &[text_tool_error("e1", "exec_command", "exit 2")],
+    )
+    .unwrap();
+    let exec_b = failed_tool_round(
+        &[test_tool_call(
+            "e2",
+            "exec_command",
+            r#"{"cmd":"ls missing-b"}"#,
+        )],
+        &[text_tool_error("e2", "exec_command", "exit 2")],
+    )
+    .unwrap();
+
+    let signatures = [
+        write.signature,
+        other_write.signature,
+        thread_a.signature,
+        thread_b.signature,
+        grep_a.signature,
+        grep_b.signature,
+        exec_a.signature,
+        exec_b.signature,
+    ];
+    let unique = signatures.iter().collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(
+        unique.len(),
+        signatures.len(),
+        "unrelated failing rounds must not share a signature: {signatures:?}"
+    );
+}
+
+#[test]
+fn failed_tool_round_ignores_successful_results() {
+    let calls = vec![test_tool_call("ok", "read", r#"{"path":"a.rs"}"#)];
+    let results = vec![(
+        "ok".to_string(),
+        "read".to_string(),
+        ToolResult::text("ok", false),
+    )];
+    assert!(failed_tool_round(&calls, &results).is_none());
+}

--- a/crates/nac-core/src/tools/mutation.rs
+++ b/crates/nac-core/src/tools/mutation.rs
@@ -90,6 +90,19 @@ impl MutationError {
         }
     }
 
+    fn already_exists(path: &str, current_revision: Option<String>) -> Self {
+        Self {
+            error: "already_exists",
+            message: format!(
+                "file already exists: {path}; expected_revision null only creates a missing file — read the file and retry write with its revision"
+            ),
+            committed: false,
+            current_revision,
+            new_revision: None,
+            durability: None,
+        }
+    }
+
     fn stale(path: &str, current_revision: String) -> Self {
         Self {
             error: "stale_revision",
@@ -826,10 +839,7 @@ fn publish_at(
         if result == -1 {
             let error = io::Error::last_os_error();
             return if error.kind() == io::ErrorKind::AlreadyExists {
-                Err(MutationError::precondition(
-                    "already_exists",
-                    format!("file already exists: {path_display}"),
-                ))
+                Err(MutationError::already_exists(path_display, None))
             } else {
                 Err(MutationError::io(path_display, error))
             };
@@ -930,9 +940,9 @@ fn prepare_new_bytes(
             expected_revision,
             content,
         } => match (expected_revision, old_bytes) {
-            (None, Some(_)) => Err(MutationError::precondition(
-                "already_exists",
-                format!("file already exists: {path_display}"),
+            (None, Some(old_bytes)) => Err(MutationError::already_exists(
+                path_display,
+                Some(revision(old_bytes)),
             )),
             (None, None) => Ok(content.into_bytes()),
             (Some(_), None) => Err(MutationError::precondition(
@@ -1169,10 +1179,7 @@ fn publish(
         match fs::hard_link(&temp_path, target) {
             Ok(()) => {}
             Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                return Err(MutationError::precondition(
-                    "already_exists",
-                    format!("file already exists: {path_display}"),
-                ))
+                return Err(MutationError::already_exists(path_display, None))
             }
             Err(error) => return Err(MutationError::io(path_display, error)),
         }
@@ -1607,7 +1614,7 @@ def publish(
             try:
                 os.link(temp_path, path)
             except FileExistsError:
-                fail("already_exists", f"file already exists: {path}")
+                fail("already_exists", f"file already exists: {path}; expected_revision null only creates a missing file — read the file and retry write with its revision")
         published = True
         try:
             if fail_after_publish:
@@ -1751,7 +1758,11 @@ try:
     elif operation == "write":
         if expected is None:
             if old is not None:
-                fail("already_exists", f"file already exists: {original_path}")
+                fail(
+                    "already_exists",
+                    f"file already exists: {original_path}; expected_revision null only creates a missing file — read the file and retry write with its revision",
+                    current_revision=rev(old),
+                )
         else:
             if old is None:
                 fail("not_found", f"file not found: {original_path}")

--- a/crates/nac-server/src/main.rs
+++ b/crates/nac-server/src/main.rs
@@ -647,7 +647,7 @@ fn internal_sandbox_mounts(args: &SandboxArgs) -> Result<Vec<(PathBuf, PathBuf, 
         (&args.sandbox_mounts, false),
         (&args.sandbox_mounts_ro, true),
     ] {
-        for pair in values.chunks_exact(2) {
+        for pair in values.as_chunks::<2>().0 {
             let host = PathBuf::from(pair[0].clone());
             let guest = PathBuf::from(pair[1].clone());
             if !host.exists() {


### PR DESCRIPTION
## Description

**What.** Abort the worker after three identical failing tool rounds, and make `already_exists` write results (and their thread previews) tell the model to `read` then `write` with a revision instead of retrying create-only.

**Why.** Flash models retry `write` with `expected_revision: null` on an existing file forever; the tool result already reaches the model, but the UI preview collapsed to `{...` and nothing stopped the loop.

The `already_exists` payload now includes `current_revision` when the file exists and a clear next-step message. Thread-log JSON previews surface `already_exists: file already exists: …` instead of the first pretty-printed `{`. After three consecutive identical failing tool rounds, the worker stops with `Stopped after 3 identical tool failures: …`. This does not change create-only `write` so that `null` overwrites, and it does not inject hints into model messages.

## Usage

No new UI control. A stuck create-only `write` loop now ends after three identical failures; the thread log shows the `already_exists` reason instead of `{...`. Restart the worker after deploy so an already-running session picks up the breaker.

## Changelog

- Agent stops after three identical failing tool rounds instead of looping forever.
- `already_exists` write results tell the model to read the file and rewrite with the current revision.
- Thread-log previews for JSON tool results show the error reason, not `{...`.

## Validation

- `cargo test -p nac-core --lib create_only_never_overwrites` — ok
- `cargo test -p nac-core --lib preview` — 10 passed

## Out of scope

- Changing `write` so `expected_revision: null` overwrites an existing file.
- Injecting recovery hints into model messages.
- Tests for the three-round circuit breaker.


Made with [Cursor](https://cursor.com)