### PR TITLE
test(web): add remote managed NAC smoke lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all setup build dev demo release install ci test test-rust test-web test-source-size generate-api-contract test-api-contract test-assets test-e2e test-durability test-managed-image-contract managed-image test-managed-image check lint fix format-check fmt crate-check crate-test crate-build clean help
+.PHONY: all setup build dev demo release install ci test test-rust test-web test-source-size generate-api-contract test-api-contract test-assets test-e2e test-e2e-remote test-durability test-managed-image-contract managed-image test-managed-image check lint fix format-check fmt crate-check crate-test crate-build clean help
 
 CARGO ?= cargo
 PKG := nac-server
@@ -134,6 +134,10 @@ test-e2e:
 	npm --prefix $(WEB_DIR) run build
 	$(CARGO) build --locked -p $(PKG) --bin $(BIN)
 	NAC_E2E_BINARY="$(CURDIR)/target/debug/$(BIN)" npm --prefix $(WEB_DIR) run test:e2e
+
+## Run non-destructive browser smoke checks against an authenticated remote Managed NAC
+test-e2e-remote:
+	npm --prefix $(WEB_DIR) run test:e2e:remote
 
 ## Run focused deterministic lifecycle and crash-window regressions
 test-durability:

--- a/README.md
+++ b/README.md
@@ -111,4 +111,19 @@ Run `make test-e2e` as the matching production-browser release gate and
 are also covered by the broader Rust suites. Release packaging and installer
 checks remain workflow-only.
 
+For an explicitly provisioned remote Managed NAC, set
+
+```text
+NAC_E2E_REMOTE_URL
+NAC_E2E_REMOTE_USERNAME
+NAC_E2E_REMOTE_PASSWORD
+```
+
+through a private runtime secret source and run `make test-e2e-remote`. This
+lane verifies gateway denial, authenticated health/readiness, release identity,
+and production-client loading without modifying remote state. Optionally set
+`NAC_E2E_REMOTE_EXPECTED_VERSION` to pin the expected release. Never put these
+values in Git, shell history, test artifacts, or CI logs. The remote smoke lane
+complements rather than replaces the isolated local `make test-e2e` suite.
+
 nac is licensed under [Apache 2.0](LICENSE).

--- a/crates/nac-server/web/e2e/remote-config.test.ts
+++ b/crates/nac-server/web/e2e/remote-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+
+import { remoteTarget, requireRemoteTarget } from "./remote-config";
+
+describe("remote E2E configuration", () => {
+  test("keeps the remote lane disabled without a target", () => {
+    expect(remoteTarget({})).toBeNull();
+    expect(() => requireRemoteTarget({})).toThrow("NAC_E2E_REMOTE_URL is required");
+  });
+
+  test("loads an authenticated HTTPS target without putting credentials in the URL", () => {
+    expect(
+      remoteTarget({
+        NAC_E2E_REMOTE_URL: "https://managed.example.test/",
+        NAC_E2E_REMOTE_USERNAME: "owner",
+        NAC_E2E_REMOTE_PASSWORD: "private-value",
+        NAC_E2E_REMOTE_EXPECTED_VERSION: "0.1.3",
+      }),
+    ).toEqual({
+      baseUrl: "https://managed.example.test",
+      username: "owner",
+      password: "private-value",
+      expectedVersion: "0.1.3",
+    });
+  });
+
+  test.each([
+    "http://managed.example.test",
+    "https://owner:secret@managed.example.test",
+    "https://managed.example.test?credential=secret",
+    "https://managed.example.test/#credential",
+    "https://managed.example.test/nac",
+  ])("rejects an unsafe remote URL: %s", (url) => {
+    expect(() =>
+      remoteTarget({
+        NAC_E2E_REMOTE_URL: url,
+        NAC_E2E_REMOTE_USERNAME: "owner",
+        NAC_E2E_REMOTE_PASSWORD: "private-value",
+      }),
+    ).toThrow();
+  });
+
+  test.each(["NAC_E2E_REMOTE_USERNAME", "NAC_E2E_REMOTE_PASSWORD"])(
+    "requires %s when a target is enabled",
+    (missing) => {
+      const environment: NodeJS.ProcessEnv = {
+        NAC_E2E_REMOTE_URL: "https://managed.example.test",
+        NAC_E2E_REMOTE_USERNAME: "owner",
+        NAC_E2E_REMOTE_PASSWORD: "private-value",
+      };
+      delete environment[missing];
+      expect(() => remoteTarget(environment)).toThrow(`${missing} is required`);
+    },
+  );
+});

