### PR TITLE
chore(release): cut v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "nac-server"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/nac-server/Cargo.toml
+++ b/crates/nac-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nac-server"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Description

**What.** Bumps the `nac-server` package from 0.1.3 to 0.1.4 so the next stable tag and published binaries identify as 0.1.4.

**Why.** `origin/main` at `bac52169a917fef82f2c6323f3ad6e09bfd43b50` already passed the Release push workflow and is newer than the latest stable tag `v0.1.3`; the checked-in version must match the tag before publication.

The bump touches only `crates/nac-server/Cargo.toml` and the `nac-server` entry in `Cargo.lock`.

Since `v0.1.3`, user-facing work is conversation forks from a finished model turn and truthful Stop: cancellation now waits until model, tool, worker, remote MCP, and command work is confirmed stopped.

## Usage

No user-facing usage change from this commit. After merge, the annotated `v0.1.4` tag and GitHub Release publish the 0.1.4 binaries.

## Changelog

- Version identity for `nac-web` becomes `0.1.4`.
- No other runtime change in this PR.

User-facing changes already on `main` since `v0.1.3` (for the eventual Release notes):

- Fork a finished model turn into a new independent session, copying threads, episodes, worksets, and workspace revisions from that prefix. ([#215](https://github.com/arcee-ai/nac/pull/215))
- Stop waits until tracked work is confirmed dead before publishing `run_cancelled`; failed cleanup ends the run as failed instead of leaving the session busy. ([#214](https://github.com/arcee-ai/nac/pull/214))

## Validation

- `cargo metadata --locked --no-deps --format-version 1` reports `nac-server` `0.1.4`.
- `git diff --check` is clean.
- Diff is the two version strings only.
- Release workflow on `bac52169a917fef82f2c6323f3ad6e09bfd43b50` succeeded: prepare, lint, test-server, test-core, aggregate test, both native builds. Publish was skipped (push event). https://github.com/arcee-ai/nac/actions/runs/33116624732

## Operational Impact

Merging prepares the stable tag. Publishing the GitHub Release for `v0.1.4` triggers verified native builds and asset upload. Nightly RCs already derive their patch from the latest stable tag.


Made with [Cursor](https://cursor.com)