### PR TITLE
ci: keep managed NAC image publishing private

### DIFF
--- a/.github/workflows/managed-image.yml
+++ b/.github/workflows/managed-image.yml
@@ -23,12 +23,6 @@ on:
       - Cargo.lock
       - crates/**
   workflow_dispatch:
-    inputs:
-      ref:
-        description: Git ref to build and publish
-        required: true
-        default: main
-        type: string
 
 permissions:
   contents: read
@@ -46,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
       - id: candidate
         name: Resolve immutable candidate
@@ -116,75 +110,3 @@ jobs:
           MANAGED_IMAGE: nac-managed-smoke:${{ needs.prepare.outputs.short_sha }}
           MANAGED_IMAGE_SKIP_BUILD: "1"
         run: sh scripts/smoke-managed-image.sh
-
-  publish:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    needs: [prepare, contract, quality, build-smoke]
-    runs-on: ubuntu-latest
-    environment: dev
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.prepare.outputs.sha }}
-      - name: Validate dev publication inputs
-        shell: bash
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          OIDC_ROLE_TO_ASSUME: ${{ secrets.OIDC_ROLE_TO_ASSUME }}
-          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          ECR_CACHE_REPOSITORY: ${{ vars.ECR_CACHE_REPOSITORY }}
-        run: |
-          for name in AWS_REGION OIDC_ROLE_TO_ASSUME ECR_REPOSITORY ECR_CACHE_REPOSITORY; do
-            if [ -z "${!name:-}" ]; then
-              echo "::error::Managed NAC dev environment is missing $name"
-              exit 1
-            fi
-          done
-      - name: Configure AWS credentials through OIDC
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: ${{ secrets.OIDC_ROLE_TO_ASSUME }}
-      - id: ecr
-        name: Sign in to ECR
-        uses: aws-actions/amazon-ecr-login@v2
-      - uses: docker/setup-buildx-action@v3
-      - id: metadata
-        name: Compose immutable image reference
-        shell: bash
-        env:
-          REGISTRY: ${{ steps.ecr.outputs.registry }}
-          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          CANDIDATE_SHA: ${{ needs.prepare.outputs.sha }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_ATTEMPT: ${{ github.run_attempt }}
-        run: |
-          tag="$REGISTRY/$REPOSITORY:sha-$CANDIDATE_SHA-run-$RUN_ID-attempt-$RUN_ATTEMPT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-      - id: publish
-        name: Publish exact linux/amd64 image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/managed/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.metadata.outputs.tag }}
-          cache-from: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ vars.ECR_CACHE_REPOSITORY }}:buildcache
-          cache-to: type=registry,ref=${{ steps.ecr.outputs.registry }}/${{ vars.ECR_CACHE_REPOSITORY }}:buildcache,mode=max
-          provenance: mode=max
-          sbom: true
-      - name: Record immutable publication
-        env:
-          IMAGE: ${{ steps.metadata.outputs.tag }}
-          DIGEST: ${{ steps.publish.outputs.digest }}
-        run: |
-          {
-            echo "### Managed NAC image"
-            echo
-            echo "- Image: \`$IMAGE\`"
-            echo "- Digest: \`$DIGEST\`"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/test-managed-image-contract.sh
+++ b/scripts/test-managed-image-contract.sh
@@ -49,14 +49,12 @@ if grep -Eq '(^|[[:space:]])(sudo|su)([[:space:]]|$)' "$dockerfile" "$entrypoint
 fi
 
 require_literal "$workflow" 'platforms: linux/amd64'
-require_literal "$workflow" 'provenance: mode=max'
-require_literal "$workflow" 'sbom: true'
-require_literal "$workflow" 'environment: dev'
-require_literal "$workflow" 'OIDC_ROLE_TO_ASSUME'
-require_literal "$workflow" 'ECR_CACHE_REPOSITORY'
+require_literal "$workflow" 'push: false'
+require_literal "$workflow" 'provenance: false'
+require_literal "$workflow" 'sbom: false'
 require_literal "$workflow" 'run: make ci'
-if grep -Eq '^[[:space:]]*tags:.*(:latest|:dev)([,[:space:]]|$)' "$workflow"; then
-    fail 'publication workflow contains a mutable latest/dev image tag'
+if grep -Eq '(id-token:[[:space:]]*write|aws-actions/|amazon-ecr|ECR_|push:[[:space:]]*true|environment:[[:space:]]*dev)' "$workflow"; then
+    fail 'public repository workflow must remain build-and-smoke only'
 fi
 
 printf '%s\n' 'managed image contract: ok'


### PR DESCRIPTION
Stacks on Allison managed NAC branch. Removes AWS OIDC, ECR configuration, and the publish job from the public repository workflow while retaining contract, quality, and linux/amd64 build-smoke CI. The internal managed-nac-controller repository owns private ECR publication from the pinned source SHA.\n\nValidation: managed image contract passes; shell syntax checks pass; git diff --check passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and contract-test changes only; no runtime or application code paths are modified.
> 
> **Overview**
> Removes **ECR publication** from the public `managed-image` workflow so this repo no longer uses AWS OIDC, dev environment gates, or a `publish` job. **Manual `workflow_dispatch`** no longer accepts a custom ref; checkout always uses the triggering commit SHA.
> 
> **Contract, quality, and `build-smoke`** stay: linux/amd64 image build with `push: false`, no provenance/SBOM, then credential-independent smoke.
> 
> `test-managed-image-contract.sh` is updated to **require** local-only build settings and **fail** if the workflow reintroduces `id-token`, AWS/ECR actions, `push: true`, or `environment: dev`—keeping publication in the internal managed-nac-controller repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fba264ec07db1c5b7762a9abbee27902b85f26c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->