### PR TITLE
chore(release): cut v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "nac-server"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/nac-server/Cargo.toml
+++ b/crates/nac-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nac-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Description

**What.** Bumps the `nac-server` package from 0.1.2 to 0.1.3 so the next stable tag and published binaries identify as 0.1.3.

**Why.** `origin/main` at `87e8e55373aedf9106a8837df1f27d376fd85e7d` already passed the Release push workflow and is newer than the latest stable tag `v0.1.2`; the checked-in version must match the tag before publication.

The bump touches only `crates/nac-server/Cargo.toml` and the `nac-server` entry in `Cargo.lock`. Session forks (#215) and command-cancellation ordering (#214) remain open and are out of this train.

Since `v0.1.2`, user-facing work includes project-backed session organization, `$skill` prompt expansion and composer autocomplete, per-session sandbox git worktrees, vision-aware image reads, Shiki highlighting, and context-tiered cost estimates, plus recovery and sandbox MCP fixes listed below.

## Usage

No user-facing usage change from this commit. After merge, the annotated `v0.1.3` tag and GitHub Release publish the 0.1.3 binaries.

## Changelog

- Version identity for `nac-web` becomes `0.1.3`.
- No other runtime change in this PR.

User-facing changes already on `main` since `v0.1.2` (for the eventual Release notes):

- Organize sessions into projects with saved location and model defaults. ([#198](https://github.com/arcee-ai/nac/pull/198), [#205](https://github.com/arcee-ai/nac/pull/205))
- Expand `$skillname` in orchestrator prompts and autocomplete those names in the composer. ([#202](https://github.com/arcee-ai/nac/pull/202), [#204](https://github.com/arcee-ai/nac/pull/204))
- Run sandboxed Git sessions in per-session worktrees instead of a writable host checkout. ([#155](https://github.com/arcee-ai/nac/pull/155))
- Return vision-aware image reads for PNG, JPEG, WebP, and static GIF. ([#194](https://github.com/arcee-ai/nac/pull/194))
- Highlight code with Shiki, including `.diff` and `.patch`. ([#208](https://github.com/arcee-ai/nac/pull/208), [#211](https://github.com/arcee-ai/nac/pull/211))
- Apply context-tiered pricing and bill reasoning tokens at the output rate. ([#191](https://github.com/arcee-ai/nac/pull/191))
- Stop after three identical failing tool rounds. ([#212](https://github.com/arcee-ai/nac/pull/212))
- Run stdio MCP servers on the host in sandbox mode. ([#187](https://github.com/arcee-ai/nac/pull/187))
- Bound SQLite connections, recover interrupted runs without losing transcripts, and keep re-dispatched thread cards running until they start. ([#192](https://github.com/arcee-ai/nac/pull/192), [#166](https://github.com/arcee-ai/nac/pull/166), [#183](https://github.com/arcee-ai/nac/pull/183), [#188](https://github.com/arcee-ai/nac/pull/188))

## Validation

- `cargo metadata --locked --no-deps --format-version 1` reports `nac-server` `0.1.3`.
- `git diff --check` is clean.
- Diff is the two version strings only.
- Release workflow on `87e8e55373aedf9106a8837df1f27d376fd85e7d` succeeded: prepare, lint, test-server, test-core, aggregate test, both native builds. Publish was skipped (push event). https://github.com/arcee-ai/nac/actions/runs/32404686263

## Operational Impact

Merging prepares the stable tag. Publishing the GitHub Release for `v0.1.3` triggers verified native builds and asset upload. Nightly RCs already derive their patch from the latest stable tag.

## Out of scope

- Does not merge or ship [#214](https://github.com/arcee-ai/nac/pull/214) (cancel exec process tree) or [#215](https://github.com/arcee-ai/nac/pull/215) (session forks).

Made with [Cursor](https://cursor.com)