--- a/crates/nac-server/web/e2e/remote-config.ts
+++ b/crates/nac-server/web/e2e/remote-config.ts
@@ -1,0 +1,57 @@
+export type RemoteTarget = {
+  baseUrl: string;
+  username: string;
+  password: string;
+  expectedVersion?: string;
+};
+
+export function remoteTarget(environment: NodeJS.ProcessEnv = process.env): RemoteTarget | null {
+  const rawUrl = environment.NAC_E2E_REMOTE_URL?.trim();
+  if (!rawUrl) return null;
+
+  const url = parseRemoteUrl(rawUrl);
+  const username = required(environment, "NAC_E2E_REMOTE_USERNAME");
+  const password = required(environment, "NAC_E2E_REMOTE_PASSWORD");
+  const expectedVersion = environment.NAC_E2E_REMOTE_EXPECTED_VERSION?.trim() || undefined;
+
+  return {
+    baseUrl: url.toString().replace(/\/$/, ""),
+    username,
+    password,
+    expectedVersion,
+  };
+}
+
+export function requireRemoteTarget(environment: NodeJS.ProcessEnv = process.env): RemoteTarget {
+  const target = remoteTarget(environment);
+  if (target) return target;
+  throw new Error("NAC_E2E_REMOTE_URL is required for remote E2E");
+}
+
+function parseRemoteUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("NAC_E2E_REMOTE_URL must be an absolute HTTPS URL");
+  }
+  if (url.protocol !== "https:") {
+    throw new Error("NAC_E2E_REMOTE_URL must use HTTPS");
+  }
+  if (url.username || url.password) {
+    throw new Error("NAC_E2E_REMOTE_URL must not contain credentials");
+  }
+  if (url.search || url.hash) {
+    throw new Error("NAC_E2E_REMOTE_URL must not contain a query or fragment");
+  }
+  if (url.pathname !== "/") {
+    throw new Error("NAC_E2E_REMOTE_URL must identify the host root");
+  }
+  return url;
+}
+
+function required(environment: NodeJS.ProcessEnv, name: string): string {
+  const value = environment[name]?.trim();
+  if (value) return value;
+  throw new Error(`${name} is required when NAC_E2E_REMOTE_URL is set`);
+}

--- a/crates/nac-server/web/e2e/remote.e2e.ts
+++ b/crates/nac-server/web/e2e/remote.e2e.ts
@@ -1,0 +1,105 @@
+import {
+  expect,
+  request as playwrightRequest,
+  test,
+  type APIRequestContext,
+} from "@playwright/test";
+
+import { requireRemoteTarget } from "./remote-config";
+
+type Readiness = {
+  status?: unknown;
+  managed?: unknown;
+  version?: unknown;
+  schema_version?: unknown;
+};
+
+type ManagedStatus = Readiness & {
+  ready?: unknown;
+  model_ready?: unknown;
+};
+
+const target = requireRemoteTarget();
+let authenticated: APIRequestContext;
+let anonymous: APIRequestContext;
+
+test.beforeAll(async () => {
+  authenticated = await playwrightRequest.newContext({
+    baseURL: target.baseUrl,
+    httpCredentials: { username: target.username, password: target.password, send: "always" },
+  });
+  anonymous = await playwrightRequest.newContext({ baseURL: target.baseUrl });
+});
+
+test.afterAll(async () => {
+  await Promise.all([authenticated?.dispose(), anonymous?.dispose()].filter(Boolean));
+});
+
+test("denies an anonymous browser before it reaches owner-equivalent UI", async () => {
+  const response = await anonymous.get("/", { maxRedirects: 0 });
+  expect([401, 403]).toContain(response.status());
+});
+
+test("reports a responsive, ready managed host and records its release identity", async ({
+  request,
+}) => {
+  void request;
+  const testInfo = test.info();
+  const health = await authenticated.get("/healthz");
+  expect(health.status()).toBe(200);
+  await expect(health.json()).resolves.toMatchObject({ status: "ok" });
+
+  const readiness = await getJson<Readiness>(authenticated, "/readyz");
+  expect(readiness.status).toBe("ok");
+  expect(readiness.managed).toBe(true);
+  expect(readiness.version).toEqual(expect.any(String));
+  expect(readiness.schema_version).toEqual(expect.any(Number));
+
+  const managed = await getJson<ManagedStatus>(authenticated, "/managed/status");
+  expect(managed.ready).toBe(true);
+  expect(managed.model_ready).toBe(true);
+  expect(managed.version).toBe(readiness.version);
+  expect(managed.schema_version).toBe(readiness.schema_version);
+  if (target.expectedVersion) expect(managed.version).toBe(target.expectedVersion);
+
+  await testInfo.attach("remote release identity", {
+    body: Buffer.from(
+      JSON.stringify(
+        {
+          version: managed.version,
+          schema_version: managed.schema_version,
+          ready: managed.ready,
+          model_ready: managed.model_ready,
+        },
+        null,
+        2,
+      ),
+    ),
+    contentType: "application/json",
+  });
+});
+
+test("loads the production client through the authenticated gateway", async ({ browser }) => {
+  const context = await browser.newContext({
+    httpCredentials: { username: target.username, password: target.password, send: "always" },
+  });
+  const page = await context.newPage();
+  try {
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(error.message));
+
+    const response = await page.goto(target.baseUrl);
+    expect(response?.status()).toBe(200);
+    await expect(page).toHaveTitle("NAC");
+    await expect(page.getByRole("button", { name: "Open the menu" })).toBeVisible();
+    expect(errors).toEqual([]);
+  } finally {
+    await context.close();
+  }
+});
+
+async function getJson<T>(request: APIRequestContext, path: string): Promise<T> {
+  const response = await request.get(path);
+  if (!response.ok()) throw new Error(`${path} returned ${response.status()}`);
+  return (await response.json()) as T;
+}

