### PR TITLE
Fix managed worker argv and exercise Git LFS runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ test-durability:
 ## Check the managed image/workflow contract without a container runtime
 test-managed-image-contract:
 	sh -n docker/managed/entrypoint.sh
+	sh -n scripts/smoke-managed-git-lfs.sh
 	sh -n scripts/smoke-managed-image.sh
 	sh -n scripts/test-managed-image-contract.sh
 	sh scripts/test-managed-image-contract.sh

--- a/crates/nac-core/src/tools/thread/worker.rs
+++ b/crates/nac-core/src/tools/thread/worker.rs
@@ -221,6 +221,7 @@ pub(super) async fn run_worker(
         )
     })?;
     let mut command = Command::new(executable);
+    command.arg("__worker");
     for name in crate::model::NATIVE_INTEGRATION_CREDENTIAL_ENV_NAMES {
         command.env_remove(name);
     }
@@ -240,7 +241,6 @@ pub(super) async fn run_worker(
         command.current_dir(&runtime.workspace_cwd);
     }
     command
-        .arg("__worker")
         .arg("--session-id")
         .arg(invocation.session_id)
         .arg("--thread-name")
@@ -599,7 +599,7 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn managed_worker_receives_only_the_nonsecret_store_root() {
+    async fn managed_worker_subcommand_precedes_nonsecret_environment_options() {
         let root =
             std::env::temp_dir().join(format!("nac_worker_secrets_{}", uuid::Uuid::new_v4()));
         let state_root = root.join("managed-state");
@@ -674,9 +674,9 @@ done
             std::fs::read_to_string(root.join("inherited-secret")).unwrap(),
             "unset"
         );
-        assert!(!std::fs::read_to_string(root.join("argv"))
-            .unwrap()
-            .contains("managed-worker-canary-never-in-argv"));
+        let argv = std::fs::read_to_string(root.join("argv")).unwrap();
+        assert_eq!(argv.lines().next(), Some("__worker"));
+        assert!(!argv.contains("managed-worker-canary-never-in-argv"));
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/docker/managed/Dockerfile
+++ b/docker/managed/Dockerfile
@@ -70,6 +70,7 @@ RUN test "$(dpkg --print-architecture)" = amd64 \
         findutils \
         gh \
         git \
+        git-lfs \
         gzip \
         jq \
         libssl-dev \
@@ -88,6 +89,7 @@ RUN test "$(dpkg --print-architecture)" = amd64 \
         xz-utils \
         zip \
     && rm -rf /var/lib/apt/lists/* \
+    && git lfs install --system --skip-repo \
     && ln -s /usr/bin/fdfind /usr/local/bin/fd \
     && curl --proto '=https' --tlsv1.2 -fsSLo /tmp/node.tar.xz \
         "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
@@ -124,12 +126,15 @@ RUN chmod 0555 /usr/local/bin/nac-web /usr/local/bin/nac-managed-entrypoint \
     && cargo --version \
     && rustfmt --version \
     && cargo-clippy --version \
+    && git lfs version \
     && node --version \
     && npm --version \
     && corepack --version \
     && go version \
     && uv --version
 
+# Keep LFS filters outside HOME, which is replaced by a persistent mount.
+# The system installation above remains available after dropping privileges.
 USER 10001:10001
 WORKDIR /repositories
 EXPOSE 3210

--- a/scripts/smoke-managed-git-lfs.sh
+++ b/scripts/smoke-managed-git-lfs.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+# Exercise the Git LFS runtime contract as the managed user without network
+# access. The fixture lives on the executable repository mount because /tmp is
+# intentionally noexec during the managed-image smoke.
+git lfs version
+test "$(git config --system --get filter.lfs.required)" = true
+test "$(git config --system --get filter.lfs.clean)" = 'git-lfs clean -- %f'
+test "$(git config --system --get filter.lfs.smudge)" = 'git-lfs smudge -- %f'
+test "$(git config --system --get filter.lfs.process)" = 'git-lfs filter-process'
+
+fixture=$(mktemp -d "${LFS_SMOKE_ROOT:-/repositories}/nac-lfs-smoke.XXXXXX")
+trap 'rm -rf "$fixture"' EXIT HUP INT TERM
+git init --bare --quiet "$fixture/remote.git"
+git init --quiet "$fixture/source"
+cd "$fixture/source"
+git config user.name 'Managed image smoke'
+git config user.email 'managed-smoke@example.test'
+git lfs track '*.bin'
+printf '%s\n' 'managed tokenizer LFS payload' > tokenizer.bin
+git add .gitattributes tokenizer.bin
+git commit --quiet -m 'LFS fixture'
+
+# Prove the Git object is an LFS pointer before exercising transfer/smudge.
+git show HEAD:tokenizer.bin | grep -Fx 'version https://git-lfs.github.com/spec/v1'
+git remote add origin "$fixture/remote.git"
+git push --quiet origin HEAD:refs/heads/main
+git --git-dir="$fixture/remote.git" symbolic-ref HEAD refs/heads/main
+
+# The independent clone has no local LFS object cache, so checkout must fetch
+# and smudge the payload through the configured system filters.
+git clone --quiet "$fixture/remote.git" "$fixture/clone"
+cmp tokenizer.bin "$fixture/clone/tokenizer.bin"
+cd "$fixture/clone"
+git lfs fsck
+printf '%s\n' 'managed Git LFS smoke: ok'

--- a/scripts/smoke-managed-image.sh
+++ b/scripts/smoke-managed-image.sh
@@ -176,7 +176,7 @@ port=$(wait_until_ready)
 "$container_runtime" exec "$container_name" /bin/sh -ceu '
     test "$(id -u):$(id -g)" = 10001:10001
     ! command -v sudo >/dev/null 2>&1
-    for tool in bash git gh ssh curl jq rg fd rsync make pkg-config cmake cc python3 uv node npm corepack rustc cargo rustfmt cargo-clippy go tar gzip xz zip unzip tini; do
+    for tool in bash git git-lfs gh ssh curl jq rg fd rsync make pkg-config cmake cc python3 uv node npm corepack rustc cargo rustfmt cargo-clippy go tar gzip xz zip unzip tini; do
         command -v "$tool" >/dev/null
     done
     rustc --version | grep -F "rustc 1.98.0" >/dev/null
@@ -199,6 +199,10 @@ port=$(wait_until_ready)
         exit 1
     fi
 '
+
+# Exercise clean/smudge and an actual LFS transfer as the managed user with the
+# read-only root and mounted HOME; binary presence alone misses setup failures.
+"$container_runtime" exec -i "$container_name" /bin/sh < "$repo_root/scripts/smoke-managed-git-lfs.sh"
 
 index_html=$(curl -fsS --noproxy '*' --connect-timeout 1 --max-time 5 \
     "http://127.0.0.1:$port/")

--- a/scripts/test-managed-image-contract.sh
+++ b/scripts/test-managed-image-contract.sh
@@ -5,6 +5,7 @@ repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 dockerfile="$repo_root/docker/managed/Dockerfile"
 entrypoint="$repo_root/docker/managed/entrypoint.sh"
 workflow="$repo_root/.github/workflows/managed-image.yml"
+lfs_smoke="$repo_root/scripts/smoke-managed-git-lfs.sh"
 
 fail() {
     printf 'managed image contract: %s\n' "$1" >&2
@@ -27,6 +28,9 @@ require_literal "$dockerfile" 'GO_VERSION=1.27.0'
 require_literal "$dockerfile" 'UV_VERSION=0.12.1'
 require_literal "$dockerfile" 'corepack enable'
 require_literal "$dockerfile" 'fd-find'
+require_literal "$dockerfile" 'git-lfs'
+require_literal "$dockerfile" 'git lfs install --system --skip-repo'
+require_literal "$dockerfile" 'git lfs version'
 require_literal "$dockerfile" '/var/lib/nac'
 require_literal "$dockerfile" '/repositories'
 require_literal "$dockerfile" '/home/nac'
@@ -41,8 +45,13 @@ require_literal "$entrypoint" 'without requiring the bootstrap mount'
 require_literal "$repo_root/scripts/smoke-managed-image.sh" 'model_credential_source = \"managed-bootstrap\"'
 require_literal "$repo_root/scripts/smoke-managed-image.sh" '/run/secrets/nac/bootstrap.json'
 require_literal "$repo_root/scripts/smoke-managed-image.sh" 'assert_bootstrap_required'
+require_literal "$repo_root/scripts/smoke-managed-image.sh" 'smoke-managed-git-lfs.sh'
 require_literal "$repo_root/scripts/smoke-managed-image.sh" 'kill --signal KILL'
 require_literal "$repo_root/scripts/smoke-managed-image.sh" 'start_container without-bootstrap'
+require_literal "$lfs_smoke" 'git lfs version'
+require_literal "$lfs_smoke" 'git clone --quiet'
+require_literal "$lfs_smoke" 'git lfs fsck'
+sh -n "$lfs_smoke"
 require_literal "$repo_root/docker/managed/fixtures/bootstrap.json" '"client_id": "managed-nac"'
 if grep -Eq '(^|[[:space:]])(sudo|su)([[:space:]]|$)' "$dockerfile" "$entrypoint"; then
     fail 'image or entrypoint grants an escalation command'


### PR DESCRIPTION
## Summary

- put the internal `__worker` subcommand before every managed-worker option and assert the emitted argv order at the real subprocess boundary
- install and configure Git LFS in the managed runtime image, with build-time and live `git lfs version` probes
- exercise clean/smudge behavior through an offline LFS-backed bare remote, push, independent clone, payload comparison, and `git lfs fsck`

## Verification

- `make setup`
- focused managed-worker subprocess test and complete worker test module (11 passed)
- `make test-managed-image-contract`
- `make ci` (full Rust/web suites, format, lint, source size, generated API/assets, static image contract)
- `make test-managed-image` with linux/amd64 Docker emulation (full readiness/restart/SIGTERM/bootstrap smoke plus Git LFS transfer/clone/fsck)

Implements ALL-19 and ALL-21 as the two accepted narrow runtime fixes from ALL-18. This reconstructs their semantics on the rewritten `allison-demo` baseline without merging conflicting PR #230 or touching settings/model, permission policy, release, upgrade, or controller architecture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Argv reordering affects every managed worker spawn (subcommand parsing); image and smoke changes expand the managed runtime contract but stay scoped to packaging and verification.
> 
> **Overview**
> Managed worker spawns now pass **`__worker` as the first argument**, before `--managed-secret-root` and other managed options, and the subprocess test asserts that argv order at the real boundary.
> 
> The **managed runtime image** adds **Git LFS** (`git-lfs`, system `git lfs install --skip-repo`, build-time `git lfs version`) with a note that system filters stay valid when **`HOME` is a mounted volume**.
> 
> **CI/smoke** gains `scripts/smoke-managed-git-lfs.sh` (offline track/push/clone/smudge/`git lfs fsck` under `/repositories`), wired into `make test-managed-image-contract`, static contract checks, and the live managed-image smoke (including `git-lfs` in the required tool list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e53ad5550136672bb1d79085a071189dc30116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->