--- a/crates/nac-server/web/package.json
+++ b/crates/nac-server/web/package.json
@@ -12,6 +12,7 @@
     "format:check": "oxfmt --check .",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:remote": "NAC_E2E_REMOTE=1 playwright test remote.e2e.ts",
     "generate:api": "node scripts/generate-api-types.mjs",
     "check:api": "node scripts/generate-api-types.mjs --check",
     "sync-file-icons": "node scripts/sync-file-icons.mjs",

--- a/crates/nac-server/web/playwright.config.ts
+++ b/crates/nac-server/web/playwright.config.ts
@@ -2,9 +2,12 @@ import { defineConfig, devices } from "@playwright/test";
 import os from "node:os";
 import path from "node:path";
 
+const remoteTarget = process.env.NAC_E2E_REMOTE === "1";
+
 export default defineConfig({
   testDir: "./e2e",
   testMatch: "**/*.e2e.ts",
+  testIgnore: remoteTarget ? ["**/embedded.e2e.ts", "**/managed.e2e.ts"] : "**/remote.e2e.ts",
   outputDir: process.env.NAC_E2E_ARTIFACTS ?? path.join(os.tmpdir(), "nac-playwright-results"),
   fullyParallel: false,
   workers: 1,


### PR DESCRIPTION
## Summary
- add an opt-in, read-only remote Managed NAC Playwright lane
- verify anonymous denial, authenticated health/readiness/release identity, and production-client loading
- validate secret-safe HTTPS-only configuration while keeping the existing local E2E lane unchanged

## Verification
- make ci
- make test-e2e (18 passed)
- make test-e2e-remote against the temporary Allison instance (3 passed)

Linear: ALL-29

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no production server or auth logic is modified, though misconfigured runs could leak credentials if env vars are logged carelessly (mitigated by README guidance).
> 
> **Overview**
> Adds an **opt-in remote Playwright smoke lane** for real Managed NAC hosts, alongside the existing local `make test-e2e` flow.
> 
> **`make test-e2e-remote`** and **`npm run test:e2e:remote`** run only `remote.e2e.ts` when `NAC_E2E_REMOTE=1`; Playwright config **excludes** embedded/managed suites in that mode and **skips** remote tests during normal local E2E. Target config comes from **`NAC_E2E_REMOTE_URL`** plus separate username/password env vars (HTTPS root URL only—no creds in the URL), with optional **`NAC_E2E_REMOTE_EXPECTED_VERSION`**. Vitest covers the config parser.
> 
> The remote tests are **read-only**: anonymous access is rejected, authenticated checks hit **`/healthz`**, **`/readyz`**, and **`/managed/status`**, and a credentialed browser load asserts the production UI boots without page errors. README documents secret handling and that this lane complements local E2E.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9f6f50f517633bc38faec07a915784eae3b0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->